### PR TITLE
Changes name of property in settings view cell model

### DIFF
--- a/Sources/Recycling/ListViews/Settings/Cell/SettingsViewCell.swift
+++ b/Sources/Recycling/ListViews/Settings/Cell/SettingsViewCell.swift
@@ -67,7 +67,7 @@ private extension SettingsViewCell {
     func set(model: SettingsViewCellModel?) {
         titleLabel.text = model?.title
         stateLabel.text = model?.status
-        hairline.isHidden = !(model?.hairline ?? true) // isHidden is false by default
+        hairline.isHidden = model?.isLastItem ?? false
     }
 
     func setup() {

--- a/Sources/Recycling/ListViews/Settings/Demo/SettingsViewDemoView.swift
+++ b/Sources/Recycling/ListViews/Settings/Demo/SettingsViewDemoView.swift
@@ -11,24 +11,24 @@ struct SettingsSection {
 struct SettingsItem: SettingsViewCellModel {
     let title: String
     var status: String?
-    let hairline: Bool
+    let isLastItem: Bool
 
-    init(title: String, status: String? = nil, hairline: Bool = true) {
+    init(title: String, status: String? = nil, isLastItem: Bool = false) {
         self.title = title
         self.status = status
-        self.hairline = hairline
+        self.isLastItem = isLastItem
     }
 }
 
 class SettingsViewDemoView: UIView {
-    private let sections = [SettingsSection(title: "Varslinger", items: [SettingsItem(title: "Prisnedgang på torget", hairline: false)]),
+    private let sections = [SettingsSection(title: "Varslinger", items: [SettingsItem(title: "Prisnedgang på torget", isLastItem: true)]),
 
                             SettingsSection(title: "Personvern", items: [SettingsItem(title: "Få nyhetsbrev fra FINN", status: "Av"),
                                                                          SettingsItem(title: "Personlin tilpasset FINN", status: "På"),
                                                                          SettingsItem(title: "Motta viktig informasjon fra FINN", status: "På"),
                                                                          SettingsItem(title: "Smart reklame"),
                                                                          SettingsItem(title: "Last ned dine data"),
-                                                                         SettingsItem(title: "Slett meg som bruker", hairline: false)])]
+                                                                         SettingsItem(title: "Slett meg som bruker", isLastItem: true)])]
 
     private lazy var settingsView: SettingsView = {
         let view = SettingsView(frame: .zero)

--- a/Sources/Recycling/ListViews/Settings/Model/SettingsViewCellModel.swift
+++ b/Sources/Recycling/ListViews/Settings/Model/SettingsViewCellModel.swift
@@ -7,5 +7,5 @@ import Foundation
 public protocol SettingsViewCellModel {
     var title: String { get }
     var status: String? { get set }
-    var hairline: Bool { get }
+    var isLastItem: Bool { get }
 }


### PR DESCRIPTION
# Why?

`isLastItem` is a better description of how to use that property.

# What?

- Changes `hairLine` property to `isLastItem`
- Flips the default value, makes the logic more intuitive
