### PR TITLE
Add support for tablet display mode

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -4,6 +4,12 @@
 
 import UIKit
 
+enum TabletDisplayMode {
+    case master
+    case detail
+    case fullscreen
+}
+
 enum Sections: String {
     case dna
     case components
@@ -55,25 +61,52 @@ enum Sections: String {
         return rawClassName.capitalizingFirstLetter
     }
 
-    static func section(for indexPath: IndexPath) -> Sections {
+    static func `for`(_ indexPath: IndexPath) -> Sections {
         return Sections.all[indexPath.section]
     }
 
     static func viewController(for indexPath: IndexPath) -> UIViewController {
         let section = Sections.all[indexPath.section]
+        let viewController: UIViewController
         switch section {
         case .dna:
             let selectedView = DnaViews.all[indexPath.row]
-            return selectedView.viewController
+            viewController = selectedView.viewController
         case .components:
             let selectedView = ComponentViews.all[indexPath.row]
-            return selectedView.viewController
+            viewController = selectedView.viewController
         case .recycling:
             let selectedView = Recycling.all[indexPath.row]
-            return selectedView.viewController
+            viewController = selectedView.viewController
         case .fullscreen:
             let selectedView = FullscreenViews.all[indexPath.row]
-            return selectedView.viewController
+            viewController = selectedView.viewController
+        }
+
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone:
+            return viewController
+        case .pad:
+            let sectionType = Sections.for(indexPath)
+            switch sectionType.tabletDisplayMode {
+            case .master:
+                return SplitViewController(masterViewController: viewController)
+            case .detail:
+                return SplitViewController(detailViewController: viewController)
+            case .fullscreen:
+                return viewController
+            }
+        default:
+            fatalError("Not supported")
+        }
+    }
+
+    var tabletDisplayMode: TabletDisplayMode {
+        switch self {
+        case .dna, .components, .fullscreen:
+            return .fullscreen
+        case .recycling:
+            return .master
         }
     }
 }

--- a/Demo/DemoViewsTableViewController.swift
+++ b/Demo/DemoViewsTableViewController.swift
@@ -65,6 +65,7 @@ extension DemoViewsTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         IndexPath.lastSelected = indexPath
+
         let viewController = Sections.viewController(for: indexPath)
         present(viewController, animated: true)
     }

--- a/Demo/Helpers.swift
+++ b/Demo/Helpers.swift
@@ -2,7 +2,7 @@
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 extension String {
     var capitalizingFirstLetter: String {
@@ -34,5 +34,40 @@ extension IndexPath {
             }
             UserDefaults.standard.synchronize()
         }
+    }
+}
+
+class SplitViewController: UISplitViewController {
+    lazy var alternativeViewController: UIViewController = {
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .milk
+
+        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(didDoubleTap))
+        doubleTap.numberOfTapsRequired = 2
+        viewController.view.addGestureRecognizer(doubleTap)
+        return viewController
+    }()
+
+    convenience init(masterViewController: UIViewController) {
+        self.init(nibName: nil, bundle: nil)
+
+        viewControllers = [masterViewController, alternativeViewController]
+        setup()
+    }
+
+    convenience init(detailViewController: UIViewController) {
+        self.init(nibName: nil, bundle: nil)
+
+        viewControllers = [alternativeViewController, detailViewController]
+        setup()
+    }
+
+    func setup() {
+        preferredDisplayMode = .allVisible
+    }
+
+    @objc func didDoubleTap() {
+        IndexPath.lastSelected = nil
+        dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Makes it easier to test view controllers contained in a UISplitViewController. In the Demo you just need to modify the computed variable `tabletDisplayMode` in the `Sections` enum.

![tablet detail mode](https://user-images.githubusercontent.com/1088217/39659658-bbfa484e-502d-11e8-8d69-c93dae9947a6.png)
