### PR TITLE
Delegate for dismissal

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -100,7 +100,7 @@ public enum ComponentViews: String {
         case .horizontalSlide:
             let presentedViewController = HorizontalSlideDemoViewController()
             let secondViewController = UINavigationController(rootViewController: presentedViewController)
-            secondViewController.transitioningDelegate = presentedViewController.transitionDelegate
+            secondViewController.transitioningDelegate = presentedViewController.transition
             secondViewController.modalPresentationStyle = .custom
             return secondViewController
         case .easterEggButton:

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		14C6F7D9212324D600A7230C /* FavoritesListViewDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C6F7D7212324D600A7230C /* FavoritesListViewDemoView.swift */; };
 		14C6F7DA212324D600A7230C /* FavoritesListViewDemoViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C6F7D8212324D600A7230C /* FavoritesListViewDemoViewHelpers.swift */; };
 		14DC126F21593B0000326DC3 /* HorizontalSlideController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DC126B21593B0000326DC3 /* HorizontalSlideController.swift */; };
-		14DC127021593B0000326DC3 /* HorizontalSlideTransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DC126C21593B0000326DC3 /* HorizontalSlideTransitionDelegate.swift */; };
+		14DC127021593B0000326DC3 /* HorizontalSlideTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DC126C21593B0000326DC3 /* HorizontalSlideTransition.swift */; };
 		14DC127121593B0000326DC3 /* HorizontalSlideTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DC126D21593B0000326DC3 /* HorizontalSlideTransitionAnimator.swift */; };
 		14DC127221593B0500326DC3 /* HorizontalSlideDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DC126A21593B0000326DC3 /* HorizontalSlideDemoViewController.swift */; };
 		14EBA258215A633800613E5A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EBA256215A633800613E5A /* LoadingView.swift */; };
@@ -256,7 +256,7 @@
 		14C6F7D8212324D600A7230C /* FavoritesListViewDemoViewHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesListViewDemoViewHelpers.swift; sourceTree = "<group>"; };
 		14DC126A21593B0000326DC3 /* HorizontalSlideDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSlideDemoViewController.swift; sourceTree = "<group>"; };
 		14DC126B21593B0000326DC3 /* HorizontalSlideController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSlideController.swift; sourceTree = "<group>"; };
-		14DC126C21593B0000326DC3 /* HorizontalSlideTransitionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSlideTransitionDelegate.swift; sourceTree = "<group>"; };
+		14DC126C21593B0000326DC3 /* HorizontalSlideTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSlideTransition.swift; sourceTree = "<group>"; };
 		14DC126D21593B0000326DC3 /* HorizontalSlideTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSlideTransitionAnimator.swift; sourceTree = "<group>"; };
 		14EBA255215A633800613E5A /* LoadingViewDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingViewDemoView.swift; sourceTree = "<group>"; };
 		14EBA256215A633800613E5A /* LoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -537,7 +537,7 @@
 			isa = PBXGroup;
 			children = (
 				14DC126921593B0000326DC3 /* Demo */,
-				14DC126C21593B0000326DC3 /* HorizontalSlideTransitionDelegate.swift */,
+				14DC126C21593B0000326DC3 /* HorizontalSlideTransition.swift */,
 				14DC126D21593B0000326DC3 /* HorizontalSlideTransitionAnimator.swift */,
 				14DC126B21593B0000326DC3 /* HorizontalSlideController.swift */,
 			);
@@ -1940,7 +1940,7 @@
 				44587019213FA344009187BE /* RegisterViewModel.swift in Sources */,
 				441FE435209A24E500B04EF1 /* AdsGridViewModel.swift in Sources */,
 				44A149EC21377C7B0053D5F7 /* SavedSearchesListView.swift in Sources */,
-				14DC127021593B0000326DC3 /* HorizontalSlideTransitionDelegate.swift in Sources */,
+				14DC127021593B0000326DC3 /* HorizontalSlideTransition.swift in Sources */,
 				4447F6E91FDB2B110033DBC1 /* Ribbon+Style.swift in Sources */,
 				45D7C56B204949E2000E788F /* SwitchView.swift in Sources */,
 				43BACE6A21117D430052114C /* ReviewView.swift in Sources */,

--- a/Sources/Components/HorizontalSlide/Demo/HorizontalSlideDemoViewController.swift
+++ b/Sources/Components/HorizontalSlide/Demo/HorizontalSlideDemoViewController.swift
@@ -5,8 +5,10 @@
 import FinniversKit
 
 class HorizontalSlideDemoViewController: UIViewController {
-    lazy var transitionDelegate: HorizontalSlideTransitionDelegate = {
-        return HorizontalSlideTransitionDelegate()
+    lazy var transition: HorizontalSlideTransition = {
+        let transition = HorizontalSlideTransition()
+        transition.delegate = self
+        return transition
     }()
 
     override func viewDidLoad() {
@@ -22,5 +24,11 @@ class HorizontalSlideDemoViewController: UIViewController {
 
     @objc func swipeGestureRecognizerAction() {
         dismiss(animated: true, completion: nil)
+    }
+}
+
+extension HorizontalSlideDemoViewController: HorizontalSlideTransitionDelegate {
+    func horizontalSlideTransitionDidDismiss(_ horizontalSlideTransition: HorizontalSlideTransition) {
+        // Do something
     }
 }

--- a/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
+++ b/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
@@ -1,8 +1,13 @@
 import UIKit
 
+protocol HorizontalSlideControllerDelegate: class {
+    func horizontalSlideControllerDidDismiss(_ horizontalSlideController: HorizontalSlideController)
+}
 
-/// Used by the HorizontalSlideTransitionDelegate when using `modalPresentationStyle = .custom`.
+/// Used by the HorizontalSlideTransition when using `modalPresentationStyle = .custom`.
 class HorizontalSlideController: UIPresentationController {
+    weak var dismissalDelegate: HorizontalSlideControllerDelegate?
+
     // MARK: - Properties
     private let containerPercentage: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 0.60 : 0.85
 
@@ -74,5 +79,6 @@ class HorizontalSlideController: UIPresentationController {
     // MARK: - Private
     @objc private func handleDismissGesture() {
         presentingViewController.dismiss(animated: true)
+        dismissalDelegate?.horizontalSlideControllerDidDismiss(self)
     }
 }

--- a/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
+++ b/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
@@ -1,8 +1,15 @@
 import UIKit
 
-public class HorizontalSlideTransitionDelegate: NSObject, UIViewControllerTransitioningDelegate {
+public protocol HorizontalSlideTransitionDelegate: class {
+    func horizontalSlideTransitionDidDismiss(_ horizontalSlideTransition: HorizontalSlideTransition)
+}
+
+public class HorizontalSlideTransition: NSObject, UIViewControllerTransitioningDelegate {
+    public weak var delegate: HorizontalSlideTransitionDelegate?
+
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         let presentationController = HorizontalSlideController(presentedViewController: presented, presenting: presenting)
+        presentationController.dismissalDelegate = self
         return presentationController
     }
 
@@ -12,5 +19,12 @@ public class HorizontalSlideTransitionDelegate: NSObject, UIViewControllerTransi
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return HorizontalSlideTransitionAnimator()
+    }
+}
+
+// MARK: - HorizontalSlideControllerDelegate
+extension HorizontalSlideTransition: HorizontalSlideControllerDelegate {
+    func horizontalSlideControllerDidDismiss(_ horizontalSlideController: HorizontalSlideController) {
+        delegate?.horizontalSlideTransitionDidDismiss(self)
     }
 }


### PR DESCRIPTION
# Why?

We want to have some tracking for when the filters are dismissed.

# What?

Adds a delegate and renames the transitioning object, mainly to avoid calling the delegate: HorizontalSlideTransitionDelegateDelegate

# Show me

No UI code.