### PR TITLE
Market icon badge bug

### DIFF
--- a/Troika/Components/MarketGrid/MarketGridCell/MarketGridCell.swift
+++ b/Troika/Components/MarketGrid/MarketGridCell/MarketGridCell.swift
@@ -70,6 +70,7 @@ public class MarketGridCell: UICollectionViewCell {
     public override func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
+        badgeImageView.image = nil
         titleLabel.text = ""
         accessibilityLabel = ""
     }


### PR DESCRIPTION
# What ?

The market icon badge was not cleared when we prepare the cell for reuse. This PR fixes this.

See screenshot for issue:
![simulator screen shot - iphone 8 - 2017-11-29 at 11 42 55](https://user-images.githubusercontent.com/1060670/33371329-a3874e46-d4fa-11e7-8f13-f174cc53836e.png)
