### PR TITLE
Fix jumping bottom safe area

### DIFF
--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -56,7 +56,14 @@ public class BottomSheet: UIViewController {
 
     // Only necessary if iOS < 11.0
     private let maskLayer = CAShapeLayer()
-    // ---------------
+
+    private var bottomSafeAreaInset: CGFloat {
+        if #available(iOS 11.0, *) {
+            return UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0
+        } else {
+            return 0
+        }
+    }
 
     // MARK: - Setup
 
@@ -112,7 +119,7 @@ public class BottomSheet: UIViewController {
             rootViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             rootViewController.view.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             rootViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            rootViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            rootViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomSafeAreaInset)
         ])
     }
 }

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -56,20 +56,20 @@ public class BottomSheet: UIViewController {
 
     // Only necessary if iOS < 11.0
     private let maskLayer = CAShapeLayer()
-
-    private var bottomSafeAreaInset: CGFloat {
-        if #available(iOS 11.0, *) {
-            return UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0
-        } else {
-            return 0
-        }
-    }
+    private let bottomSafeAreaInset: CGFloat
 
     // MARK: - Setup
 
-    public init(rootViewController: UIViewController, height: Height = .defaultFilterHeight) {
+    public init(rootViewController: UIViewController,
+                appWindow: UIWindow? = UIApplication.shared.delegate?.window ?? nil,
+                height: Height = .defaultFilterHeight) {
         self.rootViewController = rootViewController
         self.transitionDelegate = BottomSheetTransitioningDelegate(height: height)
+        if #available(iOS 11.0, *) {
+            self.bottomSafeAreaInset = appWindow?.safeAreaInsets.bottom ?? 0
+        } else {
+            self.bottomSafeAreaInset = 0
+        }
         super.init(nibName: nil, bundle: nil)
         transitioningDelegate = transitionDelegate
         modalPresentationStyle = .custom


### PR DESCRIPTION
# Why?

Views constrained to `safeAreaLayoutGuide.bottomAnchor` were "jumping" when animating/sliding the bottom sheet.

# What?

Use `safeAreaInsets` of the window to set `rootViewController.view.bottomAnchor`.

# Show me

### Before

![filter_before2](https://user-images.githubusercontent.com/10529867/51124483-b407b400-181e-11e9-8c2c-6b61ae3c70e9.gif)

### After

![filter_after2](https://user-images.githubusercontent.com/10529867/51124522-c5e95700-181e-11e9-89bf-d06f5fe2772a.gif)
