### PR TITLE
Fix/bottomsheet dismissal delegate

### DIFF
--- a/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
+++ b/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
@@ -173,6 +173,7 @@ class BottomSheetMechanicsDemoViewController: UIViewController {
         let rootController = RootViewController()
         rootController.delegate = self
         let bottomSheet = BottomSheet(rootViewController: rootController, draggableArea: .everything)
+        bottomSheet.delegate = self
         present(bottomSheet, animated: true)
         self.bottomSheet = bottomSheet
     }
@@ -186,6 +187,7 @@ class BottomSheetMechanicsDemoViewController: UIViewController {
         navigationController.navigationBar.isTranslucent = false
 
         let bottomSheet = BottomSheet(rootViewController: navigationController, draggableArea: .navigationBar)
+        bottomSheet.delegate = self
         present(bottomSheet, animated: true)
         self.bottomSheet = bottomSheet
     }
@@ -194,6 +196,7 @@ class BottomSheetMechanicsDemoViewController: UIViewController {
         let rootController = RootViewController(showDraggableLabel: true)
         rootController.delegate = self
         let bottomSheet = BottomSheet(rootViewController: rootController, draggableArea: .customRect(rootController.draggableLabelFrame))
+        bottomSheet.delegate = self
         present(bottomSheet, animated: true)
         self.bottomSheet = bottomSheet
     }
@@ -210,5 +213,11 @@ extension BottomSheetMechanicsDemoViewController: RootViewControllerDelegate {
 
     func rootViewControllerDidPressDismissButton(_ controller: RootViewController) {
         bottomSheet?.state = .dismissed
+    }
+}
+
+extension BottomSheetMechanicsDemoViewController: BottomSheetDelegate {
+    func bottomSheetDidDismiss(_ bottomSheet: BottomSheet) {
+        // BottomSheet dismissed.
     }
 }

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -103,6 +103,7 @@ public class BottomSheet: UIViewController {
             self.bottomSafeAreaInset = 0
         }
         super.init(nibName: nil, bundle: nil)
+        transitionDelegate.dismissalDelegate = self
         transitioningDelegate = transitionDelegate
         modalPresentationStyle = .custom
     }

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -4,6 +4,14 @@
 
 import UIKit
 
+public protocol BottomSheetDelegate: class {
+    func bottomSheetDidDismiss(_ bottomSheet: BottomSheet)
+}
+
+protocol BottomSheetDismissalDelegate: class {
+    func bottomSheetDidDismiss()
+}
+
 extension BottomSheet {
     public struct Height {
         public let compact: CGFloat
@@ -43,6 +51,8 @@ public class BottomSheet: UIViewController {
     }
 
     // MARK: - Public properties
+
+    public weak var delegate: BottomSheetDelegate?
 
     public var state: State {
         get { return transitionDelegate.presentationController?.state ?? .dismissed }
@@ -145,6 +155,16 @@ public class BottomSheet: UIViewController {
         ])
     }
 }
+
+// MARK: - BottomSheetDismissalDelegate
+
+extension BottomSheet: BottomSheetDismissalDelegate {
+    func bottomSheetDidDismiss() {
+        delegate?.bottomSheetDidDismiss(self)
+    }
+}
+
+// MARK: - Notch
 
 private class Notch: UIView {
 

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -8,10 +8,6 @@ public protocol BottomSheetDelegate: class {
     func bottomSheetDidDismiss(_ bottomSheet: BottomSheet)
 }
 
-protocol BottomSheetDismissalDelegate: class {
-    func bottomSheetDidDismiss()
-}
-
 extension BottomSheet {
     public struct Height {
         public let compact: CGFloat
@@ -103,7 +99,7 @@ public class BottomSheet: UIViewController {
             self.bottomSafeAreaInset = 0
         }
         super.init(nibName: nil, bundle: nil)
-        transitionDelegate.dismissalDelegate = self
+        transitionDelegate.presentationControllerDelegate = self
         transitioningDelegate = transitionDelegate
         modalPresentationStyle = .custom
     }
@@ -159,8 +155,8 @@ public class BottomSheet: UIViewController {
 
 // MARK: - BottomSheetDismissalDelegate
 
-extension BottomSheet: BottomSheetDismissalDelegate {
-    func bottomSheetDidDismiss() {
+extension BottomSheet: BottomSheetPresentationControllerDelegate {
+    func bottomSheetPresentationController(_ presentationController: BottomSheetPresentationController, didDismissPresentedViewController presentedViewController: UIViewController) {
         delegate?.bottomSheetDidDismiss(self)
     }
 }

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -126,6 +126,7 @@ private extension BottomSheetPresentationController {
     }
 
     @objc func handleTap() {
+        guard stateController.state != .dismissed else { return }
         stateController.state = .dismissed
         gestureController?.velocity = .zero
         presentedViewController.dismiss(animated: true)

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -129,6 +129,7 @@ private extension BottomSheetPresentationController {
         stateController.state = .dismissed
         gestureController?.velocity = .zero
         presentedViewController.dismiss(animated: true)
+        dismissalDelegate?.bottomSheetDidDismiss()
     }
 
     func animate(to position: CGPoint, initialVelocity: CGPoint = .zero) {

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -21,6 +21,7 @@ class BottomSheetPresentationController: UIPresentationController {
         set { updateState(newValue) }
     }
 
+    weak var dismissalDelegate: BottomSheetDismissalDelegate?
     private let height: BottomSheet.Height
     private let interactionController: BottomSheetInteractionController
     private var constraint: NSLayoutConstraint? // Constraint is used to set the y position of the bottom sheet
@@ -134,6 +135,7 @@ private extension BottomSheetPresentationController {
         switch stateController.state {
         case .dismissed:
             presentedViewController.dismiss(animated: true)
+            dismissalDelegate?.bottomSheetDidDismiss()
         default:
             springAnimator.fromPosition = currentPosition
             springAnimator.toPosition = position

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -14,6 +14,10 @@ import UIKit
  At this point, only the presenting transition is made interactive because the presentation is it self an interactive way of dismissing the bottom sheet.
 **/
 
+protocol BottomSheetPresentationControllerDelegate: class {
+    func bottomSheetPresentationController(_ presentationController: BottomSheetPresentationController, didDismissPresentedViewController presentedViewController: UIViewController)
+}
+
 class BottomSheetPresentationController: UIPresentationController {
 
     var state: BottomSheet.State {
@@ -21,7 +25,7 @@ class BottomSheetPresentationController: UIPresentationController {
         set { updateState(newValue) }
     }
 
-    weak var dismissalDelegate: BottomSheetDismissalDelegate?
+    weak var presentationControllerDelegate: BottomSheetPresentationControllerDelegate?
     private let height: BottomSheet.Height
     private let interactionController: BottomSheetInteractionController
     private var constraint: NSLayoutConstraint? // Constraint is used to set the y position of the bottom sheet
@@ -88,7 +92,10 @@ class BottomSheetPresentationController: UIPresentationController {
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         // Completed should always be true at this point of development
-        guard !completed else { return }
+        guard !completed else {
+            presentationControllerDelegate?.bottomSheetPresentationController(self, didDismissPresentedViewController: presentedViewController)
+            return
+        }
         gestureController?.delegate = self
     }
 }
@@ -130,14 +137,12 @@ private extension BottomSheetPresentationController {
         stateController.state = .dismissed
         gestureController?.velocity = .zero
         presentedViewController.dismiss(animated: true)
-        dismissalDelegate?.bottomSheetDidDismiss()
     }
 
     func animate(to position: CGPoint, initialVelocity: CGPoint = .zero) {
         switch stateController.state {
         case .dismissed:
             presentedViewController.dismiss(animated: true)
-            dismissalDelegate?.bottomSheetDidDismiss()
         default:
             springAnimator.fromPosition = currentPosition
             springAnimator.toPosition = position

--- a/Sources/Components/BottomSheet/Transition/BottomSheetTransitioningDelegate.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetTransitioningDelegate.swift
@@ -7,7 +7,7 @@ import UIKit
 class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
 
     var presentationController: BottomSheetPresentationController?
-    weak var dismissalDelegate: BottomSheetDismissalDelegate?
+    weak var presentationControllerDelegate: BottomSheetPresentationControllerDelegate?
 
     private let height: BottomSheet.Height
     private let interactionController: BottomSheetInteractionController
@@ -24,7 +24,7 @@ class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningD
                                                                    presenting: presenting,
                                                                    height: height,
                                                                    interactionController: interactionController)
-        presentationController?.dismissalDelegate = dismissalDelegate
+        presentationController?.presentationControllerDelegate = presentationControllerDelegate
         return presentationController
     }
 

--- a/Sources/Components/BottomSheet/Transition/BottomSheetTransitioningDelegate.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetTransitioningDelegate.swift
@@ -7,6 +7,7 @@ import UIKit
 class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
 
     var presentationController: BottomSheetPresentationController?
+    weak var dismissalDelegate: BottomSheetDismissalDelegate?
 
     private let height: BottomSheet.Height
     private let interactionController: BottomSheetInteractionController
@@ -23,6 +24,7 @@ class BottomSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningD
                                                                    presenting: presenting,
                                                                    height: height,
                                                                    interactionController: interactionController)
+        presentationController?.dismissalDelegate = dismissalDelegate
         return presentationController
     }
 


### PR DESCRIPTION
# Why?
We need a delegate callback when `BottomSheet` is dismissed.

# What?
- Added protocols `BottomSheetDelegate` _(public)_ and `BottomSheetDismissalDelegate` _(internal)_.
- Call `BottomSheetDelegate.bottomSheetDidDismiss(_:)` when state is set to `.dismissed`, when the swipe gesture dismisses bottomSheet, or a tap happens within `dimView`.