### PR TITLE
Added compatible topAnchor

### DIFF
--- a/Sources/Components/BroadcastView/Demo/BroadcastDemoView.swift
+++ b/Sources/Components/BroadcastView/Demo/BroadcastDemoView.swift
@@ -58,12 +58,22 @@ private extension BroadcastDemoView {
         addSubview(presentBroadcastViewButton)
 
         NSLayoutConstraint.activate([
-            broadcastView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: .mediumSpacing),
+            broadcastView.topAnchor.constraint(equalTo: compatibleTopAnchor, constant: .mediumSpacing),
             broadcastView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
             broadcastView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumSpacing),
             presentBroadcastViewButton.topAnchor.constraint(equalTo: broadcastView.bottomAnchor, constant: .mediumLargeSpacing),
             presentBroadcastViewButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
             presentBroadcastViewButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
         ])
+    }
+}
+
+fileprivate extension UIView {
+    fileprivate var compatibleTopAnchor: NSLayoutYAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return self.safeAreaLayoutGuide.topAnchor
+        } else {
+            return topAnchor
+        }
     }
 }

--- a/Sources/Components/BroadcastView/Demo/BroadcastDemoView.swift
+++ b/Sources/Components/BroadcastView/Demo/BroadcastDemoView.swift
@@ -71,7 +71,7 @@ private extension BroadcastDemoView {
 fileprivate extension UIView {
     fileprivate var compatibleTopAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11.0, *) {
-            return self.safeAreaLayoutGuide.topAnchor
+            return safeAreaLayoutGuide.topAnchor
         } else {
             return topAnchor
         }


### PR DESCRIPTION
**What?**
if iOS 11
broadcastView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
else 
broadcastView.topAnchor.constraint(equalTo: topAnchor)

**Why?**
safeAreaLayoutGuide.topAnchor is only available on iOS 11. 