### PR TITLE
Expose reloadData()

### DIFF
--- a/Troika/Components/Market Grid/Market Grid View/MarketGridView.swift
+++ b/Troika/Components/Market Grid/Market Grid View/MarketGridView.swift
@@ -70,6 +70,10 @@ public class MarketGridView: UIView {
 
     // MARK: - Functionality
 
+    public func reloadData() {
+        collectionView.reloadData()
+    }
+
     public func calculateSize(constrainedTo width: CGFloat) -> CGSize {
         let size = itemSize(for: width)
         let line = lineSpacing(for: width)

--- a/Troika/Components/Preview Grid View/Preview Grid View/PreviewGridView.swift
+++ b/Troika/Components/Preview Grid View/Preview Grid View/PreviewGridView.swift
@@ -92,6 +92,10 @@ public class PreviewGridView: UIView {
 
     // MARK: - Public
 
+    public func reloadData() {
+        collectionView.reloadData()
+    }
+
     public func scrollToTop(animated: Bool = true) {
         collectionView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: animated)
     }


### PR DESCRIPTION
# What?
Exposes reloadData() for MarketGridView and PreviewGridView.

# Why?
To reload data for example after an async network request completes.