### PR TITLE
Bumped up version number due to EmptyView Btn

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '0.3.0'
+  s.version      = '0.3.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
**_What?_**

Due to 

```
public protocol EmptyViewDelegate: class {
    func emptyView(_ emptyView: EmptyView, didSelectActionButton button: Button)
}
```
we should bump up.
