### PR TITLE
Makes spacing constants public

### DIFF
--- a/Troika/Extensions/CGFloat+Troika.swift
+++ b/Troika/Extensions/CGFloat+Troika.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-extension CGFloat {
+public extension CGFloat {
     static let verySmallSpacing: CGFloat = 2
     static let smallSpacing: CGFloat = 4
     static let mediumSpacing: CGFloat = 8


### PR DESCRIPTION
# What?
Makes spacing constants public.

# Why?
So that the predefined spacing constant values are accessible throughout the framework.