### PR TITLE
Small layout fix for InlineConsentView demo on iPad

### DIFF
--- a/Sources/Components/Consent/Demo/InlineConsentDemoView.swift
+++ b/Sources/Components/Consent/Demo/InlineConsentDemoView.swift
@@ -5,9 +5,17 @@
 import FinniversKit
 
 public class InlineConsentDemoView: UIView {
+    private let plusScreenWidth: CGFloat = 414.0
+
     private lazy var inlineConsentView: InlineConsentView = {
-        let view = InlineConsentView(frame: frame)
+        let margins = .mediumLargeSpacing * 2
+        let consentWidth = min(frame.width, plusScreenWidth)
+        let consentFrame = CGRect(x: 0, y: 0, width: (consentWidth - margins), height: frame.height)
+        let view = InlineConsentView(frame: consentFrame)
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.descriptionText = "Vi kan vise deg relevante FINN-annonser du ikke har sett. Da trenger vi å lagre dine søkevalg."
+        view.yesButtonTitle = "Ja, det er greit"
+        view.infoButtonTitle = "Mer om samtykke"
         return view
     }()
 
@@ -20,16 +28,14 @@ public class InlineConsentDemoView: UIView {
     public required init?(coder aDecoder: NSCoder) { fatalError() }
 
     private func setup() {
-        inlineConsentView.descriptionText = "Vi kan bruke søkemønsteret ditt til å gi deg relevante anbefalinger fra FINN. Er det greit at vi lagrer dine søkevalg?"
-        inlineConsentView.yesButtonTitle = "Ja, det er greit"
-        inlineConsentView.infoButtonTitle = "Mer om samtykke"
-
         addSubview(inlineConsentView)
 
         NSLayoutConstraint.activate([
             inlineConsentView.topAnchor.constraint(equalTo: topAnchor, constant: .largeSpacing),
-            inlineConsentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
-            inlineConsentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
+            inlineConsentView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            inlineConsentView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: .mediumLargeSpacing),
+            inlineConsentView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -.mediumLargeSpacing),
+            inlineConsentView.widthAnchor.constraint(equalToConstant: plusScreenWidth),
         ])
     }
 }

--- a/Sources/Components/Consent/InlineConsentView.swift
+++ b/Sources/Components/Consent/InlineConsentView.swift
@@ -108,7 +108,7 @@ public class InlineConsentView: UIView {
 
         let titleHeight = descriptionText.height(withConstrainedWidth: frame.width, font: descriptionTitleLabel.font)
         let widestButtonWidth = max(yesButton.intrinsicContentSize.width, infoButton.intrinsicContentSize.width)
-        
+
         return CGSize(width: max(frame.width, widestButtonWidth), height: intermediateSpacing + titleHeight + yesButton.intrinsicContentSize.height + infoButton.intrinsicContentSize.height)
     }
 }


### PR DESCRIPTION
# What?
Changes the constraints and initialization of the `InlineConsentView` so that it does not exceed a width limit of 414p (iPhone Plus size width).

# Why?
To be more dynamic and suited for iPad and similar to the FINN app.

# Screenshot
<img width="500" alt="simulator screen shot - ipad pro 12 9-inch - 2018-05-03 at 10 24 35" src="https://user-images.githubusercontent.com/15629801/39566737-dfafb78c-4ebc-11e8-9332-84d4989d7d16.png">