### PR TITLE
Spacing

### DIFF
--- a/Project.xcodeproj/project.pbxproj
+++ b/Project.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		25D04D7F1F583B1800EA317D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D04D7E1F583B1800EA317D /* AppDelegate.swift */; };
 		25D04D891F583B1800EA317D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 25D04D871F583B1800EA317D /* LaunchScreen.storyboard */; };
 		4523B77C1F8CF3C3001DFB96 /* Label+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4523B77B1F8CF3C3001DFB96 /* Label+Style.swift */; };
+		4537D0201F94ECE6006942E7 /* CGFloat+Troika.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4537D01F1F94ECE6006942E7 /* CGFloat+Troika.swift */; };
 		453D887F1F85192700FC63C7 /* FINNTypeWebStrippet-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 453D887B1F84FF6900FC63C7 /* FINNTypeWebStrippet-Bold.ttf */; };
 		453D88801F85192700FC63C7 /* FINNTypeWebStrippet-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 453D88791F84FF6900FC63C7 /* FINNTypeWebStrippet-Light.ttf */; };
 		453D88811F85192700FC63C7 /* FINNTypeWebStrippet-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 453D887A1F84FF6900FC63C7 /* FINNTypeWebStrippet-Medium.ttf */; };
@@ -78,6 +79,7 @@
 		25D04D881F583B1800EA317D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		25D04D8A1F583B1800EA317D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4523B77B1F8CF3C3001DFB96 /* Label+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Label+Style.swift"; sourceTree = "<group>"; };
+		4537D01F1F94ECE6006942E7 /* CGFloat+Troika.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+Troika.swift"; sourceTree = "<group>"; };
 		453D88791F84FF6900FC63C7 /* FINNTypeWebStrippet-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FINNTypeWebStrippet-Light.ttf"; sourceTree = "<group>"; };
 		453D887A1F84FF6900FC63C7 /* FINNTypeWebStrippet-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FINNTypeWebStrippet-Medium.ttf"; sourceTree = "<group>"; };
 		453D887B1F84FF6900FC63C7 /* FINNTypeWebStrippet-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FINNTypeWebStrippet-Bold.ttf"; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				457B35C91F7BC4620031E125 /* UITableView+Identifiable.swift */,
 				457B35CB1F7BC4920031E125 /* UICollectionView+Identifiable.swift */,
 				CB400B211F83C96600B26C1C /* UIImage+Troika.swift */,
+				4537D01F1F94ECE6006942E7 /* CGFloat+Troika.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 				459D37FE1F87AE5D00038582 /* RibbonViewPresentable.swift in Sources */,
 				CB3E67C71F7E4D5D00C40D47 /* PreviewPresentable.swift in Sources */,
 				453D88871F860B7900FC63C7 /* MarketGridViewConfigurable.swift in Sources */,
+				4537D0201F94ECE6006942E7 /* CGFloat+Troika.swift in Sources */,
 				45441D031F8CA1D300A3B007 /* Label.swift in Sources */,
 				457B35CC1F7BC4920031E125 /* UICollectionView+Identifiable.swift in Sources */,
 				CB3E67C61F7E4D5D00C40D47 /* PreviewCell.swift in Sources */,

--- a/Troika/Extensions/CGFloat+Troika.swift
+++ b/Troika/Extensions/CGFloat+Troika.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension CGFloat {
+    static let verySmallSpacing: CGFloat = 2
+    static let smallSpacing: CGFloat = 4
+    static let mediumSpacing: CGFloat = 8
+    static let mediumLargeSpacing: CGFloat = 16
+    static let largeSpacing: CGFloat = 32
+    static let veryLargeSpacing: CGFloat = 64
+}


### PR DESCRIPTION
# What?
Adds an extension on CGFloat to define static values for spacing. The name for the different sizes might need to change so that they become more intuitive. The values are from Zeplin. 

They are now:
- verySmallSpacing = 2
- smallSpacing = 4
- mediumSpacing = 8
- mediumLargeSpacing = 16
- largeSpacing = 32
- veryLargeSpacing = 64

# Why?
To have a set of predetermined sizes for spacing throughout the app so that none other are used.