### PR TITLE
Add dismissal gesture recognizer for horizontal slide

### DIFF
--- a/Sources/Components/HorizontalSlide/Demo/HorizontalSlideDemoViewController.swift
+++ b/Sources/Components/HorizontalSlide/Demo/HorizontalSlideDemoViewController.swift
@@ -13,5 +13,14 @@ class HorizontalSlideDemoViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .milk
+
+        let swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(swipeGestureRecognizerAction))
+        swipeGestureRecognizer.direction = .right
+        view.addGestureRecognizer(swipeGestureRecognizer)
+        view.isUserInteractionEnabled = true
+    }
+
+    @objc func swipeGestureRecognizerAction() {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
+++ b/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
@@ -12,8 +12,13 @@ class HorizontalSlideController: UIPresentationController {
         dimmingView.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
         dimmingView.alpha = 0.0
 
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(recognizer:)))
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(handleDismissGesture))
         dimmingView.addGestureRecognizer(recognizer)
+
+        let swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleDismissGesture))
+        swipeGestureRecognizer.direction = .right
+        dimmingView.addGestureRecognizer(swipeGestureRecognizer)
+
         return dimmingView
     }()
 
@@ -30,7 +35,12 @@ class HorizontalSlideController: UIPresentationController {
     override func presentationTransitionWillBegin() {
         guard let containerView = containerView else { return }
         containerView.insertSubview(dimmingView, at: 0)
-        dimmingView.fillInSuperview()
+        NSLayoutConstraint.activate([
+            dimmingView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            dimmingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            dimmingView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            dimmingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            ])
 
         guard let coordinator = presentedViewController.transitionCoordinator else {
             dimmingView.alpha = 1.0
@@ -52,7 +62,7 @@ class HorizontalSlideController: UIPresentationController {
             self.dimmingView.alpha = 0.0
         })
     }
-    
+
     override func containerViewWillLayoutSubviews() {
         presentedView?.frame = frameOfPresentedViewInContainerView
     }
@@ -62,7 +72,7 @@ class HorizontalSlideController: UIPresentationController {
     }
 
     // MARK: - Private
-    @objc private func handleTap(recognizer: UITapGestureRecognizer) {
+    @objc private func handleDismissGesture() {
         presentingViewController.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
# Why?

When a screen gets presented it feels natural to try to dismiss it by pulling to the opposite side from where it came from.

# What?

Adds a swipe gesture recognizer to dismiss the controller, tried using `UIViewControllerInteractiveTransitioning` but couldn't get the canceling part to work the way I wanted so I'm using this as a fallback, I'll keep trying mostly for learning purposes and see if I make a new PR when I nail it.

# Show me

No UI changes really, just behavior.