### PR TITLE
Label demo style names

### DIFF
--- a/Sources/Components/Broadcast/BroadcastView.swift
+++ b/Sources/Components/Broadcast/BroadcastView.swift
@@ -32,7 +32,7 @@ public class BroadcastView: UIView {
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
-    
+
     private let imageViewSizeConstraintConstant = CGSize(width: 28, height: 28)
 
     private lazy var subviewConstraints: [NSLayoutConstraint] = {

--- a/Sources/Components/Label/Demo/LabelDemoView.swift
+++ b/Sources/Components/Label/Demo/LabelDemoView.swift
@@ -112,11 +112,11 @@ public class LabelDemoView: UIView {
         multilineLabel.text = "Test Test Test"
         labelWide.text = "Test center"
 
-        labelT1.text = "Label T1"
-        labelT2.text = "Label T2"
-        labelT3.text = "Label T3"
-        labelT4.text = "Label T4"
-        labelT5.text = "Label T5"
+        labelT1.text = "Label Title1"
+        labelT2.text = "Label Title2"
+        labelT3.text = "Label Title3"
+        labelT4.text = "Label Title4"
+        labelT5.text = "Label Title5"
         labelBody.text = "Label Body"
         labelDetail.text = "Label Detail"
     }


### PR DESCRIPTION
# What?
Changes the text for the title labels. They were called t1, t2,... earlier, but has changed to title1, title2,...

# Why?
The label demo should be a guideline to how to use the labels. I think it's beneficial to therefore use the real names.