### PR TITLE
Tracking of interaction with blocks in EmptyView

### DIFF
--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -7,6 +7,7 @@ import UIKit
 
 public protocol EmptyViewDelegate: class {
     func emptyView(_ emptyView: EmptyView, didSelectActionButton button: Button)
+    func emptyView(_ emptyView: EmptyView, didMoveObjectView view: UIView)
 }
 
 public class EmptyView: UIView {
@@ -239,6 +240,7 @@ public class EmptyView: UIView {
             if let attach = attachable.attach {
                 animator.removeBehavior(attach)
                 itemBehavior.addLinearVelocity(sender.velocity(in: self), for: objectView)
+                delegate?.emptyView(self, didMoveObjectView: objectView)
             }
         }
     }


### PR DESCRIPTION
# What?
Adds a delegate method for didMoveObject called when swipe gesture recognizer ends. As it is now the delegate sends the info about the `objectView`, which includes stuff like position and name etc.. 

Please let me know if you want more info about the object, such as `itemBehavior` or `collisionBehavior` and I'll add it so that we can track those things also.

# Why?
Would be fun to see if anyone actually interacts with the blocks, and how many.