### PR TITLE
Make Broadcast equatable

### DIFF
--- a/Sources/Components/Broadcast/BroadcastContainerView/BroadcastViewMessage.swift
+++ b/Sources/Components/Broadcast/BroadcastContainerView/BroadcastViewMessage.swift
@@ -4,12 +4,16 @@
 
 import Foundation
 
-public struct Broadcast {
+public struct Broadcast: Equatable {
     public let id: Int
     public let message: String
 
     public init(id: Int, message: String) {
         self.id = id
         self.message = message
+    }
+
+    public static func == (lhs: Broadcast, rhs: Broadcast) -> Bool {
+        return lhs.id == rhs.id && lhs.message == rhs.message
     }
 }


### PR DESCRIPTION
# Why
A Broadcast should be equatable so we can check if a Broadcast is equal or not equal to another broadcast and make it possible to use functions on arrays like contains(element:)

# What
+ Make Broadcast conform to Equatable