### PR TITLE
Snap behavior in EmptyView

### DIFF
--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -110,6 +110,12 @@ public class EmptyView: UIView {
         return itemBehavior
     }()
 
+    private var rectangleSnapBehavior: UISnapBehavior?
+    private var triangleSnapBehavior: UISnapBehavior?
+    private var roundedSquareSnapBehavior: UISnapBehavior?
+    private var circleSnapBehavior: UISnapBehavior?
+    private var squareSnapBehavior: UISnapBehavior?
+
     private lazy var motionManager: CMMotionManager = {
         let motionManager = CMMotionManager()
         motionManager.accelerometerUpdateInterval = 1 / 60
@@ -162,6 +168,12 @@ public class EmptyView: UIView {
 
     private func setup() {
         backgroundColor = .milk
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(userHasTapped))
+        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(userDidLongPress))
+        longPressGesture.minimumPressDuration = 2.0
+        addGestureRecognizer(tapGesture)
+        addGestureRecognizer(longPressGesture)
 
         addSubview(rectangle)
         addSubview(triangle)
@@ -245,6 +257,49 @@ public class EmptyView: UIView {
 
     @objc private func performAction() {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
+    }
+
+    @objc func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
+        if rectangleSnapBehavior != nil {
+            removeAllSnapBehaviors()
+        }
+
+        setAllSnapBehaviors(to: gesture.location(in: self))
+        addAllSnapBehaviors()
+    }
+
+    @objc func userHasTapped() {
+        removeAllSnapBehaviors()
+    }
+
+    private func setAllSnapBehaviors(to point: CGPoint) {
+        rectangleSnapBehavior = UISnapBehavior(item: rectangle, snapTo: point)
+        triangleSnapBehavior = UISnapBehavior(item: triangle, snapTo: point)
+        roundedSquareSnapBehavior = UISnapBehavior(item: roundedSquare, snapTo: point)
+        circleSnapBehavior = UISnapBehavior(item: circle, snapTo: point)
+        squareSnapBehavior = UISnapBehavior(item: square, snapTo: point)
+    }
+
+    private func addAllSnapBehaviors() {
+        guard let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior else {
+            return
+        }
+        animator.addBehavior(rectangleSnapBehavior)
+        animator.addBehavior(triangleSnapBehavior)
+        animator.addBehavior(roundedSquareSnapBehavior)
+        animator.addBehavior(circleSnapBehavior)
+        animator.addBehavior(squareSnapBehavior)
+    }
+
+    private func removeAllSnapBehaviors() {
+        guard let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior else {
+            return
+        }
+        animator.removeBehavior(rectangleSnapBehavior)
+        animator.removeBehavior(triangleSnapBehavior)
+        animator.removeBehavior(roundedSquareSnapBehavior)
+        animator.removeBehavior(circleSnapBehavior)
+        animator.removeBehavior(squareSnapBehavior)
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -284,21 +284,37 @@ public class EmptyView: UIView {
     }
 
     private func addAllSnapBehaviors() {
-        if let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior {
+        if let rectangleSnapBehavior = rectangleSnapBehavior {
             animator.addBehavior(rectangleSnapBehavior)
+        }
+        if let triangleSnapBehavior = triangleSnapBehavior {
             animator.addBehavior(triangleSnapBehavior)
+        }
+        if let roundedSquareSnapBehavior = roundedSquareSnapBehavior {
             animator.addBehavior(roundedSquareSnapBehavior)
+        }
+        if let circleSnapBehavior = circleSnapBehavior {
             animator.addBehavior(circleSnapBehavior)
+        }
+        if let squareSnapBehavior = squareSnapBehavior {
             animator.addBehavior(squareSnapBehavior)
         }
     }
 
     private func removeAllSnapBehaviors() {
-        if let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior {
+        if let rectangleSnapBehavior = rectangleSnapBehavior {
             animator.removeBehavior(rectangleSnapBehavior)
+        }
+        if let triangleSnapBehavior = triangleSnapBehavior {
             animator.removeBehavior(triangleSnapBehavior)
+        }
+        if let roundedSquareSnapBehavior = roundedSquareSnapBehavior {
             animator.removeBehavior(roundedSquareSnapBehavior)
+        }
+        if let circleSnapBehavior = circleSnapBehavior {
             animator.removeBehavior(circleSnapBehavior)
+        }
+        if let squareSnapBehavior = squareSnapBehavior {
             animator.removeBehavior(squareSnapBehavior)
         }
     }

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -328,7 +328,7 @@ public class EmptyView: UIView {
         }
     }
 
-    // MARK: - Motion Shake
+    // MARK: Motion Shake
 
     public override func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
         if motion == .motionShake {

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -264,6 +264,14 @@ public class EmptyView: UIView {
         removeAllSnapBehaviors()
     }
 
+    @objc private func userHasLongPressed(gesture: UILongPressGestureRecognizer) {
+        if rectangleSnapBehavior != nil, triangleSnapBehavior != nil, roundedSquareSnapBehavior != nil, circleSnapBehavior != nil, squareSnapBehavior != nil {
+            removeAllSnapBehaviors()
+        }
+        let touchPosition = gesture.location(in: self)
+        setAllSnapBehaviors(to: touchPosition)
+    }
+
     private func setAllSnapBehaviors(to point: CGPoint) {
         rectangleSnapBehavior = UISnapBehavior(item: rectangle, snapTo: point)
         triangleSnapBehavior = UISnapBehavior(item: triangle, snapTo: point)
@@ -324,6 +332,10 @@ public class EmptyView: UIView {
                     let touchPosition = touch.location(in: self)
                     setAllSnapBehaviors(to: touchPosition)
                 }
+            } else {
+                let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(userHasLongPressed))
+                longPressGesture.minimumPressDuration = 2.5
+                addGestureRecognizer(longPressGesture)
             }
         }
     }

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -260,13 +260,13 @@ public class EmptyView: UIView {
     }
 
     // MARK: - Snap Behavior stuff
-    
+
     @objc private func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
         if rectangleSnapBehavior != nil {
             removeAllSnapBehaviors()
         }
-
-        setAllSnapBehaviors(to: gesture.location(in: self))
+        let touchPosition = gesture.location(in: self)
+        setAllSnapBehaviors(to: touchPosition)
         addAllSnapBehaviors()
     }
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -172,8 +172,6 @@ public class EmptyView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(userHasTapped))
         addGestureRecognizer(tapGesture)
 
-        becomeFirstResponder()
-
         addSubview(rectangle)
         addSubview(triangle)
         addSubview(roundedSquare)
@@ -340,19 +338,6 @@ public class EmptyView: UIView {
         }
     }
 
-    // MARK: Motion Shake
-
-    public override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
-        if motion == .motionShake {
-            removeAllSnapBehaviors()
-        }
-    }
-
-    public override var canBecomeFirstResponder: Bool {
-        guard window != nil else {
-            return false
-        }
-        return true
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -172,6 +172,8 @@ public class EmptyView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(userHasTapped))
         addGestureRecognizer(tapGesture)
 
+        becomeFirstResponder()
+
         addSubview(rectangle)
         addSubview(triangle)
         addSubview(roundedSquare)
@@ -324,6 +326,18 @@ public class EmptyView: UIView {
                 }
             }
         }
+    }
+
+    // MARK: - Motion Shake
+
+    public override func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            removeAllSnapBehaviors()
+        }
+    }
+
+    public override var canBecomeFirstResponder: Bool {
+        return true
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -262,12 +262,11 @@ public class EmptyView: UIView {
     // MARK: - Snap Behavior stuff
 
     @objc private func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
-        if rectangleSnapBehavior != nil {
+        if rectangleSnapBehavior != nil, triangleSnapBehavior != nil, roundedSquareSnapBehavior != nil, circleSnapBehavior != nil, squareSnapBehavior != nil {
             removeAllSnapBehaviors()
         }
         let touchPosition = gesture.location(in: self)
         setAllSnapBehaviors(to: touchPosition)
-        addAllSnapBehaviors()
     }
 
     @objc private func userHasTapped() {
@@ -280,28 +279,28 @@ public class EmptyView: UIView {
         roundedSquareSnapBehavior = UISnapBehavior(item: roundedSquare, snapTo: point)
         circleSnapBehavior = UISnapBehavior(item: circle, snapTo: point)
         squareSnapBehavior = UISnapBehavior(item: square, snapTo: point)
+
+        addAllSnapBehaviors()
     }
 
     private func addAllSnapBehaviors() {
-        guard let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior else {
-            return
+        if let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior {
+            animator.addBehavior(rectangleSnapBehavior)
+            animator.addBehavior(triangleSnapBehavior)
+            animator.addBehavior(roundedSquareSnapBehavior)
+            animator.addBehavior(circleSnapBehavior)
+            animator.addBehavior(squareSnapBehavior)
         }
-        animator.addBehavior(rectangleSnapBehavior)
-        animator.addBehavior(triangleSnapBehavior)
-        animator.addBehavior(roundedSquareSnapBehavior)
-        animator.addBehavior(circleSnapBehavior)
-        animator.addBehavior(squareSnapBehavior)
     }
 
     private func removeAllSnapBehaviors() {
-        guard let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior else {
-            return
+        if let rectangleSnapBehavior = rectangleSnapBehavior, let triangleSnapBehavior = triangleSnapBehavior, let roundedSquareSnapBehavior = roundedSquareSnapBehavior, let circleSnapBehavior = circleSnapBehavior, let squareSnapBehavior = squareSnapBehavior {
+            animator.removeBehavior(rectangleSnapBehavior)
+            animator.removeBehavior(triangleSnapBehavior)
+            animator.removeBehavior(roundedSquareSnapBehavior)
+            animator.removeBehavior(circleSnapBehavior)
+            animator.removeBehavior(squareSnapBehavior)
         }
-        animator.removeBehavior(rectangleSnapBehavior)
-        animator.removeBehavior(triangleSnapBehavior)
-        animator.removeBehavior(roundedSquareSnapBehavior)
-        animator.removeBehavior(circleSnapBehavior)
-        animator.removeBehavior(squareSnapBehavior)
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -169,9 +169,6 @@ public class EmptyView: UIView {
     private func setup() {
         backgroundColor = .milk
 
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(userHasTapped))
-        addGestureRecognizer(tapGesture)
-
         addSubview(rectangle)
         addSubview(triangle)
         addSubview(roundedSquare)
@@ -256,11 +253,7 @@ public class EmptyView: UIView {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 
-    // MARK: - Snap Behavior methods
-
-    @objc private func userHasTapped() {
-        removeAllSnapBehaviors()
-    }
+    // MARK: - SnapBehavior methods
 
     @objc private func userHasLongPressed(gesture: UILongPressGestureRecognizer) {
         if rectangleSnapBehavior != nil, triangleSnapBehavior != nil, roundedSquareSnapBehavior != nil, circleSnapBehavior != nil, squareSnapBehavior != nil {
@@ -338,6 +331,8 @@ public class EmptyView: UIView {
         }
     }
 
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        removeAllSnapBehaviors()
     }
 
     // MARK: - Accelerometer calculations

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -342,7 +342,7 @@ public class EmptyView: UIView {
 
     // MARK: Motion Shake
 
-    public override func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
+    public override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
             removeAllSnapBehaviors()
         }

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -259,6 +259,8 @@ public class EmptyView: UIView {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 
+    // MARK: - Snap Behavior stuff
+    
     @objc private func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
         if rectangleSnapBehavior != nil {
             removeAllSnapBehaviors()

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -170,10 +170,7 @@ public class EmptyView: UIView {
         backgroundColor = .milk
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(userHasTapped))
-        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(userDidLongPress))
-        longPressGesture.minimumPressDuration = 2.0
         addGestureRecognizer(tapGesture)
-        addGestureRecognizer(longPressGesture)
 
         addSubview(rectangle)
         addSubview(triangle)
@@ -261,14 +258,6 @@ public class EmptyView: UIView {
 
     // MARK: - Snap Behavior stuff
 
-    @objc private func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
-        if rectangleSnapBehavior != nil, triangleSnapBehavior != nil, roundedSquareSnapBehavior != nil, circleSnapBehavior != nil, squareSnapBehavior != nil {
-            removeAllSnapBehaviors()
-        }
-        let touchPosition = gesture.location(in: self)
-        setAllSnapBehaviors(to: touchPosition)
-    }
-
     @objc private func userHasTapped() {
         removeAllSnapBehaviors()
     }
@@ -316,6 +305,24 @@ public class EmptyView: UIView {
         }
         if let squareSnapBehavior = squareSnapBehavior {
             animator.removeBehavior(squareSnapBehavior)
+        }
+    }
+
+    // MARK: 3D-touch
+
+    public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        if let touch = touches.first {
+            if traitCollection.forceTouchCapability == .available {
+                let normalizedTouch = touch.force / touch.maximumPossibleForce
+
+                if normalizedTouch >= 0.95 {
+                    if rectangleSnapBehavior != nil, triangleSnapBehavior != nil, roundedSquareSnapBehavior != nil, circleSnapBehavior != nil, squareSnapBehavior != nil {
+                        removeAllSnapBehaviors()
+                    }
+                    let touchPosition = touch.location(in: self)
+                    setAllSnapBehaviors(to: touchPosition)
+                }
+            }
         }
     }
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -349,6 +349,9 @@ public class EmptyView: UIView {
     }
 
     public override var canBecomeFirstResponder: Bool {
+        guard window != nil else {
+            return false
+        }
         return true
     }
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -258,7 +258,7 @@ public class EmptyView: UIView {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 
-    // MARK: - Snap Behavior stuff
+    // MARK: - Snap Behavior methods
 
     @objc private func userHasTapped() {
         removeAllSnapBehaviors()

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -259,7 +259,7 @@ public class EmptyView: UIView {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 
-    @objc func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
+    @objc private func userDidLongPress(_ gesture: UILongPressGestureRecognizer) {
         if rectangleSnapBehavior != nil {
             removeAllSnapBehaviors()
         }
@@ -268,7 +268,7 @@ public class EmptyView: UIView {
         addAllSnapBehaviors()
     }
 
-    @objc func userHasTapped() {
+    @objc private func userHasTapped() {
         removeAllSnapBehaviors()
     }
 


### PR DESCRIPTION
# What?
Adds a `UISnapBehavior` to all the movable objects in the `EmptyView` when the 3D touch force value surpasses **95%** of the maximum value. For devices not supporting 3D touch a longpress for **2.5 seconds** does the same thing.

To release the movable objects (remove the snap behavior) the user can either tap the screen outside of the blocks or shake the device (`shakeMotion`).

Please let me know if I should keep doing PRs like this or if you don't want it.

# Why?
It's fun and I haven't started on a new project yet. And also, I miss FINN.

# Gif
![snapbehavior](https://user-images.githubusercontent.com/15629801/41023151-db8552a6-696b-11e8-87a3-0bce9b04c079.gif)
