### PR TITLE
Fix stackView constraints in BasicTableViewCell

### DIFF
--- a/Sources/Recycling/ListViews/Generic/Cells/BasicTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/BasicTableViewCell.swift
@@ -38,10 +38,10 @@ open class BasicTableViewCell: UITableViewCell {
         return stackView
     }()
 
-    open lazy var stackViewLeadingAnchor = stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing)
-    open lazy var stackViewTrailingAnchor = stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
-    open lazy var stackViewBottomAnchor = stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -13)
-    open lazy var stackViewTopAnchor = stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13)
+    open lazy var stackViewLeadingAnchorConstraint = stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing)
+    open lazy var stackViewTrailingAnchorConstraint = stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
+    open lazy var stackViewBottomAnchorConstraint = stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -13)
+    open lazy var stackViewTopAnchorConstraint = stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13)
 
     // MARK: - Private properties
 
@@ -84,12 +84,12 @@ open class BasicTableViewCell: UITableViewCell {
             accessoryType = .disclosureIndicator
             selectionStyle = .default
             detailLabelTrailingConstraint.constant = 0
-            stackViewTrailingAnchor.constant = 0
+            stackViewTrailingAnchorConstraint.constant = 0
         } else {
             accessoryType = .none
             selectionStyle = .none
             detailLabelTrailingConstraint.constant = -.mediumLargeSpacing
-            stackViewTrailingAnchor.constant = -.mediumLargeSpacing
+            stackViewTrailingAnchorConstraint.constant = -.mediumLargeSpacing
         }
 
         separatorInset = .leadingInset(.mediumLargeSpacing)
@@ -107,10 +107,10 @@ open class BasicTableViewCell: UITableViewCell {
         contentView.addSubview(stackView)
         contentView.addSubview(detailLabel)
         NSLayoutConstraint.activate([
-            stackViewTopAnchor,
-            stackViewLeadingAnchor,
-            stackViewTrailingAnchor,
-            stackViewBottomAnchor,
+            stackViewTopAnchorConstraint,
+            stackViewLeadingAnchorConstraint,
+            stackViewTrailingAnchorConstraint,
+            stackViewBottomAnchorConstraint,
 
             detailLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             detailLabelTrailingConstraint

--- a/Sources/Recycling/ListViews/Generic/Cells/BasicTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/BasicTableViewCell.swift
@@ -38,13 +38,16 @@ open class BasicTableViewCell: UITableViewCell {
         return stackView
     }()
 
-    open lazy var stackViewToContentViewConstraint = stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing)
+    open lazy var stackViewLeadingAnchor = stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: .mediumLargeSpacing)
+    open lazy var stackViewTrailingAnchor = stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
+    open lazy var stackViewBottomAnchor = stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -13)
+    open lazy var stackViewTopAnchor = stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13)
 
     // MARK: - Private properties
 
     private lazy var detailLabelTrailingConstraint = detailLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
     private lazy var stackViewToDetailLabelConstraint = stackView.trailingAnchor.constraint(lessThanOrEqualTo: detailLabel.leadingAnchor, constant: -.smallSpacing)
-    private lazy var stackViewTrailingAnchor = stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor)
+
     // MARK: - Setup
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -104,12 +107,13 @@ open class BasicTableViewCell: UITableViewCell {
         contentView.addSubview(stackView)
         contentView.addSubview(detailLabel)
         NSLayoutConstraint.activate([
-            stackViewToContentViewConstraint,
+            stackViewTopAnchor,
+            stackViewLeadingAnchor,
             stackViewTrailingAnchor,
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -13),
+            stackViewBottomAnchor,
+
             detailLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             detailLabelTrailingConstraint
-        ])
+            ])
     }
 }

--- a/Sources/Recycling/ListViews/Generic/Cells/CheckboxTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/CheckboxTableViewCell.swift
@@ -60,7 +60,7 @@ open class CheckboxTableViewCell: BasicTableViewCell {
 
     private func setup() {
         contentView.addSubview(checkbox)
-        stackViewLeadingAnchor.isActive = false
+        stackViewLeadingAnchorConstraint.isActive = false
 
         NSLayoutConstraint.activate([
             stackViewToCheckboxConstraint,

--- a/Sources/Recycling/ListViews/Generic/Cells/CheckboxTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/CheckboxTableViewCell.swift
@@ -60,7 +60,7 @@ open class CheckboxTableViewCell: BasicTableViewCell {
 
     private func setup() {
         contentView.addSubview(checkbox)
-        stackViewToContentViewConstraint.isActive = false
+        stackViewLeadingAnchor.isActive = false
 
         NSLayoutConstraint.activate([
             stackViewToCheckboxConstraint,

--- a/Sources/Recycling/ListViews/Generic/Cells/HeartTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/HeartTableViewCell.swift
@@ -60,7 +60,7 @@ open class HeartTableViewCell: BasicTableViewCell {
 
     private func setup() {
         contentView.addSubview(heartView)
-        stackViewLeadingAnchor.isActive = false
+        stackViewLeadingAnchorConstraint.isActive = false
         NSLayoutConstraint.activate([
             stackViewToHeartConstraint,
             heartView.heightAnchor.constraint(equalToConstant: 28),

--- a/Sources/Recycling/ListViews/Generic/Cells/HeartTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/HeartTableViewCell.swift
@@ -60,7 +60,7 @@ open class HeartTableViewCell: BasicTableViewCell {
 
     private func setup() {
         contentView.addSubview(heartView)
-        stackViewToContentViewConstraint.isActive = false
+        stackViewLeadingAnchor.isActive = false
         NSLayoutConstraint.activate([
             stackViewToHeartConstraint,
             heartView.heightAnchor.constraint(equalToConstant: 28),

--- a/Sources/Recycling/ListViews/Generic/Cells/IconTitleTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/IconTitleTableViewCell.swift
@@ -46,11 +46,11 @@ open class IconTitleTableViewCell: BasicTableViewCell {
             if let tintColor = viewModel.iconTintColor {
                 iconImageView.tintColor = tintColor
             }
-            stackViewLeadingAnchor.isActive = false
+            stackViewLeadingAnchorConstraint.isActive = false
             stackViewToIconConstraint.isActive = true
         } else {
             stackViewToIconConstraint.isActive = false
-            stackViewLeadingAnchor.isActive = true
+            stackViewLeadingAnchorConstraint.isActive = true
         }
 
         separatorInset = .leadingInset(.mediumLargeSpacing)

--- a/Sources/Recycling/ListViews/Generic/Cells/IconTitleTableViewCell.swift
+++ b/Sources/Recycling/ListViews/Generic/Cells/IconTitleTableViewCell.swift
@@ -46,11 +46,11 @@ open class IconTitleTableViewCell: BasicTableViewCell {
             if let tintColor = viewModel.iconTintColor {
                 iconImageView.tintColor = tintColor
             }
-            stackViewToContentViewConstraint.isActive = false
+            stackViewLeadingAnchor.isActive = false
             stackViewToIconConstraint.isActive = true
         } else {
             stackViewToIconConstraint.isActive = false
-            stackViewToContentViewConstraint.isActive = true
+            stackViewLeadingAnchor.isActive = true
         }
 
         separatorInset = .leadingInset(.mediumLargeSpacing)


### PR DESCRIPTION
# Why?
`BasicTableViewCell` has a stackView with a set of constraints. Unfortunately, these constraints may not fit every usecase when subclassing.

I've ran into some issues when trying to deactivate these constraints before the cell is presented/rendered. The issue seems to be not being able to reference the constraints before rendering, since we don't have a strong reference to them.

I.e.
```swift
// In BasicTableViewCell.init().
NSLayoutConstraint.activate([ /* stackView constraints */ ])

// In subclass init(), which doesn't need these constraints.
NSLayoutConstraint.deactivate(stackView.constraints) // Doesn't work. stackView.constraints is an empty list.
```

```swift
// In BasicTableViewCell.init().
NSLayoutConstraint.activate([ stackView.topAnchor.constraint(equalTo: contentView.topAnchor) ])

// In subclass init().
NSLayoutConstraint.deactivate([ stackView.topAnchor.constraint(equalTo: contentView.topAnchor) ]) // Doesn't work either..!
```

Found some guidance in [this SO post](https://stackoverflow.com/a/28717185).

# What?
- Make stackView's constraints stored into properties.

```swift
// In BasicTableViewCell.init()
stackViewTopAnchor = stackView.topAnchor.constraint(equalTo: contentView.topAnchor)
NSLayoutConstraint.activate([ stackViewTopAnchor ])

// In subclass init().
stackViewTopAnchor.isActive = false // This works!💯
```