### PR TITLE
Adds refactored spring animator class

### DIFF
--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		DAD0D490210735080091DD4D /* RadiobuttonAnimation.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DAA9A3AF2102157B0021F7DC /* RadiobuttonAnimation.xcassets */; };
 		DAD0D492210737A30091DD4D /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD0D491210737A30091DD4D /* TextView.swift */; };
 		DAD0D494210739500091DD4D /* DescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD0D493210739500091DD4D /* DescriptionView.swift */; };
+		DAE6A55C21CA524B00837BFA /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6A55B21CA524B00837BFA /* CGPoint.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -522,6 +523,7 @@
 		DAD0D48C210731B60091DD4D /* AdReporterDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdReporterDemoView.swift; sourceTree = "<group>"; };
 		DAD0D491210737A30091DD4D /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		DAD0D493210739500091DD4D /* DescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionView.swift; sourceTree = "<group>"; };
+		DAE6A55B21CA524B00837BFA /* CGPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPoint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1300,6 +1302,7 @@
 		44898D5A1FE5B9C200F6017B /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				DAE6A55A21CA523A00837BFA /* Core Graphics */,
 				441D699A1FEA947600CD919A /* Layout.swift */,
 				441D69991FEA947500CD919A /* LayoutHelpers.swift */,
 				441D69981FEA947500CD919A /* UIViewExtensions.swift */,
@@ -1891,6 +1894,14 @@
 			path = ListView;
 			sourceTree = "<group>";
 		};
+		DAE6A55A21CA523A00837BFA /* Core Graphics */ = {
+			isa = PBXGroup;
+			children = (
+				DAE6A55B21CA524B00837BFA /* CGPoint.swift */,
+			);
+			path = "Core Graphics";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -2326,6 +2337,7 @@
 				CF3D5EE4215A65D7006E4D08 /* Instrument.swift in Sources */,
 				DA8EF1222164E46E0028740C /* ConsentActionViewModel.swift in Sources */,
 				44587017213FA344009187BE /* LoginView.swift in Sources */,
+				DAE6A55C21CA524B00837BFA /* CGPoint.swift in Sources */,
 				43BACE6C21117D530052114C /* ReviewViewModel.swift in Sources */,
 				45B2E070207E181C00C68B92 /* InlineConsentView.swift in Sources */,
 				44898D651FE5B9C200F6017B /* UITableViewExtensions.swift in Sources */,

--- a/Sources/Components/BottomSheet/Animator/SpringAnimator.swift
+++ b/Sources/Components/BottomSheet/Animator/SpringAnimator.swift
@@ -6,99 +6,98 @@ import UIKit
 
 extension SpringAnimator {
     enum State {
-        case animating, paused, cancelled, stopped
+        case inactive, active, stopped
     }
 }
 
 class SpringAnimator: NSObject {
 
-    // Spring properties
-    private let damping: CGFloat
-    private let stiffness: CGFloat
-
-    // View properties
-    private var velocity: CGFloat = 0.0
-    private var position: CGFloat = 0.0
-    var initialVelocity: CGFloat = 0 {
-        didSet { velocity = -initialVelocity }
+    var fromPosition: CGPoint = .zero {
+        didSet {
+            position = toPosition - fromPosition
+        }
     }
 
-    // Animation properties
+    var toPosition: CGPoint = .zero {
+        didSet {
+            position = toPosition - fromPosition
+        }
+    }
+
+    var initialVelocity: CGPoint = .zero {
+        didSet {
+            velocity = initialVelocity
+        }
+    }
+
     var state: State = .stopped
-
-    var targetPosition = 0 as CGFloat
-    var constraint: NSLayoutConstraint?
-
+    var isRunning: Bool = false
     var completion: ((Bool) -> Void)?
-
+    // MARK: - Spring physics
+    private let damping: CGFloat
+    private let stiffness: CGFloat
+    private var velocity: CGPoint = .zero
+    private var position: CGPoint = .zero
+    // MARK: - Animation properties
+    private var animations: [(CGPoint) -> Void] = []
+    private lazy var displayLink = CADisplayLink(target: self, selector: #selector(step(displayLink:)))
     private let scale = 1 / UIScreen.main.scale
-    private var displayLink: CADisplayLink?
 
+    // MARK: - Setup
     init(dampingRatio: CGFloat, frequencyResponse: CGFloat) {
         self.stiffness = pow(2 * .pi / frequencyResponse, 2)
         self.damping = 2 * dampingRatio * sqrt(stiffness)
     }
 
-    func startAnimation() {
-        if state == .paused {
-            continueAnimation()
-        }
-
-        guard let constraint = constraint else { return }
-        position = targetPosition - constraint.constant
-
-        guard position != 0, displayLink == nil else { return }
-        displayLink = CADisplayLink(target: self, selector: #selector(step(displayLink:)))
-        displayLink?.add(to: .current, forMode: .common)
-        state = .animating
+    // MARK: - ViewAnimating
+    func addAnimation(_ animation: @escaping (CGPoint) -> Void) {
+        animations.append(animation)
     }
 
-    func continueAnimation() {
-        guard state == .paused, let constraint = constraint else { return }
-        position = targetPosition - constraint.constant
-        state = .animating
-        displayLink?.isPaused = false
+    func startAnimation() {
+        guard !isRunning else { return }
+        switch state {
+        case .stopped:
+            displayLink.add(to: .current, forMode: .common)
+        case .inactive:
+            displayLink.isPaused = false
+        default:
+            break
+        }
+        isRunning = true
+        state = .active
     }
 
     func pauseAnimation() {
-        guard state == .animating else { return }
-        state = .paused
-        displayLink?.isPaused = true
+        guard isRunning else { return }
+        displayLink.isPaused = true
+        isRunning = false
+        state = .inactive
     }
 
-    func stopAnimation() {
-        switch state {
-        case .animating, .paused: stopAnimation(didComplete: false)
-        default: return
-        }
+    func stopAnimation(_ withoutFinishing: Bool) {
+        guard isRunning else { return }
+        displayLink.remove(from: .current, forMode: .common)
+        isRunning = false
+        state = .stopped
+        completion?(!withoutFinishing)
     }
 }
 
 private extension SpringAnimator {
-
     @objc func step(displayLink: CADisplayLink) {
+        // Calculate new potision
         let acceleration = -velocity * damping - position * stiffness
         velocity += acceleration * CGFloat(displayLink.duration)
         position += velocity * CGFloat(displayLink.duration)
-        constraint?.constant = targetPosition - position
-
-        if abs(position) < scale, abs(velocity) < scale {
-            stopAnimation(didComplete: true)
+        // If it moves less than a pixel, animation is done
+        if position < scale, velocity < scale {
+            stopAnimation(false)
+            position = .zero
         }
-    }
-
-    func stopAnimation(didComplete: Bool) {
-        if didComplete {
-            constraint?.constant = targetPosition
-        }
-        displayLink?.invalidate()
-        displayLink = nil
-        completion?(didComplete)
-        completion = nil
-
-        switch didComplete {
-        case true: state = .stopped
-        case false: state = .cancelled
+        // Call to animation blocks
+        animations.forEach { animation in
+            animation(toPosition - position)
         }
     }
 }

--- a/Sources/Components/BottomSheet/Transition/BottomSheetGestureController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetGestureController.swift
@@ -6,19 +6,19 @@ import UIKit
 
 protocol BottomSheetGestureControllerDelegate: class {
     // Expects to get the current position of the bottom sheet
-    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGFloat
+    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGPoint
     func bottomSheetGestureControllerDidChangeGesture(_ controller: BottomSheetGestureController)
     func bottomSheetGestureControllerDidEndGesture(_ controller: BottomSheetGestureController)
 }
 
 class BottomSheetGestureController {
 
-    var position: CGFloat = 0
-    var velocity: CGFloat = 0
-    var translation: CGFloat = 0
+    var position: CGPoint = .zero
+    var velocity: CGPoint = .zero
+    var translation: CGPoint = .zero
     weak var delegate: BottomSheetGestureControllerDelegate?
 
-    private var initialConstant = 0 as CGFloat
+    private var initialPosition: CGPoint = .zero
     private lazy var panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(gesture:)))
     private let presentedView: UIView
     private let containerView: UIView
@@ -33,16 +33,16 @@ class BottomSheetGestureController {
 private extension BottomSheetGestureController {
     @objc func handlePan(gesture: UIPanGestureRecognizer) {
         let translation = gesture.translation(in: containerView)
-        self.translation = translation.y
+        self.translation = translation
         let velocity = gesture.velocity(in: containerView)
-        self.velocity = velocity.y
+        self.velocity = velocity
 
         switch gesture.state {
         case .began:
-            initialConstant = delegate?.bottomSheetGestureControllerDidBeginGesture(self) ?? 0
+            initialPosition = delegate?.bottomSheetGestureControllerDidBeginGesture(self) ?? .zero
 
         case .changed:
-            position = initialConstant + translation.y
+            position = initialPosition + translation
             delegate?.bottomSheetGestureControllerDidChangeGesture(self)
 
         case .ended:

--- a/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
@@ -14,7 +14,7 @@ import UIKit
 class BottomSheetInteractionController: NSObject, UIViewControllerInteractiveTransitioning {
 
     let animationController: BottomSheetAnimationController
-    var initialTransitionVelocity = 0 as CGFloat
+    var initialTransitionVelocity: CGPoint = .zero
     var stateController: BottomSheetStateController?
 
     private var constraint: NSLayoutConstraint?
@@ -33,7 +33,7 @@ class BottomSheetInteractionController: NSObject, UIViewControllerInteractiveTra
         // Keep track of context for any future transition related actions
         self.transitionContext = transitionContext
         // Start transition animation
-        animationController.targetPosition = stateController?.targetPosition ?? 0
+        animationController.targetPosition = stateController?.targetPosition ?? .zero
         animationController.initialVelocity = initialTransitionVelocity
         animationController.animateTransition(using: transitionContext)
     }
@@ -41,21 +41,21 @@ class BottomSheetInteractionController: NSObject, UIViewControllerInteractiveTra
 
 // The interaction is only used during the presentation transition
 extension BottomSheetInteractionController: BottomSheetGestureControllerDelegate {
-    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGFloat {
-        // interrupt the transition
+    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGPoint {
+        guard let constraint = constraint else { return .zero }
         animationController.pauseTransition()
-        return constraint?.constant ?? 0
+        return CGPoint(x: 0, y: constraint.constant)
     }
 
     func bottomSheetGestureControllerDidChangeGesture(_ controller: BottomSheetGestureController) {
         // Update constraint based on gesture
-        constraint?.constant = controller.position
+        constraint?.constant = controller.position.y
     }
 
     func bottomSheetGestureControllerDidEndGesture(_ controller: BottomSheetGestureController) {
         guard let transitionContext = transitionContext, let stateController = stateController else { return }
         stateController.updateState(withTranslation: controller.translation)
-        animationController.initialVelocity = controller.velocity
+        animationController.initialVelocity = -controller.velocity
         animationController.targetPosition = stateController.targetPosition
         switch stateController.state {
         case .dismissed: animationController.cancelTransition(using: transitionContext)

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -38,9 +38,9 @@ class BottomSheetPresentationController: UIPresentationController {
         // Setup views
         containerView.addSubview(presentedView)
         presentedView.translatesAutoresizingMaskIntoConstraints = false
-        constraint = presentedView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: containerView.bounds.height)
+        let constraint = presentedView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: containerView.bounds.height)
         NSLayoutConstraint.activate([
-            constraint!,
+            constraint,
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact),
@@ -53,55 +53,54 @@ class BottomSheetPresentationController: UIPresentationController {
         gestureController?.delegate = interactionController
         interactionController.setup(with: constraint)
         interactionController.stateController = stateController
+        // Add animation
+        springAnimator.addAnimation { position in
+            constraint.constant = position.y
+        }
+        self.constraint = constraint
     }
 
     override func presentationTransitionDidEnd(_ completed: Bool) {
         // If completed is false, the transition was cancelled by user interacion
         guard completed else { return }
-        setupInteractivePresentation()
+        gestureController?.delegate = self
     }
 
     override func dismissalTransitionWillBegin() {
-        // Clean up animator and gesture
-        springAnimator.stopAnimation()
-        // Setup interaction controller for dismissal
-        interactionController.initialTransitionVelocity = gestureController?.velocity ?? 0
+        springAnimator.stopAnimation(true)
+        // Make sure initial transition velocity is the same the current velocity of the bottom sheet
+        interactionController.initialTransitionVelocity = -(gestureController?.velocity ?? .zero)
     }
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         // Completed should always be true at this point of development
         guard !completed else { return }
-        setupInteractivePresentation()
-    }
-}
-
-private extension BottomSheetPresentationController {
-    func setupInteractivePresentation() {
-        // Setup gesture and animation for presentation
         gestureController?.delegate = self
-        springAnimator.constraint = constraint
     }
 }
 
 extension BottomSheetPresentationController: BottomSheetGestureControllerDelegate {
-    // This method expects to return the current y position of the bottom sheet
-    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGFloat {
+    // This method expects to return the current position of the bottom sheet
+    func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGPoint {
+        guard let constraint = constraint else { return .zero }
         springAnimator.pauseAnimation()
-        return constraint?.constant ?? 0
+        return CGPoint(x: 0, y: constraint.constant)
     }
-    // Position is the y position of the bottom sheet in the container view
+    // Position is the position of the bottom sheet in the container view
     func bottomSheetGestureControllerDidChangeGesture(_ controller: BottomSheetGestureController) {
-        constraint?.constant = controller.position
+        constraint?.constant = controller.position.y
     }
 
     func bottomSheetGestureControllerDidEndGesture(_ controller: BottomSheetGestureController) {
+        guard let constraint = constraint else { return }
         stateController.updateState(withTranslation: controller.translation)
         switch stateController.state {
         case .dismissed:
             presentedViewController.dismiss(animated: true)
         default:
-            springAnimator.targetPosition = stateController.targetPosition
-            springAnimator.initialVelocity = controller.velocity
+            springAnimator.fromPosition = CGPoint(x: 0, y: constraint.constant)
+            springAnimator.toPosition = stateController.targetPosition
+            springAnimator.initialVelocity = -controller.velocity
             springAnimator.startAnimation()
         }
     }

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -70,7 +70,7 @@ class BottomSheetPresentationController: UIPresentationController {
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         // Completed should always be true at this point of development
         guard !completed else { return }
-        setupInteractivePresentation()
+        gestureController?.delegate = self
     }
 }
 
@@ -84,14 +84,18 @@ private extension BottomSheetPresentationController {
     func setupPresentedView(_ presentedView: UIView, inContainerView containerView: UIView) {
         containerView.addSubview(presentedView)
         presentedView.translatesAutoresizingMaskIntoConstraints = false
-        constraint = presentedView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: containerView.bounds.height)
+        let constraint = presentedView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: containerView.bounds.height)
         NSLayoutConstraint.activate([
-            constraint!,
+            constraint,
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact),
             presentedView.bottomAnchor.constraint(greaterThanOrEqualTo: containerView.bottomAnchor),
         ])
+        springAnimator.addAnimation { position in
+            constraint.constant = position.y
+        }
+        self.constraint = constraint
     }
 
     @objc func handleTap() {
@@ -104,11 +108,6 @@ private extension BottomSheetPresentationController {
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.dimView.alpha = alpha
         }
-    }
-
-    func setupInteractivePresentation() {
-        // Setup gesture and animation for presentation
-        gestureController?.delegate = self
     }
 }
 

--- a/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
@@ -18,40 +18,40 @@ class BottomSheetStateController {
     var frame: CGRect = .zero
     var height: BottomSheet.Height = .zero
 
-    var targetPosition: CGFloat {
+    var targetPosition: CGPoint {
         return targetPosition(for: state)
     }
 
     private let threshold: CGFloat = 75
 
-    func updateState(withTranslation translation: CGFloat) {
+    func updateState(withTranslation translation: CGPoint) {
         state = nextState(forTranslation: translation, withCurrent: state, usingThreshold: threshold)
     }
 }
 
 private extension BottomSheetStateController {
-    func nextState(forTranslation translation: CGFloat, withCurrent current: State, usingThreshold threshold: CGFloat) -> State {
+    func nextState(forTranslation translation: CGPoint, withCurrent current: State, usingThreshold threshold: CGFloat) -> State {
         switch current {
         case .compact:
-            if translation < -threshold {
+            if translation.y < -threshold {
                 return .expanded
-            } else if translation > threshold { return .dismissed }
+            } else if translation.y > threshold { return .dismissed }
         case .expanded:
-            if translation > threshold { return .compact }
+            if translation.y > threshold { return .compact }
         case .dismissed:
-            if translation < -threshold { return .compact }
+            if translation.y < -threshold { return .compact }
         }
         return current
     }
 
-    func targetPosition(for state: State) -> CGFloat {
+    func targetPosition(for state: State) -> CGPoint {
         switch state {
         case .compact:
-            return frame.height - height.compact
+            return CGPoint(x: 0, y: frame.height - height.compact)
         case .expanded:
-            return frame.height - height.expanded
+            return CGPoint(x: 0, y: frame.height - height.expanded)
         case .dismissed:
-            return frame.height
+            return CGPoint(x: 0, y: frame.height)
         }
     }
 }

--- a/Sources/Extensions/UIKit/Core Graphics/CGPoint.swift
+++ b/Sources/Extensions/UIKit/Core Graphics/CGPoint.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright © 2018 FINN AS. All rights reserved.
+//
+
+import UIKit
+
+extension CGPoint {
+
+    static prefix func - (point: CGPoint) -> CGPoint {
+        return CGPoint(x: -point.x, y: -point.y)
+    }
+
+    static func * (point: CGPoint, scalar: CGFloat) -> CGPoint {
+        return CGPoint(x: point.x * scalar, y: point.y * scalar)
+    }
+
+    static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        return CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+    }
+
+    static func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
+
+    static func += (lhs: inout CGPoint, rhs: CGPoint) {
+        lhs.x += rhs.x
+        lhs.y += rhs.y
+    }
+
+    static func < (point: CGPoint, scalar: CGFloat) -> Bool {
+        let length = sqrt(pow(point.x, 2) + pow(point.y, 2))
+        return length < scalar
+    }
+}


### PR DESCRIPTION
# Why?

The current spring animation is too specific toward the bottom sheet position. This PR separates the spring animation from the constraint used to animate the bottom sheet. The spring animation will now calculate the position of the spring and call any animation blocks added to the animation.

Current way:
`springAnimator.constraint = bottomSheet.constraint`

New way:
`springAnimator.addAnimation { position in
          bottomSheet.constraint.constant = position.y
}`

This allows us to animate more than just the bottom sheet position in the transition. We could sync the animation of the dimView alpha with the animation of the bottom sheet position.

# What?

- Refactored SpringAnimator class. It is like the UIViewAnimating protocol, except I didn't use that protocol because some of it need iOS 10.0 and up.
- Tried to make it look more like UIView.animate API
- Added a bunch of CGPoint operator function for easier implementation

# Show me

Animate both bottom sheet position and bottom sheet background color during transition:

![bottom-sheet-color](https://user-images.githubusercontent.com/19956175/50223647-1db9ad00-039c-11e9-82f8-5b6b999f32c7.gif)

