### PR TITLE
Adds action button to empty view

### DIFF
--- a/Sources/Fullscreen/EmptyView/Demo/EmptyViewDemoView.swift
+++ b/Sources/Fullscreen/EmptyView/Demo/EmptyViewDemoView.swift
@@ -20,6 +20,7 @@ public class EmptyViewDemoView: UIView {
 
         emptyView.header = "Her var det stille gitt"
         emptyView.message = "Når du prater med andre på FINN, vil meldingene dine dukke opp her.\n\n Søk på noe du har lyst på, send en melding til selgeren og bli enige om en handel på én-to-tre!"
+        emptyView.actionButtonTitle = "Gjør et søk"
 
         addSubview(emptyView)
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -5,6 +5,10 @@
 import CoreMotion
 import UIKit
 
+public protocol EmptyViewDelegate: class {
+    func performAction(from emptyView: EmptyView)
+}
+
 public class EmptyView: UIView {
 
     // MARK: - Internal properties
@@ -62,6 +66,14 @@ public class EmptyView: UIView {
         return label
     }()
 
+    private lazy var actionButton: Button = {
+        let button = Button(style: .callToAction)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(performAction), for: .touchUpInside)
+        button.isHidden = true // Default is hidden. When a title is set it well be displayed.
+        return button
+    }()
+
     private lazy var animator: UIDynamicAnimator = {
         let animator = UIDynamicAnimator(referenceView: self)
         return animator
@@ -103,6 +115,8 @@ public class EmptyView: UIView {
 
     // MARK: - External properties / Dependency injection
 
+    public weak var delegate: EmptyViewDelegate?
+
     public var header: String = "" {
         didSet {
             headerLabel.text = header
@@ -114,6 +128,14 @@ public class EmptyView: UIView {
         didSet {
             messageLabel.text = message
             messageLabel.accessibilityLabel = message
+        }
+    }
+
+    public var actionButtonTitle: String = "" {
+        didSet {
+            actionButton.setTitle(actionButtonTitle, for: .normal)
+            actionButton.accessibilityLabel = actionButtonTitle
+            actionButton.isHidden = actionButtonTitle.isEmpty
         }
     }
 
@@ -139,6 +161,7 @@ public class EmptyView: UIView {
 
         addSubview(headerLabel)
         addSubview(messageLabel)
+        addSubview(actionButton)
 
         getAccelerometerData()
 
@@ -150,6 +173,10 @@ public class EmptyView: UIView {
             messageLabel.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: .largeSpacing),
             messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
+
+            actionButton.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: .largeSpacing),
+            actionButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
+            actionButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
         ])
     }
 
@@ -203,6 +230,10 @@ public class EmptyView: UIView {
                 itemBehavior.addLinearVelocity(sender.velocity(in: self), for: objectView)
             }
         }
+    }
+
+    @objc private func performAction() {
+        delegate?.performAction(from: self)
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -70,7 +70,7 @@ public class EmptyView: UIView {
         let button = Button(style: .callToAction)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(performAction), for: .touchUpInside)
-        button.isHidden = true // Default is hidden. When a title is set it well be displayed.
+        button.isHidden = true // Default is hidden. When a title is set it will be displayed.
         return button
     }()
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -6,7 +6,7 @@ import CoreMotion
 import UIKit
 
 public protocol EmptyViewDelegate: class {
-    func performAction(from emptyView: EmptyView)
+    func emptyView(_ emptyView: EmptyView, didSelectActionButton button: Button)
 }
 
 public class EmptyView: UIView {
@@ -233,7 +233,7 @@ public class EmptyView: UIView {
     }
 
     @objc private func performAction() {
-        delegate?.performAction(from: self)
+        delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 
     // MARK: - Accelerometer calculations


### PR DESCRIPTION
# What?
Adds action button to empty view

# Why?
In case the empty view is used as a placeholder for content when logged out we need an option to send the user to the login flow. 

# How?
The button is optional. If you set the button title it will show. Otherwise it will remain hidden.

# Screens
![simulator screen shot - iphone 5s - 2018-04-25 at 10 42 36](https://user-images.githubusercontent.com/1060670/39235559-76c1d422-4876-11e8-9292-413f12f0f15e.png)
