### PR TITLE
Consent needs bullet points

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -217,7 +217,7 @@ enum Recycling: String {
 enum FullscreenViews: String {
     case frontpageView
     case registerView
-    case popupConsentView
+    case popupView
     case emptyView
     case loginView
 
@@ -225,7 +225,7 @@ enum FullscreenViews: String {
         return [
             .frontpageView,
             .registerView,
-            .popupConsentView,
+            .popupView,
             .emptyView,
             .loginView,
         ]
@@ -241,7 +241,7 @@ enum FullscreenViews: String {
             return ViewController<LoginViewDemoView>()
         case .emptyView:
             return ViewController<EmptyViewDemoView>()
-        case .popupConsentView:
+        case .popupView:
             return ViewController<PopupViewDemoView>()
         }
     }

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoView.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoView.swift
@@ -163,7 +163,7 @@ public final class ConsentTransparencyInfoView: UIView {
             usageHeaderLabel.text = model.usageHeaderText
             usageIntro1Label.text = model.usageIntro1Text
             usageIntro2Label.text = model.usageIntro2Text
-            usageBulletPointsLabel.attributedText = model.usageBulletPointsText.asBulletPoints()
+            usageBulletPointsLabel.attributedText = model.usageBulletPointsText
             improveHeaderLabel.text = model.improveHeaderText
             improveIntroLabel.text = model.improveIntroText
             if showSettingsButtons {
@@ -175,7 +175,7 @@ public final class ConsentTransparencyInfoView: UIView {
             privacyFinnButton.setTitle(model.privacyFinnButtonTitle, for: .normal)
             usageSchibstedHeaderLabel.text = model.usageSchibstedHeaderText
             usageSchibstedIntroLabel.text = model.usageSchibstedIntroText
-            usageSchibstedBulletPointsLabel.attributedText = model.usageBulletPointsText.asBulletPoints()
+            usageSchibstedBulletPointsLabel.attributedText = model.usageBulletPointsText
             if showSettingsButtons {
                 usageSchibstedButtonIntroLabel.text = model.usageSchibstedButtonIntroWithSettingsText
             } else {

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoView.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoView.swift
@@ -34,112 +34,84 @@ public final class ConsentTransparencyInfoView: UIView {
         return label
     }()
 
-    private lazy var mainIntroLabel: Label = {
+    private lazy var finnHeaderLabel: Label = {
+        let label = Label(style: .title4(.licorice))
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var finnIntroLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var usageHeaderLabel: Label = {
-        let label = Label(style: .title2)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        return label
-    }()
-
-    private lazy var usageIntro1Label: Label = {
+    private lazy var finnBulletPointsLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var usageIntro2Label: Label = {
-        let label = Label(style: .title3)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        return label
-    }()
-
-    private lazy var usageBulletPointsLabel: Label = {
+    private lazy var finnButtonIntroLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var improveHeaderLabel: Label = {
-        let label = Label(style: .title3)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        return label
-    }()
-
-    private lazy var improveIntroLabel: Label = {
-        let label = Label(style: .body(.licorice))
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        return label
-    }()
-
-    private lazy var improveButtonIntroLabel: Label = {
-        let label = Label(style: .body(.licorice))
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        return label
-    }()
-
-    private lazy var settingsFinnButton: Button = {
+    private lazy var finnSettingsButton: Button = {
         let button = Button(style: .flat)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(settingsFinnTapped), for: .touchUpInside)
         return button
     }()
 
-    private lazy var privacyFinnButton: Button = {
+    private lazy var finnPrivacyButton: Button = {
         let button = Button(style: .flat)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(privacyFinnTapped), for: .touchUpInside)
         return button
     }()
 
-    private lazy var usageSchibstedHeaderLabel: Label = {
-        let label = Label(style: .title2)
+    private lazy var schibstedHeaderLabel: Label = {
+        let label = Label(style: .title4(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var usageSchibstedIntroLabel: Label = {
+    private lazy var schibstedIntroLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var usageSchibstedBulletPointsLabel: Label = {
+    private lazy var schibstedBulletPointsLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var usageSchibstedButtonIntroLabel: Label = {
+    private lazy var schibstedButtonIntroLabel: Label = {
         let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
     }()
 
-    private lazy var settingsSchibstedButton: Button = {
+    private lazy var schibstedSettingsButton: Button = {
         let button = Button(style: .flat)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(settingsSchibstedTapped), for: .touchUpInside)
         return button
     }()
 
-    private lazy var privacySchibstedButton: Button = {
+    private lazy var schibstedPrivacyButton: Button = {
         let button = Button(style: .flat)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(privacySchibstedTapped), for: .touchUpInside)
@@ -159,30 +131,26 @@ public final class ConsentTransparencyInfoView: UIView {
             }
 
             mainHeaderLabel.text = model.mainHeaderText
-            mainIntroLabel.text = model.mainIntroText
-            usageHeaderLabel.text = model.usageHeaderText
-            usageIntro1Label.text = model.usageIntro1Text
-            usageIntro2Label.text = model.usageIntro2Text
-            usageBulletPointsLabel.attributedText = model.usageBulletPointsText
-            improveHeaderLabel.text = model.improveHeaderText
-            improveIntroLabel.text = model.improveIntroText
+            finnHeaderLabel.text = model.finnHeaderText
+            finnIntroLabel.text = model.finnIntroText
+            finnBulletPointsLabel.attributedText = model.finnBulletPointsText
             if showSettingsButtons {
-                improveButtonIntroLabel.text = model.improveButtonIntroWithSettingsText
+                finnButtonIntroLabel.text = model.finnButtonIntroWithSettingsText
             } else {
-                improveButtonIntroLabel.text = model.improveButtonIntroWithoutSettingsText
+                finnButtonIntroLabel.text = model.finnButtonIntroWithoutSettingsText
             }
-            settingsFinnButton.setTitle(model.settingsFinnButtonTitle, for: .normal)
-            privacyFinnButton.setTitle(model.privacyFinnButtonTitle, for: .normal)
-            usageSchibstedHeaderLabel.text = model.usageSchibstedHeaderText
-            usageSchibstedIntroLabel.text = model.usageSchibstedIntroText
-            usageSchibstedBulletPointsLabel.attributedText = model.usageBulletPointsText
+            finnSettingsButton.setTitle(model.finnSettingsButtonTitle, for: .normal)
+            finnPrivacyButton.setTitle(model.finnPrivacyButtonTitle, for: .normal)
+            schibstedHeaderLabel.text = model.schibstedHeaderText
+            schibstedIntroLabel.text = model.schibstedIntroText
+            schibstedBulletPointsLabel.attributedText = model.finnBulletPointsText
             if showSettingsButtons {
-                usageSchibstedButtonIntroLabel.text = model.usageSchibstedButtonIntroWithSettingsText
+                schibstedButtonIntroLabel.text = model.schibstedButtonIntroWithSettingsText
             } else {
-                usageSchibstedButtonIntroLabel.text = model.usageSchibstedButtonIntroWithoutSettingsText
+                schibstedButtonIntroLabel.text = model.schibstedButtonIntroWithoutSettingsText
             }
-            settingsSchibstedButton.setTitle(model.settingsSchibstedButtonTitle, for: .normal)
-            privacySchibstedButton.setTitle(model.privacySchibstedButtonTitle, for: .normal)
+            schibstedSettingsButton.setTitle(model.schibstedSettingsButtonTitle, for: .normal)
+            schibstedPrivacyButton.setTitle(model.schibstedPrivacyButtonTitle, for: .normal)
         }
     }
 
@@ -221,29 +189,25 @@ private extension ConsentTransparencyInfoView {
         scrollView.addSubview(contentView)
 
         contentView.addSubview(mainHeaderLabel)
-        contentView.addSubview(mainIntroLabel)
-        contentView.addSubview(usageHeaderLabel)
-        contentView.addSubview(usageIntro1Label)
-        contentView.addSubview(usageIntro2Label)
-        contentView.addSubview(usageBulletPointsLabel)
-        contentView.addSubview(improveHeaderLabel)
-        contentView.addSubview(improveIntroLabel)
-        contentView.addSubview(improveButtonIntroLabel)
-        contentView.addSubview(privacyFinnButton)
-        contentView.addSubview(usageSchibstedHeaderLabel)
-        contentView.addSubview(usageSchibstedIntroLabel)
-        contentView.addSubview(usageSchibstedBulletPointsLabel)
-        contentView.addSubview(usageSchibstedButtonIntroLabel)
-        contentView.addSubview(privacySchibstedButton)
+        contentView.addSubview(finnHeaderLabel)
+        contentView.addSubview(finnIntroLabel)
+        contentView.addSubview(finnBulletPointsLabel)
+        contentView.addSubview(finnButtonIntroLabel)
+        contentView.addSubview(finnPrivacyButton)
+        contentView.addSubview(schibstedHeaderLabel)
+        contentView.addSubview(schibstedIntroLabel)
+        contentView.addSubview(schibstedBulletPointsLabel)
+        contentView.addSubview(schibstedButtonIntroLabel)
+        contentView.addSubview(schibstedPrivacyButton)
 
-        let privacyFinnButtonConstraintToSettings = privacyFinnButton.topAnchor.constraint(equalTo: settingsFinnButton.bottomAnchor, constant: .mediumLargeSpacing)
-        let privacyFinnButtonConstraintToIntro = privacyFinnButton.topAnchor.constraint(equalTo: improveButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing)
+        let finnPrivacyButtonConstraintToSettings = finnPrivacyButton.topAnchor.constraint(equalTo: finnSettingsButton.bottomAnchor, constant: .mediumLargeSpacing)
+        let finnPrivacyButtonConstraintToIntro = finnPrivacyButton.topAnchor.constraint(equalTo: finnButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing)
 
-        let privacySchibstedButtonConstraintToSettings = privacySchibstedButton.topAnchor.constraint(equalTo: settingsSchibstedButton.bottomAnchor, constant: .mediumLargeSpacing)
-        let privacySchibstedButtonConstraintToIntro = privacySchibstedButton.topAnchor.constraint(equalTo: usageSchibstedButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing)
+        let schibstedPrivacyButtonConstraintToSettings = schibstedPrivacyButton.topAnchor.constraint(equalTo: schibstedSettingsButton.bottomAnchor, constant: .mediumLargeSpacing)
+        let schibstedPrivacyButtonConstraintToIntro = schibstedPrivacyButton.topAnchor.constraint(equalTo: schibstedButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing)
 
-        privacyFinnButtonConstraintToSettings.isActive = false
-        privacySchibstedButtonConstraintToSettings.isActive = false
+        finnPrivacyButtonConstraintToSettings.isActive = false
+        schibstedPrivacyButtonConstraintToSettings.isActive = false
 
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: topAnchor),
@@ -261,81 +225,66 @@ private extension ConsentTransparencyInfoView {
             mainHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
             mainHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            mainIntroLabel.topAnchor.constraint(equalTo: mainHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            mainIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            mainIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            finnHeaderLabel.topAnchor.constraint(equalTo: mainHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            finnHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            finnHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            usageHeaderLabel.topAnchor.constraint(equalTo: mainIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            usageHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            finnIntroLabel.topAnchor.constraint(equalTo: finnHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            finnIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            finnIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            usageIntro1Label.topAnchor.constraint(equalTo: usageHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            usageIntro1Label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageIntro1Label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            finnBulletPointsLabel.topAnchor.constraint(equalTo: finnIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            finnBulletPointsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            finnBulletPointsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            usageIntro2Label.topAnchor.constraint(equalTo: usageIntro1Label.bottomAnchor, constant: .mediumLargeSpacing),
-            usageIntro2Label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageIntro2Label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            finnButtonIntroLabel.topAnchor.constraint(equalTo: finnBulletPointsLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            finnButtonIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            finnButtonIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            usageBulletPointsLabel.topAnchor.constraint(equalTo: usageIntro2Label.bottomAnchor, constant: .mediumLargeSpacing),
-            usageBulletPointsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageBulletPointsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            finnPrivacyButtonConstraintToIntro,
+            finnPrivacyButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            finnPrivacyButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            improveHeaderLabel.topAnchor.constraint(equalTo: usageBulletPointsLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            improveHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            improveHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            schibstedHeaderLabel.topAnchor.constraint(equalTo: finnPrivacyButton.bottomAnchor, constant: .mediumLargeSpacing),
+            schibstedHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            schibstedHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            improveIntroLabel.topAnchor.constraint(equalTo: improveHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            improveIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            improveIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            schibstedIntroLabel.topAnchor.constraint(equalTo: schibstedHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            schibstedIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            schibstedIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            improveButtonIntroLabel.topAnchor.constraint(equalTo: improveIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            improveButtonIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            improveButtonIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            schibstedBulletPointsLabel.topAnchor.constraint(equalTo: schibstedIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            schibstedBulletPointsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            schibstedBulletPointsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            privacyFinnButtonConstraintToIntro,
-            privacyFinnButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            privacyFinnButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            schibstedButtonIntroLabel.topAnchor.constraint(equalTo: schibstedBulletPointsLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            schibstedButtonIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            schibstedButtonIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            usageSchibstedHeaderLabel.topAnchor.constraint(equalTo: privacyFinnButton.bottomAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedHeaderLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedHeaderLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
-
-            usageSchibstedIntroLabel.topAnchor.constraint(equalTo: usageSchibstedHeaderLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
-
-            usageSchibstedBulletPointsLabel.topAnchor.constraint(equalTo: usageSchibstedIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedBulletPointsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedBulletPointsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
-
-            usageSchibstedButtonIntroLabel.topAnchor.constraint(equalTo: usageSchibstedBulletPointsLabel.bottomAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedButtonIntroLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            usageSchibstedButtonIntroLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
-
-            privacySchibstedButtonConstraintToIntro,
-            privacySchibstedButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-            privacySchibstedButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
-            privacySchibstedButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -.mediumSpacing),
+            schibstedPrivacyButtonConstraintToIntro,
+            schibstedPrivacyButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+            schibstedPrivacyButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+            schibstedPrivacyButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -.mediumSpacing),
         ])
 
         if showSettingsButtons {
-            contentView.addSubview(settingsFinnButton)
-            contentView.addSubview(settingsSchibstedButton)
+            contentView.addSubview(schibstedSettingsButton)
+            contentView.addSubview(finnSettingsButton)
 
-            privacyFinnButtonConstraintToIntro.isActive = false
-            privacySchibstedButtonConstraintToIntro.isActive = false
+            finnPrivacyButtonConstraintToIntro.isActive = false
+            schibstedPrivacyButtonConstraintToIntro.isActive = false
 
             NSLayoutConstraint.activate([
-                privacyFinnButtonConstraintToSettings,
-                settingsFinnButton.topAnchor.constraint(equalTo: improveButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
-                settingsFinnButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-                settingsFinnButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+                finnPrivacyButtonConstraintToSettings,
+                schibstedPrivacyButtonConstraintToSettings,
 
-                privacySchibstedButtonConstraintToSettings,
-                settingsSchibstedButton.topAnchor.constraint(equalTo: usageSchibstedButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
-                settingsSchibstedButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
-                settingsSchibstedButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+                schibstedSettingsButton.topAnchor.constraint(equalTo: schibstedButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
+                schibstedSettingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+                schibstedSettingsButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
+
+                finnSettingsButton.topAnchor.constraint(equalTo: finnButtonIntroLabel.bottomAnchor, constant: .mediumLargeSpacing),
+                finnSettingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
+                finnSettingsButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
             ])
         }
     }

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
@@ -10,7 +10,7 @@ public protocol ConsentTransparencyInfoViewModel {
     var usageHeaderText: String { get }
     var usageIntro1Text: String { get }
     var usageIntro2Text: String { get }
-    var usageBulletPointsText: [String] { get }
+    var usageBulletPointsText: NSAttributedString { get }
     var improveHeaderText: String { get }
     var improveIntroText: String { get }
     var improveButtonIntroWithSettingsText: String { get }
@@ -19,7 +19,7 @@ public protocol ConsentTransparencyInfoViewModel {
     var privacyFinnButtonTitle: String { get }
     var usageSchibstedHeaderText: String { get }
     var usageSchibstedIntroText: String { get }
-    var usageSchibstedBulletPointsText: [String] { get }
+    var usageSchibstedBulletPointsText: NSAttributedString { get }
     var usageSchibstedButtonIntroWithSettingsText: String { get }
     var usageSchibstedButtonIntroWithoutSettingsText: String { get }
     var settingsSchibstedButtonTitle: String { get }

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
@@ -6,22 +6,20 @@ import Foundation
 
 public protocol ConsentTransparencyInfoViewModel {
     var mainHeaderText: String { get }
-    var mainIntroText: String { get }
-    var usageHeaderText: String { get }
-    var usageIntro1Text: String { get }
-    var usageIntro2Text: String { get }
-    var usageBulletPointsText: NSAttributedString { get }
-    var improveHeaderText: String { get }
-    var improveIntroText: String { get }
-    var improveButtonIntroWithSettingsText: String { get }
-    var improveButtonIntroWithoutSettingsText: String { get }
-    var settingsFinnButtonTitle: String { get }
-    var privacyFinnButtonTitle: String { get }
-    var usageSchibstedHeaderText: String { get }
-    var usageSchibstedIntroText: String { get }
-    var usageSchibstedBulletPointsText: NSAttributedString { get }
-    var usageSchibstedButtonIntroWithSettingsText: String { get }
-    var usageSchibstedButtonIntroWithoutSettingsText: String { get }
-    var settingsSchibstedButtonTitle: String { get }
-    var privacySchibstedButtonTitle: String { get }
+
+    var finnHeaderText: String { get }
+    var finnIntroText: String { get }
+    var finnBulletPointsText: NSAttributedString { get }
+    var finnButtonIntroWithSettingsText: String { get }
+    var finnButtonIntroWithoutSettingsText: String { get }
+    var finnSettingsButtonTitle: String { get }
+    var finnPrivacyButtonTitle: String { get }
+
+    var schibstedHeaderText: String { get }
+    var schibstedIntroText: String { get }
+    var schibstedBulletPointsText: NSAttributedString { get }
+    var schibstedButtonIntroWithSettingsText: String { get }
+    var schibstedButtonIntroWithoutSettingsText: String { get }
+    var schibstedSettingsButtonTitle: String { get }
+    var schibstedPrivacyButtonTitle: String { get }
 }

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/ConsentTransparencyInfoViewModel.swift
@@ -25,9 +25,3 @@ public protocol ConsentTransparencyInfoViewModel {
     var settingsSchibstedButtonTitle: String { get }
     var privacySchibstedButtonTitle: String { get }
 }
-
-extension Array where Element == String {
-    func asBulletPoints() -> NSAttributedString {
-        return NSAttributedString.makeBulletPointFrom(stringList: self, font: .body, bullet: "\u{2022}", indentation: .mediumLargeSpacing, lineSpacing: .verySmallSpacing, paragraphSpacing: .mediumSpacing, textColor: .licorice, bulletColor: .licorice)
-    }
-}

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
@@ -17,14 +17,9 @@ public struct ConsentTransparencyInfoDefaultData: ConsentTransparencyInfoViewMod
 
     public var usageIntro2Text = "Levere den tjenesten du forventer av oss"
 
-    public var usageBulletPointsText: [String] {
-        return [
-            "Annonsering, annonsevisninger og mulighet for å kontakte annonsør",
-            "Meldingsutveksling",
-            "Søk og varslinger",
-            "Gi en best mulig tjeneste til deg, gjennom å tilpasse innholdet vårt. For eksempel ved å vektlegge søketreff nær der du bor.",
-            "Anbefale innhold vi tror er interessant for deg. Dette innholdet kan vi vise på FINN, eller på andre nettsteder.",
-        ]
+    public var usageBulletPointsText: NSAttributedString {
+        let bulletPoints = ["Annonsering, annonsevisninger og mulighet for å kontakte annonsør", "Meldingsutveksling", "Søk og varslinger", "Gi en best mulig tjeneste til deg, gjennom å tilpasse innholdet vårt. For eksempel ved å vektlegge søketreff nær der du bor.", "Anbefale innhold vi tror er interessant for deg. Dette innholdet kan vi vise på FINN, eller på andre nettsteder."]
+        return NSAttributedString.makeBulletPointFrom(stringList: bulletPoints, font: .body)
     }
 
     public var improveHeaderText = "Forbedre produktene våre"
@@ -43,11 +38,9 @@ public struct ConsentTransparencyInfoDefaultData: ConsentTransparencyInfoViewMod
 
     public var usageSchibstedIntroText = "Schibsted Norge bruker data om deg og hva du gjør på FINN og andre Schibsted-tjenester primært for å"
 
-    public var usageSchibstedBulletPointsText: [String] {
-        return [
-            "Ivareta en trygg, enkel og effektiv påloggingstjeneste.",
-            "Gi deg relevant reklameinnhold fremfor tilfeldig reklame.",
-        ]
+    public var usageSchibstedBulletPointsText: NSAttributedString {
+        let bulletPoints = ["Ivareta en trygg, enkel og effektiv påloggingstjeneste.", "Gi deg relevant reklameinnhold fremfor tilfeldig reklame."]
+        return NSAttributedString.makeBulletPointFrom(stringList: bulletPoints, font: .body)
     }
 
     public var usageSchibstedButtonIntroWithSettingsText = "Du kan endre innstillingene dine eller lese Schibsted Norges personvernerklæring ved å trykke knappene under dette avsnittet."

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
@@ -25,7 +25,7 @@ public struct ConsentTransparencyInfoDefaultData: ConsentTransparencyInfoViewMod
     public var finnSettingsButtonTitle = "Innstillinger på FINN"
     public var finnPrivacyButtonTitle = "Vår personvernerklæring"
 
-    public var schibstedHeaderText = "Hva bruker Schibsted dataen til?"
+    public var schibstedHeaderText = "Hva bruker Schibsted Norge dataen til?"
     public var schibstedIntroText = "Schibsted Norge bruker data om deg og hva du gjør på FINN og andre Schibsted-tjenester primært for å"
     public var schibstedBulletPointsText: NSAttributedString {
         let bulletPoints = [

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDefaultData.swift
@@ -9,45 +9,33 @@ public struct ConsentTransparencyInfoDefaultData: ConsentTransparencyInfoViewMod
 
     public var mainHeaderText = "Sikring og bruk av dine data"
 
-    public var mainIntroText = "Når du bruker FINN, gir du oss og Schibsted Norge tilgang til opplysninger om deg. Her kan du lese hva vi bruker dem til."
-
-    public var usageHeaderText = "Hva bruker FINN dataen til?"
-
-    public var usageIntro1Text = "FINN bruker data om deg og hva du gjør på FINN til flere formål."
-
-    public var usageIntro2Text = "Levere den tjenesten du forventer av oss"
-
-    public var usageBulletPointsText: NSAttributedString {
-        let bulletPoints = ["Annonsering, annonsevisninger og mulighet for å kontakte annonsør", "Meldingsutveksling", "Søk og varslinger", "Gi en best mulig tjeneste til deg, gjennom å tilpasse innholdet vårt. For eksempel ved å vektlegge søketreff nær der du bor.", "Anbefale innhold vi tror er interessant for deg. Dette innholdet kan vi vise på FINN, eller på andre nettsteder."]
+    public var finnHeaderText = "Hva bruker FINN dataen til?"
+    public var finnIntroText = "FINN bruker data om deg og hva du gjør på FINN til flere formål. De viktigste er:"
+    public var finnBulletPointsText: NSAttributedString {
+        let bulletPoints = [
+            "Levere den tjenesten du forventer av oss: Vise frem annonser, sørge for medlingsutveksling og tilby søk og varslinger",
+            "Gi deg tilpasset innhold: Vise søketrff nær deg, og anbefale relevant innhold. Dette kan vi vise på FINN, eller på andre nettsteder", "Annonsering, annonsevisninger og mulighet for å kontakte annonsør",
+            "Forbedre produktene våre gjennom statistikk: Sjekke hvordan tjenesten fungerer, og måle effekten av endringer vi gjør",
+            "Sikre en trygg markedsplass ved å forhindre svindel, brudd på annonsereglene og annen misbruk av tjenestene våre",
+        ]
         return NSAttributedString.makeBulletPointFrom(stringList: bulletPoints, font: .body)
     }
+    public var finnButtonIntroWithSettingsText = "Du kan endre innstillingene dine eller lese vår personvernerklæring her:"
+    public var finnButtonIntroWithoutSettingsText = "Du kan lese vår personvernerklæring her:"
+    public var finnSettingsButtonTitle = "Innstillinger på FINN"
+    public var finnPrivacyButtonTitle = "Vår personvernerklæring"
 
-    public var improveHeaderText = "Forbedre produktene våre"
-
-    public var improveIntroText = "Vi bruker statistikk og analyse som grunnlag for avgjørelser om hvilke endringer vi bør gjøre i tjenestene våre, og hvilken effekt endringene har. Sikre en trygg markedsplass ved å forhindre svindel, misbruk av tjenestene våre, eller brudd på annonsereglene."
-
-    public var improveButtonIntroWithSettingsText = "Du kan endre innstillingene dine eller lese vår personvernerklæring ved å trykke knappene under dette avsnittet."
-
-    public var improveButtonIntroWithoutSettingsText = "Du kan lese vår personvernerklæring her:"
-
-    public var settingsFinnButtonTitle = "Innstillinger"
-
-    public var privacyFinnButtonTitle = "Personvernerklæring"
-
-    public var usageSchibstedHeaderText = "Hva bruker Schibsted dataen til?"
-
-    public var usageSchibstedIntroText = "Schibsted Norge bruker data om deg og hva du gjør på FINN og andre Schibsted-tjenester primært for å"
-
-    public var usageSchibstedBulletPointsText: NSAttributedString {
-        let bulletPoints = ["Ivareta en trygg, enkel og effektiv påloggingstjeneste.", "Gi deg relevant reklameinnhold fremfor tilfeldig reklame."]
+    public var schibstedHeaderText = "Hva bruker Schibsted dataen til?"
+    public var schibstedIntroText = "Schibsted Norge bruker data om deg og hva du gjør på FINN og andre Schibsted-tjenester primært for å"
+    public var schibstedBulletPointsText: NSAttributedString {
+        let bulletPoints = [
+            "Tilby en trygg, enkel og effektiv påloggingstjeneste.",
+            "Gi deg relevant reklameinnhold: Vi tror du setter mer pris på reklame som er tilpasset deg, enn tilfeldig reklame.",
+        ]
         return NSAttributedString.makeBulletPointFrom(stringList: bulletPoints, font: .body)
     }
-
-    public var usageSchibstedButtonIntroWithSettingsText = "Du kan endre innstillingene dine eller lese Schibsted Norges personvernerklæring ved å trykke knappene under dette avsnittet."
-
-    public var usageSchibstedButtonIntroWithoutSettingsText = "Du kan lese Schibsted Norges personvernerklæring her:"
-
-    public var settingsSchibstedButtonTitle = "Innstillinger"
-
-    public var privacySchibstedButtonTitle = "Personvernerklæring"
+    public var schibstedButtonIntroWithSettingsText = "Du kan endre innstillingene dine eller lese Schibsted Norges personvernerklæring her:"
+    public var schibstedButtonIntroWithoutSettingsText = "Du kan lese Schibsted Norges personvernerklæring her:"
+    public var schibstedSettingsButtonTitle = "Innstillinger hos Schibsted"
+    public var schibstedPrivacyButtonTitle = "Schibsteds personvernerklæring"
 }

--- a/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDemoView.swift
+++ b/Sources/Components/Consent/ConsentTransparency/ConsentTransparencyInfoView/Demo/ConsentTransparencyInfoDemoView.swift
@@ -8,7 +8,7 @@ public class ConsentTransparencyInfoDemoView: UIView {
     private let maxScreenWidth: CGFloat = 800.0
 
     private lazy var consentTransparencyInfoView: ConsentTransparencyInfoView = {
-        let view = ConsentTransparencyInfoView(showSettingsButtons: false)
+        let view = ConsentTransparencyInfoView(showSettingsButtons: true)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public extension NSAttributedString {
-    static func makeBulletPointFrom(stringList: [String], font: UIFont, bullet: String, indentation: CGFloat, lineSpacing: CGFloat, paragraphSpacing: CGFloat, textColor: UIColor, bulletColor: UIColor) -> NSAttributedString {
+    static func makeBulletPointFrom(stringList: [String], font: UIFont, bullet: String = "\u{2022}", indentation: CGFloat = .mediumLargeSpacing, lineSpacing: CGFloat = .verySmallSpacing, paragraphSpacing: CGFloat = .mediumSpacing, textColor: UIColor = .licorice, bulletColor: UIColor = .licorice) -> NSAttributedString {
         let textAttributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: textColor]
         let bulletAttributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: bulletColor]
 

--- a/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
+++ b/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
@@ -60,7 +60,7 @@ struct PopupConsentViewTransparency: PopupViewModel {
         let mutableAttributedString = NSMutableAttributedString()
         let firstParagraph = NSAttributedString(string: "Hei! For å gjøre FINN bedre samler vi inn informasjon fra alle dere som besøker oss. Vi bruker personlig informasjon og data for å:\n\n")
         let bulletPointArray: [String] = ["Kunne gi deg relevante anbefalinger og tips", "Sørge for at tjenesten FINN fungerer så bra som mulig", "Sikre at FINN er trygg plass å handle på"]
-        let secondParagraph = NSAttributedString.makeBulletPointFrom(stringList: bulletPointArray, font: .detail, paragraphSpacing: .smallSpacing)
+        let secondParagraph = NSAttributedString.makeBulletPointFrom(stringList: bulletPointArray, font: .detail, paragraphSpacing: .verySmallSpacing)
         let thirdParagraph = NSAttributedString(string: "\n\nNår du bruker FINN er Schibsted Norge (eieren vår) behandlingsansvarlig for påloggingsløsning og reklame, mens FINN er behandlingsansvarlig for det øvrige innholdet. Både FINN og Schibsted Norge behandler data om deg.")
         mutableAttributedString.append(firstParagraph)
         mutableAttributedString.append(secondParagraph)

--- a/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
+++ b/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
@@ -61,7 +61,7 @@ struct PopupConsentViewTransparency: PopupViewModel {
         let firstParagraph = NSAttributedString(string: "Hei! For å gjøre FINN bedre samler vi inn informasjon fra alle dere som besøker oss. Vi bruker personlig informasjon og data for å:\n\n")
         let bulletPointArray: [String] = ["Kunne gi deg relevante anbefalinger og tips", "Sørge for at tjenesten FINN fungerer så bra som mulig", "Sikre at FINN er trygg plass å handle på"]
         let secondParagraph = NSAttributedString.makeBulletPointFrom(stringList: bulletPointArray, font: .detail, paragraphSpacing: .smallSpacing)
-        let thirdParagraph = NSAttributedString(string: "\nNår du bruker FINN er Schibsted Norge (eieren vår) behandlingsansvarlig for påloggingsløsning og reklame, mens FINN er behandlingsansvarlig for det øvrige innholdet. Både FINN og Schibsted Norge behandler data om deg.")
+        let thirdParagraph = NSAttributedString(string: "\n\nNår du bruker FINN er Schibsted Norge (eieren vår) behandlingsansvarlig for påloggingsløsning og reklame, mens FINN er behandlingsansvarlig for det øvrige innholdet. Både FINN og Schibsted Norge behandler data om deg.")
         mutableAttributedString.append(firstParagraph)
         mutableAttributedString.append(secondParagraph)
         mutableAttributedString.append(thirdParagraph)

--- a/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
+++ b/Sources/Fullscreen/Popup/Demo/PopupViewDefaultData.swift
@@ -27,7 +27,8 @@ struct PopupConsentViewDefaultData: PopupViewModel {
     public var dismissButtonTitle: String? = "Spør senere"
     public var linkButtonTitle: String? = "Mer om anbefalinger"
     public var descriptionTitle = "Få personlige anbefalinger"
-    public var descriptionText = "Vi kan vise deg relevante FINN-annonser du ikke har sett. Da trenger vi å lagre dine søkevalg."
+    public var descriptionText: String? = "Vi kan vise deg relevante FINN-annonser du ikke har sett. Da trenger vi å lagre dine søkevalg."
+    public var attributedDescriptionText: NSAttributedString?
     public var image: UIImage = UIImage(named: "illustrasjonMedFarge")!
 
     public init() {}
@@ -39,7 +40,8 @@ struct PopupConsentViewDefaultDataRejected: PopupViewModel {
     public var dismissButtonTitle: String?
     public var linkButtonTitle: String?
     public var descriptionTitle = "Personlige anbefalinger er slått av"
-    public var descriptionText = "Vi vil ikke lenger tipse deg om relevante annonser du ikke sett."
+    public var descriptionText: String? = "Vi vil ikke lenger tipse deg om relevante annonser du ikke sett."
+    public var attributedDescriptionText: NSAttributedString?
     public var image: UIImage = UIImage(named: "illustrasjonUtenFarge")!
 
     public init() {}
@@ -47,12 +49,24 @@ struct PopupConsentViewDefaultDataRejected: PopupViewModel {
 
 struct PopupConsentViewTransparency: PopupViewModel {
     public var callToActionButtonTitle = "Jeg forstår"
-    public var alternativeActionButtonTitle = "Vis meg mer"
+    public var alternativeActionButtonTitle = "Les mer"
     public var dismissButtonTitle: String?
     public var linkButtonTitle: String?
-    public var descriptionTitle = "Din data, dine valg"
-    public var descriptionText = "FINN er en del av Schibsted Norge. Når du bruker FINN er Schibsted Norge behandlingsansvarlig for påloggingsløsning og reklame, mens FINN er behandlingsansvarlig for det øvrige innholdet i tjenesten vår. Både FINN og Schibsted Norge behandler data om deg.\n\nFINN bruker dine data til å tilpasse tjenestene til deg, mens Schibsted Norge i tillegg bruker dem til å gi deg mer relevante annonser. Persondata brukes også for å sikre at tjenestene er trygge og sikre for deg."
+    public var descriptionTitle = "Dine data, dine valg"
+    public var descriptionText: String?
     public var image: UIImage = UIImage(named: "consentTransparencyImage")!
+
+    public var attributedDescriptionText: NSAttributedString? {
+        let mutableAttributedString = NSMutableAttributedString()
+        let firstParagraph = NSAttributedString(string: "Hei! For å gjøre FINN bedre samler vi inn informasjon fra alle dere som besøker oss. Vi bruker personlig informasjon og data for å:\n\n")
+        let bulletPointArray: [String] = ["Kunne gi deg relevante anbefalinger og tips", "Sørge for at tjenesten FINN fungerer så bra som mulig", "Sikre at FINN er trygg plass å handle på"]
+        let secondParagraph = NSAttributedString.makeBulletPointFrom(stringList: bulletPointArray, font: .detail, paragraphSpacing: .smallSpacing)
+        let thirdParagraph = NSAttributedString(string: "\nNår du bruker FINN er Schibsted Norge (eieren vår) behandlingsansvarlig for påloggingsløsning og reklame, mens FINN er behandlingsansvarlig for det øvrige innholdet. Både FINN og Schibsted Norge behandler data om deg.")
+        mutableAttributedString.append(firstParagraph)
+        mutableAttributedString.append(secondParagraph)
+        mutableAttributedString.append(thirdParagraph)
+        return mutableAttributedString
+    }
 
     public init() {}
 }

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -190,7 +190,7 @@ public class PopupView: UIView {
             linkButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
             linkButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
-            buttonStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumLargeSpacing),
+            buttonStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
             buttonStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
             buttonStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
         ])

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -177,11 +177,11 @@ public class PopupView: UIView {
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            descriptionTitleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: .mediumLargeSpacing),
+            descriptionTitleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: .mediumSpacing),
             descriptionTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
             descriptionTitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 
-            descriptionLabel.topAnchor.constraint(equalTo: descriptionTitleLabel.bottomAnchor, constant: .mediumLargeSpacing),
+            descriptionLabel.topAnchor.constraint(equalTo: descriptionTitleLabel.bottomAnchor, constant: .mediumSpacing),
             descriptionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing),
             descriptionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumLargeSpacing),
 

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -109,6 +109,8 @@ public class PopupView: UIView {
 
             callToActionButton.setTitle(model.callToActionButtonTitle, for: .normal)
             alternativeActionButton.setTitle(model.alternativeActionButtonTitle, for: .normal)
+            descriptionTitleLabel.text = model.descriptionTitle
+            imageView.image = model.image
 
             if let topRightButtonTitle = model.dismissButtonTitle, topRightButtonTitle != "" {
                 dismissButton.isHidden = false
@@ -123,14 +125,12 @@ public class PopupView: UIView {
             } else {
                 linkButton.isHidden = true
             }
-            descriptionTitleLabel.text = model.descriptionTitle
+            
             if let attributedString = model.attributedDescriptionText {
                 descriptionLabel.attributedText = attributedString
             } else {
                 descriptionLabel.text = model.descriptionText
             }
-
-            imageView.image = model.image
         }
     }
 

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -124,7 +124,11 @@ public class PopupView: UIView {
                 linkButton.isHidden = true
             }
             descriptionTitleLabel.text = model.descriptionTitle
-            descriptionLabel.text = model.descriptionText
+            if let attributedString = model.attributedDescriptionText {
+                descriptionLabel.attributedText = attributedString
+            } else {
+                descriptionLabel.text = model.descriptionText
+            }
 
             imageView.image = model.image
         }

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -125,7 +125,7 @@ public class PopupView: UIView {
             } else {
                 linkButton.isHidden = true
             }
-            
+
             if let attributedString = model.attributedDescriptionText {
                 descriptionLabel.attributedText = attributedString
             } else {

--- a/Sources/Fullscreen/Popup/PopupViewModel.swift
+++ b/Sources/Fullscreen/Popup/PopupViewModel.swift
@@ -10,6 +10,7 @@ public protocol PopupViewModel {
     var dismissButtonTitle: String? { get }
     var linkButtonTitle: String? { get }
     var descriptionTitle: String { get }
-    var descriptionText: String { get }
+    var descriptionText: String? { get }
+    var attributedDescriptionText: NSAttributedString? { get }
     var image: UIImage { get }
 }


### PR DESCRIPTION
# What?
The consent transparency got a new text and must support bullet points. Therefore, a new optional parameter of type _NSAttributedString_, called `attributedDescriptionText`, is added to the `PopupViewModel` and the `descriptionText` parameter is made optional.

Also, the method called `makeBulletPointFrom` in the NSAttributedString extension got some default values to make it shorter to call.

### REMEMBER!
**NB!** Will have to change the `ConsentTransparencyInfoDefaultData` and the `PopupViewConsentDefaultData` in the FINN app after this is merged. Most of it can be copied from this PR.

# Screenshots
### ConsentTransparencyViewController
<img width="250" alt="old" src="https://user-images.githubusercontent.com/15629801/40409965-ce7c78fa-5e6c-11e8-85fd-7d593828b660.png"> <img width="250" alt="new" src="https://user-images.githubusercontent.com/15629801/40411513-fa29c940-5e70-11e8-8a10-81dfafb7eb6a.png">

### ConsentTransparencyInfoViewController
<img width="250" alt="old" src="https://user-images.githubusercontent.com/15629801/39808719-0553e1a8-5380-11e8-8662-5c41f01e2e11.png"> <img width="250" alt="new" src="https://user-images.githubusercontent.com/15629801/40427546-517cd494-5e9e-11e8-89e8-631863dca81d.png">