### PR TITLE
Front page: update header title when inline consent view is shown

### DIFF
--- a/Sources/Fullscreen/FrontPage/Demo/FrontPageViewDefaultData.swift
+++ b/Sources/Fullscreen/FrontPage/Demo/FrontPageViewDefaultData.swift
@@ -5,11 +5,12 @@
 import FinniversKit
 
 public struct FrontpageViewDefaultData: FrontPageViewModel {
-    public var adsGridViewHeaderTitle = "Anbefalinger"
-    public var retryButtonTitle = "Prøv igjen"
-    public var noRecommendationsText = "Vi klarte dessverre ikke å laste dine anbefalinger."
-    public var inlineConsentYesButtonTitle = "Ja, det er greit"
-    public var inlineConsentInfoButtonTitle = "Mer om samtykke"
+    public let adsGridViewHeaderTitle = "Anbefalinger"
+    public let retryButtonTitle = "Prøv igjen"
+    public let noRecommendationsText = "Vi klarte dessverre ikke å laste dine anbefalinger."
+    public let inlineConsentYesButtonTitle = "Ja, det er greit"
+    public let inlineConsentInfoButtonTitle = "Mer om samtykke"
+    public let inlineConsentTitle = "Slå på anbefalinger"
 
     public init() {}
 }

--- a/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -9,10 +9,10 @@ public protocol FrontPageViewDelegate: AnyObject {
 public final class FrontPageView: UIView {
     public var model: FrontPageViewModel? {
         didSet {
-            headerLabel.text = model?.adsGridViewHeaderTitle
             adsRetryView.set(labelText: model?.noRecommendationsText, buttonText: model?.retryButtonTitle)
             inlineConsentView.yesButtonTitle = model?.inlineConsentYesButtonTitle ?? ""
             inlineConsentView.infoButtonTitle = model?.inlineConsentInfoButtonTitle ?? ""
+            updateHeaderTitle()
         }
     }
 
@@ -102,12 +102,14 @@ public final class FrontPageView: UIView {
     public func showInlineConsents(withText text: String) {
         inlineConsentView.isHidden = false
         inlineConsentView.descriptionText = text
+        updateHeaderTitle()
         setupFrames()
     }
 
     public func hideInlineConsents() {
         inlineConsentView.isHidden = true
         inlineConsentView.descriptionText = ""
+        updateHeaderTitle()
         setupFrames()
     }
 
@@ -175,6 +177,10 @@ public final class FrontPageView: UIView {
         headerView.frame.size.height = height
         adsRetryView.frame.origin = CGPoint(x: 0, y: headerView.frame.height + .veryLargeSpacing)
         adsRetryView.frame.size = CGSize(width: bounds.width, height: 200)
+    }
+
+    private func updateHeaderTitle() {
+        headerLabel.text = inlineConsentView.isHidden ? model?.adsGridViewHeaderTitle : model?.inlineConsentTitle
     }
 }
 

--- a/Sources/Fullscreen/FrontPage/FrontPageViewModel.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageViewModel.swift
@@ -8,6 +8,7 @@ public protocol FrontPageViewModel {
     var adsGridViewHeaderTitle: String { get }
     var retryButtonTitle: String { get }
     var noRecommendationsText: String { get }
+    var inlineConsentTitle: String { get }
     var inlineConsentYesButtonTitle: String { get }
     var inlineConsentInfoButtonTitle: String { get }
 }


### PR DESCRIPTION
# Why?

We need a different header title for when inline consents are shown or not.

# What?

Update header title when inline consent view is shown or hidden.

# Show me

### Before

![simulator screen shot - iphone xs - 2018-11-23 at 10 16 47](https://user-images.githubusercontent.com/10529867/48942157-8b4df700-ef1e-11e8-9591-ac09c5a2bcc5.png)

### After

![simulator screen shot - iphone xs - 2018-11-23 at 12 49 45](https://user-images.githubusercontent.com/10529867/48942167-97d24f80-ef1e-11e8-8475-ad1704c4929b.png)