### PR TITLE
Fix retry view on the front page

### DIFF
--- a/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
@@ -69,12 +69,14 @@ final class FrontPageRetryView: UIView {
     }
 
     private func setup() {
+        backgroundColor = .milk
+
         addSubview(label)
         addSubview(button)
         addSubview(activityIndicatorView)
 
         NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: topAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumSpacing),
 

--- a/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
@@ -42,11 +42,10 @@ final class FrontPageRetryView: UIView {
         return button
     }()
 
-    private lazy var activityIndicatorView: UIActivityIndicatorView = {
-        let indicatorView = UIActivityIndicatorView(style: .whiteLarge)
-        indicatorView.translatesAutoresizingMaskIntoConstraints = false
-        indicatorView.color = .primaryBlue
-        return indicatorView
+    private lazy var loadingIndicatorView: LoadingIndicatorView = {
+        let view = LoadingIndicatorView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     // MARK: - Init
@@ -73,7 +72,7 @@ final class FrontPageRetryView: UIView {
 
         addSubview(label)
         addSubview(button)
-        addSubview(activityIndicatorView)
+        addSubview(loadingIndicatorView)
 
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
@@ -83,25 +82,27 @@ final class FrontPageRetryView: UIView {
             button.topAnchor.constraint(equalTo: label.bottomAnchor, constant: .largeSpacing),
             button.centerXAnchor.constraint(equalTo: label.centerXAnchor),
 
-            activityIndicatorView.centerXAnchor.constraint(equalTo: button.centerXAnchor),
-            activityIndicatorView.centerYAnchor.constraint(equalTo: button.centerYAnchor)
+            loadingIndicatorView.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+            loadingIndicatorView.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            loadingIndicatorView.widthAnchor.constraint(equalToConstant: 40),
+            loadingIndicatorView.heightAnchor.constraint(equalToConstant: 40)
         ])
     }
 
     private func configure(for state: State) {
         switch state {
         case .hidden:
-            activityIndicatorView.stopAnimating()
+            loadingIndicatorView.stopAnimating()
             isHidden = true
         case .labelAndButton:
             button.isHidden = false
             label.isHidden = false
-            activityIndicatorView.stopAnimating()
+            loadingIndicatorView.stopAnimating()
             isHidden = false
         case .loading:
             button.isHidden = true
             label.isHidden = true
-            activityIndicatorView.startAnimating()
+            loadingIndicatorView.startAnimating()
             isHidden = false
         }
     }

--- a/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -151,7 +151,7 @@ public final class FrontPageView: UIView {
         backgroundColor = .milk
 
         addSubview(adsGridView)
-        addSubview(adsRetryView)
+        adsGridView.collectionView.addSubview(adsRetryView)
 
         headerView.addSubview(marketsGridView)
         headerView.addSubview(headerLabel)


### PR DESCRIPTION
# Why?

Because `FrontPageRetryView` was missing background color and didn't scroll together with its superview.

# What?

- Set background color and fix position of `FrontPageRetryView`
- Use custom loading indicator instead of the standard one 

# Show me

### Before

![frontpage_before](https://user-images.githubusercontent.com/10529867/51921540-e3eeb400-23e7-11e9-8e27-1ed802f41579.gif)

### After

![frontpage_after](https://user-images.githubusercontent.com/10529867/51921549-ec46ef00-23e7-11e9-9977-253e4b4988f8.gif)