### PR TITLE
Added UIAppFonts to info.plist

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -19,7 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        UIFont.registerFinniversKitFonts()
         NotificationCenter.default.addObserver(self, selector: #selector(injected(notification:)), name: Notification.Name.InjectionNotification, object: nil)
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author             = "FINN.no"
   s.social_media_url   = "https://twitter.com/search?q=FINN.no"
 
-  s.platform = :ios, '9.0'
+  s.platform = :ios
   s.swift_version = "4.0"
   s.ios.deployment_target = "9.0"
   s.pod_target_xcconfig = { "SWIFT_VERSION" => "4.0" }

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author             = "FINN.no"
   s.social_media_url   = "https://twitter.com/search?q=FINN.no"
 
-  s.platform     = :ios
+  s.platform = :ios, '9.0'
   s.swift_version = "4.0"
   s.ios.deployment_target = "9.0"
   s.pod_target_xcconfig = { "SWIFT_VERSION" => "4.0" }
@@ -34,6 +34,11 @@ Pod::Spec.new do |s|
 
   s.source_files  = "Sources/", "Sources/Extensions/", "Sources/Extensions/UIKit/", "Sources/Components/**/*.swift", "Sources/DNA/**/*.swift", "Sources/Protocols/"
   s.resources     = "Sources/Resources/Fonts/*.ttf", "Sources/Resources/*.xcassets"
+  s.resource_bundles = {
+      'FinniversKit' => ["Sources/Resources/*.xcassets", "Sources/Resources/Fonts/*.ttf"]
+    }
 
   s.exclude_files = "Sources/Components/**/*DemoView.swift", "Sources/Components/**/Demo/", "*DemoView.swift", "Sources/Components/**/**/Demo/*.swift", "*Helpers.swift"
+
+  s.requires_arc = true
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) ![](https://img.shields.io/badge/platform-iOS-lightgrey.svg) ![](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg)
 
-FinniversKit is the iOS native implementation of FINN's design system. [You can find the reference here](http://finnivers.finn.no/d/2koIuZwTP5cy/design-system). This framework is composed of small components that are meant to be used as building blocks of the FINN iOS app. 
+FinniversKit is the iOS native implementation of FINN's design system. [You can find the reference here](http://finnivers.finn.no/d/2koIuZwTP5cy/design-system). This framework is composed of small components that are meant to be used as building blocks of the FINN iOS app.
 
 In order to develop our components in an isolated way we have structured them so they can be used idependently of each other. Run the Demo project for a list of all our components.
 
@@ -22,12 +22,6 @@ Import the framework to access all the components.
 
 ```swift
 import FinniversKit
-```
-
-In your AppDelegate call the following line to register the custom fonts in your project.
-
-``` Swift
-UIFont.registerFinniversKitFonts()
 ```
 
 ## License

--- a/Sources/DNA/Font/Font.swift
+++ b/Sources/DNA/Font/Font.swift
@@ -107,7 +107,7 @@ extension UIFont {
     }
 
     private static func registerFinniversKitFonts() {
-        Fontregister.registerFinniversKitFonts
+        _ = Fontregister.registerFinniversKitFonts
     }
 }
 

--- a/Sources/DNA/Font/Font.swift
+++ b/Sources/DNA/Font/Font.swift
@@ -6,44 +6,51 @@ import UIKit
 
 public extension UIFont {
     public static var title1: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 36.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 36.0)!
         return font.scaledFont(forTextStyle: .title1)
     }
 
     public static var title2: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 28.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 28.0)!
         return font.scaledFont(forTextStyle: .title2)
     }
 
     public static var title3: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 22.5)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 22.5)!
         return font.scaledFont(forTextStyle: .title3)
     }
 
     public static var title4: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 18.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 18.0)!
         return font.scaledFont(forTextStyle: .headline)
     }
 
     public static var title5: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 14.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Medium", size: 14.0)!
         return font.scaledFont(forTextStyle: .callout)
     }
 
     public static var body: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 18.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 18.0)!
         return font.scaledFont(forTextStyle: .body)
     }
 
     public static var detail: UIFont {
-        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 14.0)!
+        registerFinniversKitFonts()
 
+        let font = UIFont(name: "FINNTypeWebStrippet-Light", size: 14.0)!
         return font.scaledFont(forTextStyle: .footnote)
     }
 
@@ -58,13 +65,22 @@ public extension UIFont {
 }
 
 extension UIFont {
-    static func registerFont(with filenameString: String, bundleIdentifierString: String) {
-        guard let bundle = Bundle(identifier: bundleIdentifierString) else {
-            print("UIFont+:  Failed to register font - bundle identifier invalid.")
-            return
+    static func registerFont(with filenameString: String) {
+        if let bundleUrl = Bundle(for: FinniversKit.self).url(forResource: "FinniversKit", withExtension: "bundle") {
+            if let bundle = Bundle(url: bundleUrl) {
+                registerFontFor(bundle: bundle, forResource: filenameString)
+            }
         }
 
-        guard let pathForResourceString = bundle.path(forResource: filenameString, ofType: "ttf") else {
+        if let bundleIdentifier = Bundle(for: FinniversKit.self).bundleIdentifier {
+            if let bundle = Bundle(identifier: bundleIdentifier) {
+                registerFontFor(bundle: bundle, forResource: filenameString)
+            }
+        }
+    }
+
+    private static func registerFontFor(bundle: Bundle, forResource: String) {
+        guard let pathForResourceString = bundle.path(forResource: forResource, ofType: "ttf") else {
             print("UIFont+:  Failed to register font - path for resource not found.")
             return
         }
@@ -90,10 +106,22 @@ extension UIFont {
         }
     }
 
-    public static func registerFinniversKitFonts() {
-        registerFont(with: "FINNTypeWebStrippet-Light", bundleIdentifierString: "no.finn.FinniversKit")
-        registerFont(with: "FINNTypeWebStrippet-Medium", bundleIdentifierString: "no.finn.FinniversKit")
-        registerFont(with: "FINNTypeWebStrippet-Regular", bundleIdentifierString: "no.finn.FinniversKit")
-        registerFont(with: "FINNTypeWebStrippet-Bold", bundleIdentifierString: "no.finn.FinniversKit")
+    private static func registerFinniversKitFonts() {
+        Fontregister.registerFinniversKitFonts
+    }
+}
+
+// https://medium.com/swift-and-ios-writing/a-quick-look-at-gcd-and-swift-3-732bef6e1838
+// https://stackoverflow.com/questions/37801407/whither-dispatch-once-in-swift-3/37801408
+// Registering fonts, only once instead of each time.
+
+private final class Fontregister {
+    static let registerFinniversKitFonts = Fontregister()
+    init() {
+        print("Fontregister register FinniversKit Fonts")
+        UIFont.registerFont(with: "FINNTypeWebStrippet-Light")
+        UIFont.registerFont(with: "FINNTypeWebStrippet-Medium")
+        UIFont.registerFont(with: "FINNTypeWebStrippet-Regular")
+        UIFont.registerFont(with: "FINNTypeWebStrippet-Bold")
     }
 }

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -2,13 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>FINNTypeWebStrippet-Bold.ttf</string>
-		<string>FINNTypeWebStrippet-Light.ttf</string>
-		<string>FINNTypeWebStrippet-Medium.ttf</string>
-		<string>FINNTypeWebStrippet-Regular.ttf</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>FINNTypeWebStrippet-Bold.ttf</string>
+		<string>FINNTypeWebStrippet-Light.ttf</string>
+		<string>FINNTypeWebStrippet-Medium.ttf</string>
+		<string>FINNTypeWebStrippet-Regular.ttf</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
**What?**

Added FinniversKit fonts to Info.plist (Fonts provided by application/UIAppFonts).
We don't need to call `UIFont.registerFinniversKitFonts()` anymore, it's called once automatically 

**Why?**

Support for CocoaPods. 