### PR TITLE
Refactor/case iterable

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -3,20 +3,11 @@
 //
 import UIKit
 
-public enum DnaViews: String {
+public enum DnaViews: String, CaseIterable {
     case color
     case font
     case spacing
     case assets
-
-    public static var all: [DnaViews] {
-        return [
-            .color,
-            .font,
-            .spacing,
-            .assets
-        ]
-    }
 
     public var viewController: UIViewController {
         switch self {
@@ -32,7 +23,7 @@ public enum DnaViews: String {
     }
 }
 
-public enum ComponentViews: String {
+public enum ComponentViews: String, CaseIterable {
     case button
     case label
     case ribbon
@@ -47,25 +38,6 @@ public enum ComponentViews: String {
     case loadingIndicator
     case horizontalSlide
     case easterEggButton
-
-    public static var all: [ComponentViews] {
-        return [
-            .button,
-            .label,
-            .ribbon,
-            .textField,
-            .toast,
-            .switchView,
-            .inlineConsent,
-            .consentTransparencyInfo,
-            .checkbox,
-            .radioButton,
-            .roundedImageView,
-            .loadingIndicator,
-            .horizontalSlide,
-            .easterEggButton
-        ]
-    }
 
     public var viewController: UIViewController {
         switch self {
@@ -105,7 +77,7 @@ public enum ComponentViews: String {
     }
 }
 
-public enum RecyclingViews: String {
+public enum RecyclingViews: String, CaseIterable {
     case notificationsListView
     case favoriteFoldersListView
     case favoritesListView
@@ -113,18 +85,6 @@ public enum RecyclingViews: String {
     case marketsGridView
     case adsGridView
     case settingsView
-
-    public static var all: [RecyclingViews] {
-        return [
-            .notificationsListView,
-            .favoriteFoldersListView,
-            .favoritesListView,
-            .savedSearchesListView,
-            .marketsGridView,
-            .adsGridView,
-            .settingsView
-        ]
-    }
 
     public var viewController: UIViewController {
         switch self {
@@ -146,7 +106,7 @@ public enum RecyclingViews: String {
     }
 }
 
-public enum FullscreenViews: String {
+public enum FullscreenViews: String, CaseIterable {
     case frontpageView
     case popupView
     case emptyView
@@ -158,22 +118,6 @@ public enum FullscreenViews: String {
     case consentActionView
     case loadingView
     case drumMachine
-
-    public static var all: [FullscreenViews] {
-        return [
-            .frontpageView,
-            .popupView,
-            .emptyView,
-            .reportAdView,
-            .reviewView,
-            .registerView,
-            .loginView,
-            .consentToggleView,
-            .consentActionView,
-            .loadingView,
-            .drumMachine
-        ]
-    }
 
     public var viewController: UIViewController {
         switch self {
@@ -203,22 +147,12 @@ public enum FullscreenViews: String {
     }
 }
 
-public enum TableViewCellViews: String {
+public enum TableViewCellViews: String, CaseIterable {
     case basicCell
     case basicCellVariations
     case checkboxCell
     case checkboxSubtitleCell
     case iconTitleCell
-
-    public static var all: [TableViewCellViews] {
-        return [
-            .basicCell,
-            .basicCellVariations,
-            .checkboxCell,
-            .checkboxSubtitleCell,
-            .iconTitleCell
-        ]
-    }
 
     public var viewController: UIViewController {
         switch self {

--- a/Demo/DemoHelpers.swift
+++ b/Demo/DemoHelpers.swift
@@ -23,7 +23,7 @@ public struct ContainmentOptions: OptionSet {
 
     /// Attaches a navigation bar, a tab bar or both depending on what is returned here.
     /// If you return nil the screen will have no containers.
-    /// Or replace `return nil` with `self = .all`, `self = .navigationController` or `self = .tabBarController`
+    /// Or replace `return nil` with `self = .allCases`, `self = .navigationController` or `self = .tabBarController`
     ///
     /// - Parameter indexPath: The component's index path
     // swiftlint:disable:next cyclomatic_complexity
@@ -31,14 +31,14 @@ public struct ContainmentOptions: OptionSet {
         let sectionType = Sections.for(indexPath)
         switch sectionType {
         case .dna:
-            guard let screens = DnaViews.all[safe: indexPath.row] else {
+            guard let screens = DnaViews.allCases[safe: indexPath.row] else {
                 return nil
             }
             switch screens {
             default: return nil
             }
         case .fullscreen:
-            guard let screens = FullscreenViews.all[safe: indexPath.row] else {
+            guard let screens = FullscreenViews.allCases[safe: indexPath.row] else {
                 return nil
             }
             switch screens {
@@ -49,21 +49,21 @@ public struct ContainmentOptions: OptionSet {
             default: return nil
             }
         case .components:
-            guard let screens = ComponentViews.all[safe: indexPath.row] else {
+            guard let screens = ComponentViews.allCases[safe: indexPath.row] else {
                 return nil
             }
             switch screens {
             default: return nil
             }
         case .recycling:
-            guard let screens = RecyclingViews.all[safe: indexPath.row] else {
+            guard let screens = RecyclingViews.allCases[safe: indexPath.row] else {
                 return nil
             }
             switch screens {
             default: return nil
             }
         case .tableViewCells:
-            guard let screens = TableViewCellViews.all[safe: indexPath.row] else {
+            guard let screens = TableViewCellViews.allCases[safe: indexPath.row] else {
                 return nil
             }
             switch screens {
@@ -73,88 +73,78 @@ public struct ContainmentOptions: OptionSet {
     }
 }
 
-enum Sections: String {
+enum Sections: String, CaseIterable {
     case dna
     case components
     case recycling
     case fullscreen
     case tableViewCells
 
-    static var all: [Sections] {
-        return [
-            .dna,
-            .components,
-            .recycling,
-            .fullscreen,
-            .tableViewCells
-        ]
-    }
-
     var numberOfItems: Int {
         switch self {
         case .dna:
-            return DnaViews.all.count
+            return DnaViews.allCases.count
         case .components:
-            return ComponentViews.all.count
+            return ComponentViews.allCases.count
         case .recycling:
-            return RecyclingViews.all.count
+            return RecyclingViews.allCases.count
         case .fullscreen:
-            return FullscreenViews.all.count
+            return FullscreenViews.allCases.count
         case .tableViewCells:
-            return TableViewCellViews.all.count
+            return TableViewCellViews.allCases.count
         }
     }
 
     static func formattedName(for section: Int) -> String {
-        let section = Sections.all[section]
+        let section = Sections.allCases[section]
         let rawClassName = section.rawValue
         return rawClassName
     }
 
     static func formattedName(for indexPath: IndexPath) -> String {
-        let section = Sections.all[indexPath.section]
+        let section = Sections.allCases[indexPath.section]
         var rawClassName: String
         switch section {
         case .dna:
-            rawClassName = DnaViews.all[indexPath.row].rawValue
+            rawClassName = DnaViews.allCases[indexPath.row].rawValue
         case .components:
-            rawClassName = ComponentViews.all[indexPath.row].rawValue
+            rawClassName = ComponentViews.allCases[indexPath.row].rawValue
         case .recycling:
-            rawClassName = RecyclingViews.all[indexPath.row].rawValue
+            rawClassName = RecyclingViews.allCases[indexPath.row].rawValue
         case .fullscreen:
-            rawClassName = FullscreenViews.all[indexPath.row].rawValue
+            rawClassName = FullscreenViews.allCases[indexPath.row].rawValue
         case .tableViewCells:
-            rawClassName = TableViewCellViews.all[indexPath.row].rawValue
+            rawClassName = TableViewCellViews.allCases[indexPath.row].rawValue
         }
 
         return rawClassName.capitalizingFirstLetter
     }
 
     static func `for`(_ indexPath: IndexPath) -> Sections {
-        return Sections.all[indexPath.section]
+        return Sections.allCases[indexPath.section]
     }
 
     // swiftlint:disable:next cyclomatic_complexity
     static func viewController(for indexPath: IndexPath) -> UIViewController? {
-        guard let section = Sections.all[safe: indexPath.section] else {
+        guard let section = Sections.allCases[safe: indexPath.section] else {
             return nil
         }
         var viewController: UIViewController?
         switch section {
         case .dna:
-            let selectedView = DnaViews.all[safe: indexPath.row]
+            let selectedView = DnaViews.allCases[safe: indexPath.row]
             viewController = selectedView?.viewController
         case .components:
-            let selectedView = ComponentViews.all[safe: indexPath.row]
+            let selectedView = ComponentViews.allCases[safe: indexPath.row]
             viewController = selectedView?.viewController
         case .recycling:
-            let selectedView = RecyclingViews.all[safe: indexPath.row]
+            let selectedView = RecyclingViews.allCases[safe: indexPath.row]
             viewController = selectedView?.viewController
         case .fullscreen:
-            let selectedView = FullscreenViews.all[safe: indexPath.row]
+            let selectedView = FullscreenViews.allCases[safe: indexPath.row]
             viewController = selectedView?.viewController
         case .tableViewCells:
-            let selectedView = TableViewCellViews.all[safe: indexPath.row]
+            let selectedView = TableViewCellViews.allCases[safe: indexPath.row]
             viewController = selectedView?.viewController
         }
 

--- a/Demo/DemoViewsTableViewController.swift
+++ b/Demo/DemoViewsTableViewController.swift
@@ -44,11 +44,11 @@ class DemoViewsTableViewController: UITableViewController {
 
 extension DemoViewsTableViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return Sections.all.count
+        return Sections.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let section = Sections.all[section]
+        let section = Sections.allCases[section]
         return section.numberOfItems
     }
 

--- a/UnitTests/ComponentViewTests.swift
+++ b/UnitTests/ComponentViewTests.swift
@@ -7,7 +7,7 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class ComponentViewTests: FBSnapshotTestCase {
-    static var allViews = ComponentViews.all
+    static var allViews = ComponentViews.allCases
 
     override func setUp() {
         super.setUp()

--- a/UnitTests/DnaViewTests.swift
+++ b/UnitTests/DnaViewTests.swift
@@ -7,7 +7,7 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class DnaViewTests: FBSnapshotTestCase {
-    static var allViews = DnaViews.all
+    static var allViews = DnaViews.allCases
 
     override func setUp() {
         super.setUp()

--- a/UnitTests/FullscreenViewTests.swift
+++ b/UnitTests/FullscreenViewTests.swift
@@ -7,7 +7,7 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class FullscreenViewTests: FBSnapshotTestCase {
-    static var allViews = FullscreenViews.all
+    static var allViews = FullscreenViews.allCases
 
     override func setUp() {
         super.setUp()

--- a/UnitTests/RecyclingViewTests.swift
+++ b/UnitTests/RecyclingViewTests.swift
@@ -7,7 +7,7 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class RecyclingViewTests: FBSnapshotTestCase {
-    static var allViews = RecyclingViews.all
+    static var allViews = RecyclingViews.allCases
 
     override func setUp() {
         super.setUp()

--- a/UnitTests/TableViewCellViewsTests.swift
+++ b/UnitTests/TableViewCellViewsTests.swift
@@ -7,7 +7,7 @@ import FinniversKit
 import Demo
 
 class TableViewCellsViewTests: FBSnapshotTestCase {
-    static var allViews = TableViewCellViews.all
+    static var allViews = TableViewCellViews.allCases
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
# Why?
`CaseIterable` was added to Swift 4.2, which makes it unnecessary to declare an `all` attribute for the enums within the Demo target.

# What?
- Removed all instances of `all` from the enums and made them implement `CaseIterable` instead.