### PR TITLE
Front-page view: set delegate

### DIFF
--- a/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -61,6 +61,7 @@ public final class FrontPageView: UIView {
         adsGridView.translatesAutoresizingMaskIntoConstraints = false
 
         super.init(frame: .zero)
+        self.delegate = delegate
         inlineConsentView.delegate = inlineConsentViewDelegate
     }
 


### PR DESCRIPTION
# Why?

Because we forgot to set it during initialisation 🙈  

# What?

Set `FrontPageViewDelegate` in `init`.

# Show me

No UI changes.