### PR TITLE
updated sardine color

### DIFF
--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -30,7 +30,7 @@ extension UIColor {
     }
 
     public class var sardine: UIColor {
-        return UIColor(r: 223, g: 228, b: 232)!
+        return UIColor(r: 195, g: 204, b: 217)!
     }
 
     public class var salmon: UIColor {


### PR DESCRIPTION
What:
Changed Sardine Color to match Zeplin Spec

Why:
The color was outdated, and not very visible as a disabled state.

Before:
![sardine before](https://user-images.githubusercontent.com/27729512/41856828-53307cde-7896-11e8-815e-5bf158a9cd34.png)

After:
![sardine after](https://user-images.githubusercontent.com/27729512/41856836-56607ada-7896-11e8-8691-8a064396d710.png)