### PR TITLE
PreviewCell image loading 

### DIFF
--- a/Troika/Components/Preview Grid View/Preview Cell/PreviewCell.swift
+++ b/Troika/Components/Preview Grid View/Preview Cell/PreviewCell.swift
@@ -183,13 +183,18 @@ public class PreviewCell: UICollectionViewCell {
                 subTitleLabel.text = presentable.subTitle
                 imageTextLabel.text = presentable.imageText
                 accessibilityLabel = presentable.accessibilityLabel
-
-                loadImage(presentable: presentable)
             }
         }
     }
 
+    // MARK: - Public
 
+    /// Loads the image for the `presentable` if imagePath is set
+    public func loadImage() {
+        if let presentable = presentable {
+            loadImage(presentable: presentable)
+        }
+    }
 
     // MARK: - Private
 

--- a/Troika/Components/Preview Grid View/Preview Grid View/PreviewGridView.swift
+++ b/Troika/Components/Preview Grid View/Preview Grid View/PreviewGridView.swift
@@ -142,6 +142,10 @@ extension PreviewGridView: UICollectionViewDataSource {
     }
 
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        if let cell = cell as? PreviewCell {
+            cell.loadImage()
+        }
+
         delegate?.willDisplay(itemAtIndex: indexPath.row, inPreviewGridView: self)
     }
 


### PR DESCRIPTION
# What?
Changes the loading of image in PreviewCell from automatically when setting the presentable to be triggered by a method call. 

# Why?
While loading it when setting the presentable seems like a good ide, we might need to control when the image is loaded. This is the case when the cell havne't yet got its frame when setting the presentable and don't know the size of the image it requires. 