### PR TITLE
Bottom sheet optional compact height

### DIFF
--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -6,19 +6,23 @@ import UIKit
 
 extension BottomSheet {
     public struct Height {
-        public let compact: CGFloat
+        public let compact: CGFloat?
         public let expanded: CGFloat
 
         public static var defaultFilterHeight: Height {
             let screenSize = UIScreen.main.bounds.size
-            let compact: CGFloat = screenSize.height >= 812 ? 570 : 510
-            let expanded = screenSize.height - 64
-            return Height(compact: compact, expanded: expanded)
+            if screenSize.height <= 568 {
+                return Height(compact: nil, expanded: 510)
+            }
+            if screenSize.height >= 812 {
+                return Height(compact: 570, expanded: screenSize.height - 64)
+            }
+            return Height(compact: 510, expanded: screenSize.height - 64)
         }
 
         public static let zero = Height(compact: 0, expanded: 0)
 
-        public init(compact: CGFloat, expanded: CGFloat) {
+        public init(compact: CGFloat?, expanded: CGFloat) {
             self.compact = compact
             self.expanded = expanded
         }

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -6,13 +6,13 @@ import UIKit
 
 extension BottomSheet {
     public struct Height {
-        public let compact: CGFloat?
+        public let compact: CGFloat
         public let expanded: CGFloat
 
         public static var defaultFilterHeight: Height {
             let screenSize = UIScreen.main.bounds.size
             if screenSize.height <= 568 {
-                return Height(compact: nil, expanded: 510)
+                return Height(compact: 510, expanded: 510)
             }
             if screenSize.height >= 812 {
                 return Height(compact: 570, expanded: screenSize.height - 64)
@@ -22,7 +22,7 @@ extension BottomSheet {
 
         public static let zero = Height(compact: 0, expanded: 0)
 
-        public init(compact: CGFloat?, expanded: CGFloat) {
+        public init(compact: CGFloat, expanded: CGFloat) {
             self.compact = compact
             self.expanded = expanded
         }

--- a/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
@@ -53,7 +53,7 @@ class BottomSheetInteractionController: NSObject, UIViewControllerInteractiveTra
 private extension BottomSheetInteractionController {
     func alphaValue(for position: CGPoint) -> CGFloat {
         guard let stateController = stateController else { return 0 }
-        return (stateController.frame.height - position.y) / (stateController.height.compact ?? stateController.height.expanded)
+        return (stateController.frame.height - position.y) / stateController.height.compact
     }
 }
 

--- a/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetInteractionController.swift
@@ -53,7 +53,7 @@ class BottomSheetInteractionController: NSObject, UIViewControllerInteractiveTra
 private extension BottomSheetInteractionController {
     func alphaValue(for position: CGPoint) -> CGFloat {
         guard let stateController = stateController else { return 0 }
-        return (stateController.frame.height - position.y) / stateController.height.compact
+        return (stateController.frame.height - position.y) / (stateController.height.compact ?? stateController.height.expanded)
     }
 }
 

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -25,8 +25,8 @@ class BottomSheetPresentationController: UIPresentationController {
     private let interactionController: BottomSheetInteractionController
     private var constraint: NSLayoutConstraint? // Constraint is used to set the y position of the bottom sheet
     private var gestureController: BottomSheetGestureController?
-    private let stateController = BottomSheetStateController()
     private let springAnimator = SpringAnimator(dampingRatio: 0.78, frequencyResponse: 0.5)
+    private lazy var stateController = BottomSheetStateController(height: height)
 
     private var hasReachExpandedPosition = false
     private var currentPosition: CGPoint {
@@ -57,7 +57,6 @@ class BottomSheetPresentationController: UIPresentationController {
         setupPresentedView(presentedView, inContainerView: containerView)
         // Setup controller
         stateController.frame = containerView.bounds
-        stateController.height = height
         gestureController = BottomSheetGestureController(presentedView: presentedView, containerView: containerView)
         gestureController?.delegate = interactionController
         interactionController.setup(with: constraint)
@@ -108,7 +107,7 @@ private extension BottomSheetPresentationController {
             constraint,
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact),
+            presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact ?? height.expanded),
             presentedView.bottomAnchor.constraint(greaterThanOrEqualTo: containerView.bottomAnchor),
         ])
         self.constraint = constraint
@@ -116,7 +115,7 @@ private extension BottomSheetPresentationController {
 
     func alphaValue(for position: CGPoint) -> CGFloat {
         guard let containerView = containerView else { return 0 }
-        return (containerView.bounds.height - position.y) / height.compact
+        return (containerView.bounds.height - position.y) / (height.compact ?? height.expanded)
     }
 
     func updateState(_ state: BottomSheet.State) {

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -107,7 +107,7 @@ private extension BottomSheetPresentationController {
             constraint,
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact ?? height.expanded),
+            presentedView.heightAnchor.constraint(greaterThanOrEqualToConstant: height.compact),
             presentedView.bottomAnchor.constraint(greaterThanOrEqualTo: containerView.bottomAnchor),
         ])
         self.constraint = constraint
@@ -115,7 +115,7 @@ private extension BottomSheetPresentationController {
 
     func alphaValue(for position: CGPoint) -> CGFloat {
         guard let containerView = containerView else { return 0 }
-        return (containerView.bounds.height - position.y) / (height.compact ?? height.expanded)
+        return (containerView.bounds.height - position.y) / height.compact
     }
 
     func updateState(_ state: BottomSheet.State) {

--- a/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
@@ -6,9 +6,9 @@ import UIKit
 
 class BottomSheetStateController {
 
-    var state: BottomSheet.State = .compact
     var frame: CGRect = .zero
-    var height: BottomSheet.Height = .zero
+    var state: BottomSheet.State
+    var height: BottomSheet.Height
 
     var targetPosition: CGPoint {
         return targetPosition(for: state)
@@ -18,11 +18,17 @@ class BottomSheetStateController {
         return CGPoint(x: 0, y: frame.height - height.expanded)
     }
 
-    var compactPosition: CGPoint {
-        return CGPoint(x: 0, y: frame.height - height.compact)
+    var compactPosition: CGPoint? {
+        guard let height = height.compact else { return nil }
+        return CGPoint(x: 0, y: frame.height - height)
     }
 
     private let threshold: CGFloat = 75
+
+    init(height: BottomSheet.Height) {
+        self.height = height
+        self.state = height.compact == nil ? .expanded : .compact
+    }
 
     func updateState(withTranslation translation: CGPoint) {
         state = nextState(forTranslation: translation, withCurrent: state, usingThreshold: threshold)
@@ -40,7 +46,7 @@ private extension BottomSheetStateController {
             }
         case .expanded:
             if translation.y > threshold {
-                return .compact
+                return height.compact == nil ? .dismissed : .compact
             }
         case .dismissed:
             if translation.y < -threshold {
@@ -53,7 +59,7 @@ private extension BottomSheetStateController {
     func targetPosition(for state: BottomSheet.State) -> CGPoint {
         switch state {
         case .compact:
-            return compactPosition
+            return compactPosition ?? .zero
         case .expanded:
             return expandedPosition
         case .dismissed:

--- a/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetStateController.swift
@@ -18,16 +18,17 @@ class BottomSheetStateController {
         return CGPoint(x: 0, y: frame.height - height.expanded)
     }
 
-    var compactPosition: CGPoint? {
-        guard let height = height.compact else { return nil }
-        return CGPoint(x: 0, y: frame.height - height)
+    var compactPosition: CGPoint {
+        return CGPoint(x: 0, y: frame.height - height.compact)
     }
 
     private let threshold: CGFloat = 75
+    private var isExpandedByDefault = false
 
     init(height: BottomSheet.Height) {
         self.height = height
-        self.state = height.compact == nil ? .expanded : .compact
+        self.isExpandedByDefault = height.compact == height.expanded
+        self.state = isExpandedByDefault ? .expanded : .compact
     }
 
     func updateState(withTranslation translation: CGPoint) {
@@ -46,7 +47,7 @@ private extension BottomSheetStateController {
             }
         case .expanded:
             if translation.y > threshold {
-                return height.compact == nil ? .dismissed : .compact
+                return isExpandedByDefault ? .dismissed : .compact
             }
         case .dismissed:
             if translation.y < -threshold {
@@ -59,7 +60,7 @@ private extension BottomSheetStateController {
     func targetPosition(for state: BottomSheet.State) -> CGPoint {
         switch state {
         case .compact:
-            return compactPosition ?? .zero
+            return compactPosition
         case .expanded:
             return expandedPosition
         case .dismissed:


### PR DESCRIPTION
# Why?

You might not always want to expand the bottom sheet.

# What?

- Made compact height optional. Setting this to nil makes the bottom sheet expanded by default.
- By adjusting the expanded height you will get the effect that you cannot expand the bottom sheet.