### PR TITLE
Optional dynamic type

### DIFF
--- a/Sources/DNA/Font/Font.swift
+++ b/Sources/DNA/Font/Font.swift
@@ -98,8 +98,12 @@ public extension UIFont {
 
     func scaledFont(forTextStyle textStyle: UIFontTextStyle) -> UIFont {
         if #available(iOS 11.0, *) {
-            let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-            return fontMetrics.scaledFont(for: self)
+            if FinniversKit.isDynamicTypeEnabled {
+                let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+                return fontMetrics.scaledFont(for: self)
+            } else {
+                return self
+            }
         } else {
             return self
         }

--- a/Sources/FinniversKit.swift
+++ b/Sources/FinniversKit.swift
@@ -5,12 +5,12 @@
 import Foundation
 
 /// Class for referencing the framework bundle
-public class FinniversKit {
+@objc public class FinniversKit: NSObject {
     static var bundle: Bundle {
         return Bundle(for: FinniversKit.self)
     }
 
-    public static var isDynamicTypeEnabled: Bool = true
+    @objc public static var isDynamicTypeEnabled: Bool = true
 }
 
 public extension Bundle {

--- a/Sources/FinniversKit.swift
+++ b/Sources/FinniversKit.swift
@@ -9,6 +9,8 @@ public class FinniversKit {
     static var bundle: Bundle {
         return Bundle(for: FinniversKit.self)
     }
+
+    public static var isDynamicTypeEnabled: Bool = true
 }
 
 public extension Bundle {


### PR DESCRIPTION
We still have a few places in the FINN app not optimized for dynamic type (AdIn for example). The plan is to disable Dynamic Type for App Store builds until we feel more confident with the quality of our Dynamic Type support. I would like to encourage you to blow up your Simulator font sizes, though since we should have this enabled for beta and debug.

![foto](https://user-images.githubusercontent.com/1088217/40332317-fbfbac5c-5d53-11e8-9535-2693c2342ab2.jpg)
