### PR TITLE
Add padding in text fields

### DIFF
--- a/Sources/Components/TextField/TextField.swift
+++ b/Sources/Components/TextField/TextField.swift
@@ -120,8 +120,8 @@ public class TextField: UIView {
 
     // MARK: - External properties
 
-    public lazy var textField: FKTextField = {
-        let textField = FKTextField()
+    public lazy var textField: UITextField = {
+        let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.font = UIFont.body
         textField.textColor = .licorice
@@ -230,10 +230,10 @@ public class TextField: UIView {
             textFieldBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
             textFieldBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            textField.topAnchor.constraint(equalTo: textFieldBackgroundView.topAnchor, constant: .mediumSpacing),
+            textField.topAnchor.constraint(equalTo: textFieldBackgroundView.topAnchor, constant: .mediumSpacing + .smallSpacing),
             textField.leadingAnchor.constraint(equalTo: textFieldBackgroundView.leadingAnchor, constant: .mediumSpacing),
             textField.trailingAnchor.constraint(equalTo: textFieldBackgroundView.trailingAnchor, constant: -.mediumSpacing),
-            textField.bottomAnchor.constraint(equalTo: textFieldBackgroundView.bottomAnchor, constant: -.mediumSpacing),
+            textField.bottomAnchor.constraint(equalTo: textFieldBackgroundView.bottomAnchor, constant: -.mediumSpacing + -.smallSpacing),
 
             underline.leadingAnchor.constraint(equalTo: leadingAnchor),
             underline.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -380,33 +380,5 @@ extension TextField: UITextFieldDelegate {
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return delegate?.textField(self, shouldChangeCharactersIn: range, replacementString: string) ?? true
-    }
-}
-
-// MARK: - FKTextField
-
-/**
- This class exist for drawing and positioning overrides to make custom padding in text fields.
-
- - note:
- https://stackoverflow.com/questions/2694411/text-inset-for-uitextfield
- https://medium.com/@lawrey/swift-3-add-padding-to-uitextfield-40288b0a57f5
-
- */
-
-public class FKTextField: UITextField {
-    public override func textRect(forBounds bounds: CGRect) -> CGRect {
-        return UIEdgeInsetsInsetRect(bounds,
-                                     UIEdgeInsetsMake(5, 0, 5, .mediumSpacing))
-    }
-
-    public override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
-        return UIEdgeInsetsInsetRect(bounds,
-                                     UIEdgeInsetsMake(5, 0, 5, 0))
-    }
-
-    public override func editingRect(forBounds bounds: CGRect) -> CGRect {
-        return UIEdgeInsetsInsetRect(bounds,
-                                     UIEdgeInsetsMake(5, 0, 5, .largeSpacing))
     }
 }

--- a/Sources/Components/TextField/TextField.swift
+++ b/Sources/Components/TextField/TextField.swift
@@ -120,8 +120,8 @@ public class TextField: UIView {
 
     // MARK: - External properties
 
-    public lazy var textField: UITextField = {
-        let textField = UITextField()
+    public lazy var textField: FKTextField = {
+        let textField = FKTextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.font = UIFont.body
         textField.textColor = .licorice
@@ -380,5 +380,33 @@ extension TextField: UITextFieldDelegate {
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return delegate?.textField(self, shouldChangeCharactersIn: range, replacementString: string) ?? true
+    }
+}
+
+// MARK: - FKTextField
+
+/**
+ This class exist for drawing and positioning overrides to make custom padding in text fields.
+
+ - note:
+ https://stackoverflow.com/questions/2694411/text-inset-for-uitextfield
+ https://medium.com/@lawrey/swift-3-add-padding-to-uitextfield-40288b0a57f5
+
+ */
+
+public class FKTextField: UITextField {
+    public override func textRect(forBounds bounds: CGRect) -> CGRect {
+        return UIEdgeInsetsInsetRect(bounds,
+                                     UIEdgeInsetsMake(5, 0, 5, .mediumSpacing))
+    }
+
+    public override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        return UIEdgeInsetsInsetRect(bounds,
+                                     UIEdgeInsetsMake(5, 0, 5, 0))
+    }
+
+    public override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        return UIEdgeInsetsInsetRect(bounds,
+                                     UIEdgeInsetsMake(5, 0, 5, .largeSpacing))
     }
 }


### PR DESCRIPTION
**_What_**
Added class for creating padding in text fields, and increased the padding.
**_Why:_** 
to match design spec, and have the same height as buttons.

Before: ![text field before](https://user-images.githubusercontent.com/27729512/41969066-928eacd6-7a06-11e8-9b03-d47cc625c02b.png)

After:
![text field after](https://user-images.githubusercontent.com/27729512/41969065-927219ea-7a06-11e8-8a6c-fcfb904e4070.png)
