### PR TITLE
Script fails when parent has white space

### DIFF
--- a/Others/format.sh
+++ b/Others/format.sh
@@ -4,7 +4,7 @@ HEADER="//\n//  Copyright © FINN.no AS, Inc. All rights reserved.\n//"
 
 command="${SRCROOT}/Others/swiftformat"
 
-OUTPUT=$($command \
+OUTPUT=$("$command" \
 --stripunusedargs closure-only \
 --header "$HEADER" \
 --disable redundantReturn \


### PR DESCRIPTION
**_What_**
enclose command variable in double quotes to avoid space

**_Why_**
This error appears if the parent directory contains whitespace like "/Users/admin/Documents/X sample"
Carthage:

> *** Building scheme "FinniversKit" in FinniversKit.xcodeproj
> Build Failed
> 	Task failed with exit code 65:
> 	/usr/bin/xcrun xcodebuild -project /Users/admin/Documents/X\ sample/Carthage/Checkouts/FinniversKit/FinniversKit.xcodeproj -scheme FinniversKit -configuration Release -derivedDataPath /Users/admin/Library/Caches/org.carthage.CarthageKit/DerivedData/9.3_9E145/FinniversKit/439238e1704ed3199498c46f061d3d76e76205a9 -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath /var/folders/m0/mfjt5hnx04ncp4y834vlztyr0000gn/T/FinniversKit SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in /Users/admin/Documents/X sample/Carthage/Checkouts/FinniversKit)
> 
> This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/m0/mfjt5hnx04ncp4y834vlztyr0000gn/T/carthage-xcodebuild.TDcj0H.log

Xcode:
> /Users/admin/Documents/X sample/Carthage/Checkouts/FinniversKit/Others/format.sh: line 11: /Users/admin/Documents/X: No such file or directory
> Command /bin/sh emitted errors but did not return a nonzero exit code to indicate failure