### PR TITLE
Changed border radius and labels

### DIFF
--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -19,7 +19,7 @@ public class AdsGridViewCell: UICollectionViewCell {
     private static let subtitleHeight: CGFloat = 17.0
     private static let subtitleTopMargin: CGFloat = 6.0
     private static let margin: CGFloat = 8.0
-    private static let cornerRadius: CGFloat = 2.0
+    private static let cornerRadius: CGFloat = 8.0
     private static let imageDescriptionHeight: CGFloat = 35.0
     private static let iconSize: CGFloat = 23.0
 
@@ -42,14 +42,14 @@ public class AdsGridViewCell: UICollectionViewCell {
     }()
 
     private lazy var titleLabel: Label = {
-        let label = Label(style: .detail(.licorice))
+        let label = Label(style: .body(.licorice))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.backgroundColor = .clear
         return label
     }()
 
     private lazy var subtitleLabel: Label = {
-        let label = Label(style: .detail(.licorice))
+        let label = Label(style: .detail(.stone))
         label.translatesAutoresizingMaskIntoConstraints = false
         label.backgroundColor = .clear
         return label


### PR DESCRIPTION
What & Why: Changed to smooth corners on images. Text labels are changed to detail+body since detail will be too small for titles. Also changed the color for the location from Licorice to Stone.

Before:
![before](https://user-images.githubusercontent.com/27729512/41916893-65268c9e-7959-11e8-99c8-86f1a827cc7a.png)

After:
![after](https://user-images.githubusercontent.com/27729512/41916892-650aa844-7959-11e8-9812-c397f70adde6.png)
