### PR TITLE
Update FinniversKitView template

### DIFF
--- a/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
+++ b/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ___FILEBASENAMEASIDENTIFIER___: <#View Class#> {
+final public class ___FILEBASENAMEASIDENTIFIER___: <#View Class#> {
 
     // MARK: - Internal properties
 

--- a/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
+++ b/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
@@ -18,14 +18,21 @@ final public class ___FILEBASENAMEASIDENTIFIER___: <#View Class#> {
         setup()
     }
 
-    private func setup() {
+    // MARK: - Superclass Overrides
+    
+}
+
+// MARK: - Private
+
+private extension ___FILEBASENAMEASIDENTIFIER___ {
+    func setup() {
         // Perform setup
         // Add child views as subviews
         // Setup constraints/frames
     }
+}
 
-    // MARK: - Superclass Overrides
+// MARK: - Public
 
-    // MARK: - Private
-
+public extension ___FILEBASENAMEASIDENTIFIER___ {
 }

--- a/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
+++ b/Templates/FinniversKitView.xctemplate/___FILEBASENAME___.swift
@@ -22,6 +22,11 @@ final public class ___FILEBASENAMEASIDENTIFIER___: <#View Class#> {
     
 }
 
+// MARK: - Public
+
+public extension ___FILEBASENAMEASIDENTIFIER___ {
+}
+
 // MARK: - Private
 
 private extension ___FILEBASENAMEASIDENTIFIER___ {
@@ -30,9 +35,4 @@ private extension ___FILEBASENAMEASIDENTIFIER___ {
         // Add child views as subviews
         // Setup constraints/frames
     }
-}
-
-// MARK: - Public
-
-public extension ___FILEBASENAMEASIDENTIFIER___ {
 }


### PR DESCRIPTION
# Why
This is a proposition for changes to the `FinniversKitView` template.

# What

## Make template class `final`
+ Classes should default to be final.
+ If the class needs to be a subclassable at a later stage we can remove the final keyword once we have made sure it will function properly as a superclass.
+ There are performance  gains by making classes `final` by reducing dynamic dispatch

## Make template class `public`
+ By default all FinniversKit views are intended to public. This saves us from returning to the class and making it public once its not available for us in outside the FinniversKit module😄

## Add `private extension` and `public extension`
+ Makes for a better overview of the classes `private` and `public` functions

# Discussion
What do we feel about the `// MARK: -`? Any changes we would like to make?

# Screenshots
![screen shot 2018-05-03 at 11 51 08](https://user-images.githubusercontent.com/3429232/39570370-66e27018-4ec8-11e8-81f9-e686dd29d765.png)