### PR TITLE
Adds a method to set the switch state

### DIFF
--- a/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
+++ b/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
@@ -82,6 +82,11 @@ public class ConsentToggleView: UIView {
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    public func setOn(_ on: Bool, animated: Bool = false) {
+        toggle.setOn(on, animated: animated)
+        model?.state = on
+    }
 }
 
 // MARK: - Private methods


### PR DESCRIPTION
# Why?

I need a way to easily set the switch position outside the view

# What?

- Added a method to set the state of the switch in the ConsentToggleView
