### PR TITLE
Rename ViewController and improve initalizers

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -21,13 +21,13 @@ public enum DnaViews: String {
     public var viewController: UIViewController {
         switch self {
         case .color:
-            return ViewController<ColorDemoView>()
+            return DemoViewController<ColorDemoView>()
         case .font:
-            return ViewController<FontDemoView>()
+            return DemoViewController<FontDemoView>()
         case .spacing:
-            return ViewController<SpacingDemoView>()
+            return DemoViewController<SpacingDemoView>()
         case .assets:
-            return ViewController<AssetsDemoView>()
+            return DemoViewController<AssetsDemoView>()
         }
     }
 }
@@ -66,29 +66,29 @@ public enum ComponentViews: String {
     public var viewController: UIViewController {
         switch self {
         case .broadcast:
-            return ViewController<BroadcastDemoView>()
+            return DemoViewController<BroadcastDemoView>()
         case .button:
-            return ViewController<ButtonDemoView>()
+            return DemoViewController<ButtonDemoView>()
         case .label:
-            return ViewController<LabelDemoView>()
+            return DemoViewController<LabelDemoView>()
         case .ribbon:
-            return ViewController<RibbonDemoView>()
+            return DemoViewController<RibbonDemoView>()
         case .textField:
-            return ViewController<TextFieldDemoView>()
+            return DemoViewController<TextFieldDemoView>()
         case .toast:
-            return ViewController<ToastDemoView>()
+            return DemoViewController<ToastDemoView>()
         case .switchView:
-            return ViewController<SwitchViewDemoView>()
+            return DemoViewController<SwitchViewDemoView>()
         case .inlineConsent:
-            return ViewController<InlineConsentDemoView>()
+            return DemoViewController<InlineConsentDemoView>()
         case .consentTransparencyInfo:
-            return ViewController<ConsentTransparencyInfoDemoView>()
+            return DemoViewController<ConsentTransparencyInfoDemoView>()
         case .checkbox:
-            return ViewController<CheckboxDemoView>(usingDoubleTap: false)
+            return DemoViewController<CheckboxDemoView>(withDismissButton: true)
         case .radioButton:
-            return ViewController<RadioButtonDemoView>(usingDoubleTap: false)
+            return DemoViewController<RadioButtonDemoView>(withDismissButton: true)
         case .roundedImageView:
-            return ViewController<RoundedImageViewDemoView>()
+            return DemoViewController<RoundedImageViewDemoView>()
         }
     }
 }
@@ -115,17 +115,17 @@ public enum RecyclingViews: String {
     public var viewController: UIViewController {
         switch self {
         case .notificationsListView:
-            return ViewController<NotificationsListViewDemoView>()
+            return DemoViewController<NotificationsListViewDemoView>()
         case .favoriteFoldersListView:
-            return ViewController<FavoriteFoldersListViewDemoView>()
+            return DemoViewController<FavoriteFoldersListViewDemoView>()
         case .favoritesListView:
-            return ViewController<FavoritesListViewDemoView>()
+            return DemoViewController<FavoritesListViewDemoView>()
         case .savedSearchesListView:
-            return ViewController<SavedSearchesListViewDemoView>()
+            return DemoViewController<SavedSearchesListViewDemoView>()
         case .marketsGridView:
-            return ViewController<MarketsGridViewDemoView>()
+            return DemoViewController<MarketsGridViewDemoView>()
         case .adsGridView:
-            return ViewController<AdsGridViewDemoView>()
+            return DemoViewController<AdsGridViewDemoView>()
         }
     }
 }
@@ -154,19 +154,19 @@ public enum FullscreenViews: String {
     public var viewController: UIViewController {
         switch self {
         case .frontpageView:
-            return ViewController<FrontpageViewDemoView>()
+            return DemoViewController<FrontpageViewDemoView>()
         case .emptyView:
-            return ViewController<EmptyViewDemoView>()
+            return DemoViewController<EmptyViewDemoView>()
         case .popupView:
-            return ViewController<PopupViewDemoView>()
+            return DemoViewController<PopupViewDemoView>()
         case .reportAdView:
-            return ViewController<AdReporterDemoView>(usingDoubleTap: false)
+            return DemoViewController<AdReporterDemoView>(withDismissButton: true)
         case .reviewView:
-            return ViewController<ReviewViewDemoView>()
+            return DemoViewController<ReviewViewDemoView>()
         case .registerView:
-            return ViewController<RegisterViewDemoView>()
+            return DemoViewController<RegisterViewDemoView>()
         case .loginView:
-            return ViewController<LoginViewDemoView>()
+            return DemoViewController<LoginViewDemoView>()
         }
     }
 }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -1,10 +1,9 @@
 //
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
-
 import FinniversKit
 
-public class ViewController<View: UIView>: UIViewController {
+public class DemoViewController<View: UIView>: UIViewController {
     lazy var playgroundView: View = {
         let playgroundView = View(frame: view.frame)
         playgroundView.translatesAutoresizingMaskIntoConstraints = false
@@ -23,17 +22,18 @@ public class ViewController<View: UIView>: UIViewController {
         return true
     }
 
-    var usingDoubleTap: Bool
+    var hasDismissButton: Bool = false
+    var usingDoubleTapToDismiss: Bool = false
 
     // Normal behaviour
-    public init() {
-        usingDoubleTap = true
+    public init(usingDoubleTapToDismiss: Bool = true) {
+        self.usingDoubleTapToDismiss = usingDoubleTapToDismiss
         super.init(nibName: nil, bundle: nil)
     }
 
     // Instantiate the view controller with a dismiss button
-    public init(usingDoubleTap: Bool) {
-        self.usingDoubleTap = usingDoubleTap
+    public init(withDismissButton hasDismissButton: Bool) {
+        self.hasDismissButton = hasDismissButton
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -52,13 +52,9 @@ public class ViewController<View: UIView>: UIViewController {
             playgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             playgroundView.topAnchor.constraint(equalTo: view.compatibleTopAnchor),
             playgroundView.bottomAnchor.constraint(equalTo: view.compatibleBottomAnchor),
-        ])
+            ])
 
-        if usingDoubleTap {
-            let doubleTap = UITapGestureRecognizer(target: self, action: #selector(didDoubleTap))
-            doubleTap.numberOfTapsRequired = 2
-            view.addGestureRecognizer(doubleTap)
-        } else {
+        if hasDismissButton {
             let button = Button(style: .callToAction)
             button.setTitle("Dismiss", for: .normal)
             button.addTarget(self, action: #selector(didDoubleTap), for: .touchUpInside)
@@ -67,7 +63,11 @@ public class ViewController<View: UIView>: UIViewController {
             NSLayoutConstraint.activate([
                 button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
                 button.bottomAnchor.constraint(equalTo: view.compatibleBottomAnchor, constant: -.veryLargeSpacing),
-            ])
+                ])
+        } else if usingDoubleTapToDismiss {
+            let doubleTap = UITapGestureRecognizer(target: self, action: #selector(didDoubleTap))
+            doubleTap.numberOfTapsRequired = 2
+            view.addGestureRecognizer(doubleTap)
         }
     }
 

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		144959DB2122C4400084549F /* FinniversImageAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 144959D92122C4400084549F /* FinniversImageAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		144959DC2122C4400084549F /* FinniversImageAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 144959DA2122C4400084549F /* FinniversImageAsset.m */; };
 		144959E02122D8C20084549F /* AssetsDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144959DF2122D8C20084549F /* AssetsDemoView.swift */; };
-		146D3C401FBE466D00124B76 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146D3C3F1FBE466D00124B76 /* ViewController.swift */; };
+		146D3C401FBE466D00124B76 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146D3C3F1FBE466D00124B76 /* DemoViewController.swift */; };
 		14C6F7D3212324CA00A7230C /* FavoritesListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C6F7CE212324C900A7230C /* FavoritesListViewCell.swift */; };
 		14C6F7D4212324CA00A7230C /* FavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C6F7D0212324C900A7230C /* FavoritesListView.swift */; };
 		14C6F7D5212324CA00A7230C /* FavoritesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C6F7D2212324C900A7230C /* FavoritesListViewModel.swift */; };
@@ -217,7 +217,7 @@
 		144959D92122C4400084549F /* FinniversImageAsset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FinniversImageAsset.h; sourceTree = "<group>"; };
 		144959DA2122C4400084549F /* FinniversImageAsset.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FinniversImageAsset.m; sourceTree = "<group>"; };
 		144959DF2122D8C20084549F /* AssetsDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetsDemoView.swift; sourceTree = "<group>"; };
-		146D3C3F1FBE466D00124B76 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		146D3C3F1FBE466D00124B76 /* DemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoViewController.swift; sourceTree = "<group>"; };
 		14C6F7CE212324C900A7230C /* FavoritesListViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesListViewCell.swift; sourceTree = "<group>"; };
 		14C6F7D0212324C900A7230C /* FavoritesListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesListView.swift; sourceTree = "<group>"; };
 		14C6F7D2212324C900A7230C /* FavoritesListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesListViewModel.swift; sourceTree = "<group>"; };
@@ -403,7 +403,7 @@
 				144351BA1FBE2BF1007B2229 /* Assets.xcassets */,
 				14405C5F1FAFBBF000D03E04 /* Info.plist */,
 				144351C31FBE2FA2007B2229 /* AppDelegate.swift */,
-				146D3C3F1FBE466D00124B76 /* ViewController.swift */,
+				146D3C3F1FBE466D00124B76 /* DemoViewController.swift */,
 				4577F61D201F3D54009CBAE8 /* DemoViewsTableViewController.swift */,
 				AAC1AFB32021058000C71B7C /* Demo.swift */,
 				141F08C52123110B001DB145 /* DemoHelpers.swift */,
@@ -1559,7 +1559,7 @@
 				4408A6A82027AC71008C0BD9 /* ColorDemoView.swift in Sources */,
 				44A149F22137805C0053D5F7 /* SavedSearchesListViewDemoViewHelpers.swift in Sources */,
 				4458701D213FA353009187BE /* RegisterViewDefaultData.swift in Sources */,
-				146D3C401FBE466D00124B76 /* ViewController.swift in Sources */,
+				146D3C401FBE466D00124B76 /* DemoViewController.swift in Sources */,
 				44D9126A2077AD0200486848 /* PopupViewDefaultData.swift in Sources */,
 				444246072137D61200D42AB8 /* FavoriteFoldersListViewDemoViewHelpers.swift in Sources */,
 				432CE09E21131B4800F01EC5 /* RoundedImageViewDemoView.swift in Sources */,

--- a/Sources/Resources/FinniversImageAsset.h
+++ b/Sources/Resources/FinniversImageAsset.h
@@ -7,7 +7,6 @@
 
 @import Foundation;
 
-extern NSString *const FinniversImageAssetNoImage;
 extern NSString *const FinniversImageAssetarrowDown;
 extern NSString *const FinniversImageAssetarrowRight;
 extern NSString *const FinniversImageAssetarrowUp;
@@ -52,6 +51,7 @@ extern NSString *const FinniversImageAssetmittanbud;
 extern NSString *const FinniversImageAssetmore;
 extern NSString *const FinniversImageAssetmoreImg;
 extern NSString *const FinniversImageAssetmoteplassen;
+extern NSString *const FinniversImageAssetnoImage;
 extern NSString *const FinniversImageAssetnotifications;
 extern NSString *const FinniversImageAssetonlyNew;
 extern NSString *const FinniversImageAssetpin;

--- a/Sources/Resources/FinniversImageAsset.m
+++ b/Sources/Resources/FinniversImageAsset.m
@@ -7,7 +7,6 @@
 
 #import "FinniversImageAsset.h"
 
-NSString *const FinniversImageAssetNoImage = @"NoImage";
 NSString *const FinniversImageAssetarrowDown = @"arrowDown";
 NSString *const FinniversImageAssetarrowRight = @"arrowRight";
 NSString *const FinniversImageAssetarrowUp = @"arrowUp";
@@ -52,6 +51,7 @@ NSString *const FinniversImageAssetmittanbud = @"mittanbud";
 NSString *const FinniversImageAssetmore = @"more";
 NSString *const FinniversImageAssetmoreImg = @"moreImg";
 NSString *const FinniversImageAssetmoteplassen = @"moteplassen";
+NSString *const FinniversImageAssetnoImage = @"noImage";
 NSString *const FinniversImageAssetnotifications = @"notifications";
 NSString *const FinniversImageAssetonlyNew = @"onlyNew";
 NSString *const FinniversImageAssetpin = @"pin";

--- a/Sources/Resources/FinniversImageAsset.swift
+++ b/Sources/Resources/FinniversImageAsset.swift
@@ -14,7 +14,6 @@ public extension UIImage {
 }
 
 public enum FinniversImageAsset: String {
-    case noImage = "NoImage"
     case arrowDown
     case arrowRight
     case arrowUp
@@ -59,6 +58,7 @@ public enum FinniversImageAsset: String {
     case more
     case moreImg
     case moteplassen
+    case noImage
     case notifications
     case onlyNew
     case pin
@@ -88,7 +88,6 @@ public enum FinniversImageAsset: String {
 
     public static var imageNames: [FinniversImageAsset] {
         return [
-            .noImage,
             .arrowDown,
             .arrowRight,
             .arrowUp,
@@ -133,6 +132,7 @@ public enum FinniversImageAsset: String {
             .more,
             .moreImg,
             .moteplassen,
+            .noImage,
             .notifications,
             .onlyNew,
             .pin,


### PR DESCRIPTION
Having a class called "ViewController" isn't necessarily the best idea, it's too generic and can cause confusion, this PR aims to fix that. Also, this PR changes the wording of the initializer `usingDoubleTap` to `withDismissButton`. 

By default components in FinniversKit are dismissed using double tap, for some controllers where testing double tap is important (like checkboxes) this was an issue, that's why we introduced the initializer `usingDoubleTap: false`, sadly, this didn't show the true intention, since using `usingDoubleTap: false` would mean that instead of double tapping for dismiss, you would get a "Dismiss" button instead. On this PR this will change so this behavior is more clear since it entails what will happen if you trigger this effect. Also if you check the initializers you can see that the default behavior is `usingDoubleTapToDismiss = true`, which is what will happen if you don't do anything.

![image](https://user-images.githubusercontent.com/1088217/45301558-824dac00-b511-11e8-9de0-d836695d18b8.jpg)
