### PR TITLE
Fix warnings generated by SwiftLint 0.30.1

### DIFF
--- a/Sources/Components/Broadcast/BroadcastMessage.swift
+++ b/Sources/Components/Broadcast/BroadcastMessage.swift
@@ -20,8 +20,8 @@ public struct BroadcastMessage: Hashable, Codable {
         broadcastAreas = []
     }
 
-    public var hashValue: Int {
-        return id.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id.hashValue)
     }
 
     public static func == (lhs: BroadcastMessage, rhs: BroadcastMessage) -> Bool {

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -5,59 +5,59 @@
 import UIKit
 
 @objc extension UIColor {
-    @objc public class var ice: UIColor {
+    public class var ice: UIColor {
         return UIColor(r: 241, g: 249, b: 255)!
     }
 
-    @objc public class var milk: UIColor {
+    public class var milk: UIColor {
         return UIColor(r: 255, g: 255, b: 255)!
     }
 
-    @objc public class var licorice: UIColor {
+    public class var licorice: UIColor {
         return UIColor(r: 71, g: 68, b: 69)!
     }
 
-    @objc public class var primaryBlue: UIColor {
+    public class var primaryBlue: UIColor {
         return UIColor(r: 0, g: 99, b: 251)!
     }
 
-    @objc public class var secondaryBlue: UIColor {
+    public class var secondaryBlue: UIColor {
         return UIColor(r: 6, g: 190, b: 251)!
     }
 
-    @objc public class var stone: UIColor {
+    public class var stone: UIColor {
         return UIColor(r: 118, g: 118, b: 118)!
     }
 
-    @objc public class var sardine: UIColor {
+    public class var sardine: UIColor {
         return UIColor(r: 195, g: 204, b: 217)!
     }
 
-    @objc public class var salmon: UIColor {
+    public class var salmon: UIColor {
         return UIColor(r: 255, g: 206, b: 215)!
     }
 
-    @objc public class var mint: UIColor {
+    public class var mint: UIColor {
         return UIColor(r: 204, g: 255, b: 236)!
     }
 
-    @objc public class var toothPaste: UIColor {
+    public class var toothPaste: UIColor {
         return UIColor(r: 182, g: 240, b: 255)!
     }
 
-    @objc public class var banana: UIColor {
+    public class var banana: UIColor {
         return UIColor(r: 255, g: 245, b: 200)!
     }
 
-    @objc public class var cherry: UIColor {
+    public class var cherry: UIColor {
         return UIColor(r: 218, g: 36, b: 0)!
     }
 
-    @objc public class var watermelon: UIColor {
+    public class var watermelon: UIColor {
         return UIColor(r: 255, g: 88, b: 68)!
     }
 
-    @objc public class var pea: UIColor {
+    public class var pea: UIColor {
         return UIColor(r: 104, g: 226, b: 184)!
     }
 
@@ -127,24 +127,24 @@ extension CGColor {
 
 // MARK: - Button
 
-extension UIColor {
-    @objc public class var callToActionButtonHighlightedBodyColor: UIColor {
+@objc extension UIColor {
+    public class var callToActionButtonHighlightedBodyColor: UIColor {
         return primaryBlue.withAlphaComponent(0.8)
     }
 
-    @objc public class var destructiveButtonHighlightedBodyColor: UIColor {
+    public class var destructiveButtonHighlightedBodyColor: UIColor {
         return cherry.withAlphaComponent(0.8)
     }
 
-    @objc public class var defaultButtonHighlightedBodyColor: UIColor {
+    public class var defaultButtonHighlightedBodyColor: UIColor {
         return UIColor(r: 241, g: 249, b: 255)!
     }
 
-    @objc public class var linkButtonHighlightedTextColor: UIColor {
+    public class var linkButtonHighlightedTextColor: UIColor {
         return primaryBlue.withAlphaComponent(0.8)
     }
 
-    @objc public class var flatButtonHighlightedTextColor: UIColor {
+    public class var flatButtonHighlightedTextColor: UIColor {
         return primaryBlue.withAlphaComponent(0.8)
     }
 }

--- a/Sources/DNA/Font/Font.swift
+++ b/Sources/DNA/Font/Font.swift
@@ -17,7 +17,7 @@ enum FontType: String {
     /// - It should only be used one T1 and it should be the first text element that catches the users attention.
     /// - It shall give the user an overview of which page he or she is located.
     /// - This always has the weight Medium.
-    @objc public static var title1: UIFont {
+    public static var title1: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.medium.rawValue, size: 34.0)!
@@ -33,7 +33,7 @@ enum FontType: String {
     /// - A page can contain multiple T2 to divide content into several sections.
     /// - There should be a lot of space between sections to create a clear distinction on the content.
     /// - This always has the weight Light.
-    @objc public static var title2: UIFont {
+    public static var title2: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.light.rawValue, size: 28.0)!
@@ -45,7 +45,7 @@ enum FontType: String {
     /// ## Usage:
     /// - If a T2 have more sublevels, you can use T3.
     /// - This always has the weight Light.
-    @objc public static var title3: UIFont {
+    public static var title3: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.light.rawValue, size: 22)!
@@ -56,7 +56,7 @@ enum FontType: String {
     ///
     /// ## Usage:
     /// - This have the same size as the body text, but is always bolded (Medium) to differenciate them.
-    @objc public static var title4: UIFont {
+    public static var title4: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.medium.rawValue, size: 16.0)!
@@ -67,7 +67,7 @@ enum FontType: String {
     ///
     /// ## Usage:
     /// - Regular text below titles is called body text and is weighted Medium.
-    @objc public static var body: UIFont {
+    public static var body: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.light.rawValue, size: 16.0)!
@@ -79,7 +79,7 @@ enum FontType: String {
     /// ## Usage:
     /// - Used for short amount of text if neither the Body or Detail is appropriate.
     /// - This is slightly smaller than body text. Weighted Light.
-    @objc public static var caption: UIFont {
+    public static var caption: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.light.rawValue, size: 14.0)!
@@ -92,7 +92,7 @@ enum FontType: String {
     /// - Used for short amount of text if neither the Body or Detail is appropriate.
     /// - Bold version of Caption
     /// - This is slightly smaller than body text. Weighted Medium.
-    @objc public static var captionHeavy: UIFont {
+    public static var captionHeavy: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.medium.rawValue, size: 14.0)!
@@ -103,7 +103,7 @@ enum FontType: String {
     ///
     /// ## Usage:
     /// - Used for small, bold headlines.
-    @objc public static var title5: UIFont {
+    public static var title5: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.medium.rawValue, size: 12.0)!
@@ -117,7 +117,7 @@ enum FontType: String {
     /// - This is slightly smaller than body text. Weighted Regular.
     /// - The color Stone is prefered in most cases with white background.
     /// - For colored background such as ribbons, the color should be Licorice.
-    @objc public static var detail: UIFont {
+    public static var detail: UIFont {
         registerCustomFonts()
 
         let font = UIFont(name: FontType.regular.rawValue, size: 12.0)!

--- a/Sources/FinniversKit.swift
+++ b/Sources/FinniversKit.swift
@@ -14,7 +14,7 @@ import Foundation
 }
 
 @objc public extension Bundle {
-    @objc static var finniversKit: Bundle {
+    static var finniversKit: Bundle {
         return FinniversKit.bundle
     }
 }


### PR DESCRIPTION
# Why?

Because new version of SwiftLint generates more warnings on build.

# What?

- Remove redundant @objc attribute
- Replace `hashValue` with `hash(into:)`

# Show me

No UI changes