### PR TITLE
Inline consent view

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -124,6 +124,7 @@ enum ComponentViews: String {
     case textFieldDemoView
     case toastDemoView
     case switchViewDemoView
+    case inlineConsentDemoView
 
     var viewController: UIViewController {
         switch self {
@@ -143,6 +144,8 @@ enum ComponentViews: String {
             return ViewController<ToastDemoView>()
         case .switchViewDemoView:
             return ViewController<SwitchViewDemoView>()
+        case .inlineConsentDemoView:
+            return ViewController<InlineConsentDemoView>()
         }
     }
 
@@ -156,6 +159,7 @@ enum ComponentViews: String {
             .textFieldDemoView,
             .toastDemoView,
             .switchViewDemoView,
+            .inlineConsentDemoView,
         ]
     }
 }

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		44F8831220551D59003E3171 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */; };
 		4577F61E201F3D54009CBAE8 /* DemoViewsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4577F61D201F3D54009CBAE8 /* DemoViewsTableViewController.swift */; };
 		45B2E062207C9B6000C68B92 /* InlineConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E061207C9B6000C68B92 /* InlineConsentView.swift */; };
+		45B2E068207CAA5900C68B92 /* InlineConsentDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E066207CAA4C00C68B92 /* InlineConsentDemoView.swift */; };
 		45D7C56B204949E2000E788F /* SwitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56A204949E2000E788F /* SwitchView.swift */; };
 		45D7C56D20494C7A000E788F /* SwitchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56C20494C7A000E788F /* SwitchViewModel.swift */; };
 		45D7C57120494F77000E788F /* SwitchViewDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56F20494F72000E788F /* SwitchViewDemoView.swift */; };
@@ -248,6 +249,7 @@
 		44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		4577F61D201F3D54009CBAE8 /* DemoViewsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoViewsTableViewController.swift; sourceTree = "<group>"; };
 		45B2E061207C9B6000C68B92 /* InlineConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineConsentView.swift; sourceTree = "<group>"; };
+		45B2E066207CAA4C00C68B92 /* InlineConsentDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineConsentDemoView.swift; sourceTree = "<group>"; };
 		45D7C56A204949E2000E788F /* SwitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchView.swift; sourceTree = "<group>"; };
 		45D7C56C20494C7A000E788F /* SwitchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewModel.swift; sourceTree = "<group>"; };
 		45D7C56F20494F72000E788F /* SwitchViewDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewDemoView.swift; sourceTree = "<group>"; };
@@ -820,10 +822,19 @@
 		45B2E060207C9B0400C68B92 /* InlineConsent */ = {
 			isa = PBXGroup;
 			children = (
+				45B2E065207CAA2A00C68B92 /* Demo */,
 				45B2E061207C9B6000C68B92 /* InlineConsentView.swift */,
 			);
 			name = InlineConsent;
 			path = "New Group";
+			sourceTree = "<group>";
+		};
+		45B2E065207CAA2A00C68B92 /* Demo */ = {
+			isa = PBXGroup;
+			children = (
+				45B2E066207CAA4C00C68B92 /* InlineConsentDemoView.swift */,
+			);
+			path = Demo;
 			sourceTree = "<group>";
 		};
 		45D7C569204949B7000E788F /* Switch */ = {
@@ -1097,6 +1108,7 @@
 				4447F70A1FDB2B4C0033DBC1 /* MarketGridViewDemoView.swift in Sources */,
 				AF91BB9F202C868E003E6366 /* BroadcastDemoView.swift in Sources */,
 				44D912772077AD1800486848 /* LoginViewDefaultData.swift in Sources */,
+				45B2E068207CAA5900C68B92 /* InlineConsentDemoView.swift in Sources */,
 				4447F70E1FDB2B590033DBC1 /* PreviewHelpers.swift in Sources */,
 				4408A6AE2027AC7F008C0BD9 /* SpacingDemoView.swift in Sources */,
 				4447F70C1FDB2B540033DBC1 /* PreviewGridCellDemoView.swift in Sources */,

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		44D912782077AD1800486848 /* LoginViewDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D912762077AD1800486848 /* LoginViewDemoView.swift */; };
 		44F8831220551D59003E3171 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */; };
 		4577F61E201F3D54009CBAE8 /* DemoViewsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4577F61D201F3D54009CBAE8 /* DemoViewsTableViewController.swift */; };
+		45B2E062207C9B6000C68B92 /* InlineConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E061207C9B6000C68B92 /* InlineConsentView.swift */; };
 		45D7C56B204949E2000E788F /* SwitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56A204949E2000E788F /* SwitchView.swift */; };
 		45D7C56D20494C7A000E788F /* SwitchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56C20494C7A000E788F /* SwitchViewModel.swift */; };
 		45D7C57120494F77000E788F /* SwitchViewDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56F20494F72000E788F /* SwitchViewDemoView.swift */; };
@@ -246,6 +247,7 @@
 		44D912762077AD1800486848 /* LoginViewDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewDemoView.swift; sourceTree = "<group>"; };
 		44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		4577F61D201F3D54009CBAE8 /* DemoViewsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoViewsTableViewController.swift; sourceTree = "<group>"; };
+		45B2E061207C9B6000C68B92 /* InlineConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineConsentView.swift; sourceTree = "<group>"; };
 		45D7C56A204949E2000E788F /* SwitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchView.swift; sourceTree = "<group>"; };
 		45D7C56C20494C7A000E788F /* SwitchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewModel.swift; sourceTree = "<group>"; };
 		45D7C56F20494F72000E788F /* SwitchViewDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchViewDemoView.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 		4447F6641FDB2B110033DBC1 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				45B2E060207C9B0400C68B92 /* InlineConsent */,
 				45D7C569204949B7000E788F /* Switch */,
 				AF91BB95202C7487003E6366 /* Broadcast */,
 				55C5B27A203DC344007D7277 /* BroadcastContainer */,
@@ -814,6 +817,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		45B2E060207C9B0400C68B92 /* InlineConsent */ = {
+			isa = PBXGroup;
+			children = (
+				45B2E061207C9B6000C68B92 /* InlineConsentView.swift */,
+			);
+			name = InlineConsent;
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		45D7C569204949B7000E788F /* Switch */ = {
 			isa = PBXGroup;
 			children = (
@@ -1143,6 +1155,7 @@
 				4447F6E61FDB2B110033DBC1 /* PreviewGridLayoutConfiguration.swift in Sources */,
 				CBD2F08D20615990002AA385 /* TextField+State.swift in Sources */,
 				441D699C1FEA947600CD919A /* LayoutHelpers.swift in Sources */,
+				45B2E062207C9B6000C68B92 /* InlineConsentView.swift in Sources */,
 				44D912602077AC8A00486848 /* AttachableView.swift in Sources */,
 				4447F6EA1FDB2B110033DBC1 /* RibbonView.swift in Sources */,
 				4408A6A32027AC41008C0BD9 /* Color.swift in Sources */,

--- a/Sources/Components/New Group/Demo/InlineConsentDemoView.swift
+++ b/Sources/Components/New Group/Demo/InlineConsentDemoView.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import FinniversKit
+
+public class InlineConsentDemoView: UIView {
+    private lazy var inlineConsentView: InlineConsentView = {
+        let view = InlineConsentView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setup()
+    }
+
+    public required init?(coder aDecoder: NSCoder) { fatalError() }
+
+    private func setup() {
+        inlineConsentView.descriptionText = "Vi kan bruke søkemønsteret ditt til å gi deg relevante anbefalinger fra FINN. Er det greit at vi lagrer dine søkevalg?"
+        inlineConsentView.yesButtonTitle = "Ja, det er greit"
+        inlineConsentView.infoButtonTitle = "Mer om samtykke"
+
+        addSubview(inlineConsentView)
+
+        NSLayoutConstraint.activate([
+            inlineConsentView.topAnchor.constraint(equalTo: topAnchor, constant: .largeSpacing),
+            inlineConsentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
+            inlineConsentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
+        ])
+    }
+}

--- a/Sources/Components/New Group/InlineConsentView.swift
+++ b/Sources/Components/New Group/InlineConsentView.swift
@@ -1,0 +1,126 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+import UIKit
+
+public protocol InlineConsentViewDelegate: NSObjectProtocol {
+    func inlineConsentView(_ consentActivateDiscoverView: InlineConsentView, didSelectActivateButton button: Button)
+    func inlineConsentView(_ consentActivateDiscoverView: InlineConsentView, didSelectInfoButton button: Button)
+}
+
+public class InlineConsentView: UIView {
+
+    // MARK: - Internal properties
+
+    private lazy var descriptionTitleLabel: Label = {
+        let label = Label(style: .body(.licorice))
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var yesButton: Button = {
+        let button = Button(style: .callToAction)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(yesButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var infoButton: Button = {
+        let button = Button(style: .flat)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(infoButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    // MARK: - External properties / Dependency injection
+
+    public weak var delegate: InlineConsentViewDelegate?
+
+    public var descriptionText: String = "" {
+        didSet {
+            descriptionTitleLabel.text = descriptionText
+        }
+    }
+
+    public var yesButtonTitle: String = "" {
+        didSet {
+            yesButton.setTitle(yesButtonTitle, for: .normal)
+        }
+    }
+
+    public var infoButtonTitle: String = "" {
+        didSet {
+            infoButton.setTitle(infoButtonTitle, for: .normal)
+        }
+    }
+
+    // MARK: - Setup
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setup()
+    }
+
+    private func setup() {
+        addSubview(descriptionTitleLabel)
+        addSubview(yesButton)
+        addSubview(infoButton)
+
+        NSLayoutConstraint.activate([
+            descriptionTitleLabel.topAnchor.constraint(equalTo: topAnchor),
+            descriptionTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            descriptionTitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            yesButton.topAnchor.constraint(equalTo: descriptionTitleLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            yesButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+
+            infoButton.topAnchor.constraint(equalTo: yesButton.bottomAnchor, constant: .mediumLargeSpacing),
+            infoButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            infoButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc private func yesButtonTapped(_ sender: Button) {
+        delegate?.inlineConsentView(self, didSelectActivateButton: sender)
+    }
+
+    @objc private func infoButtonTapped(_ sender: Button) {
+        delegate?.inlineConsentView(self, didSelectInfoButton: sender)
+    }
+
+    // MARK: - Superclass overrides
+
+    public override var intrinsicContentSize: CGSize {
+        let intermediateSpacing = CGFloat.mediumLargeSpacing * 2
+
+        guard let descriptionText = descriptionTitleLabel.text else {
+            return CGSize.zero
+        }
+        let screenSize = UIScreen.main.bounds
+
+        let titleHeight = descriptionText.height(withConstrainedWidth: screenSize.width - .mediumLargeSpacing * 2, font: descriptionTitleLabel.font) // .meiumLargeSpacing * 2, is margins in MarketViewController
+        let activateButtonSize = CGSize(width: 130, height: 38)
+        let infoButtonSize = CGSize(width: 142, height: 30)
+        let widestButtonWidth = max(activateButtonSize.width, infoButtonSize.width)
+
+        return CGSize(width: max(screenSize.width, widestButtonWidth), height: intermediateSpacing + titleHeight + activateButtonSize.height + infoButtonSize.height)
+    }
+}
+
+fileprivate extension String {
+    func height(withConstrainedWidth width: CGFloat, font: UIFont) -> CGFloat {
+        let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
+        let boundingBox = (self as NSString).boundingRect(with: constraintRect, options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil)
+
+        return ceil(boundingBox.height)
+    }
+}


### PR DESCRIPTION
# What?
A smaller consent view. Inline means that it is not a "popup", but a view that is present until you interact with it. Sort of in the same sense that _"Discover Cat"_ is an inline rating view.

# Why?
Extracts the view from the FINN app to be consistent with the practice of using FinniversKit.

# Screenshot
![simulator screen shot - iphone x - 2018-04-10 at 10 40 21](https://user-images.githubusercontent.com/15629801/38545949-9605f678-3cab-11e8-9cb2-5f4dc089563d.png)
