### PR TITLE
Change TextView's delegate type

### DIFF
--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -12,7 +12,7 @@ public class TextView: UIView {
 
     // MARK: - Public properties
 
-    public weak var delegate: UITextViewDelegate?
+    public weak var delegate: TextViewDelegate?
 
     public var text: String! {
         get { return textView.text }

--- a/Sources/Fullscreen/AdReporter/AdReporterView.swift
+++ b/Sources/Fullscreen/AdReporter/AdReporterView.swift
@@ -124,10 +124,10 @@ public class AdReporterView: UIScrollView {
 
 // MARK: -
 
-extension AdReporterView: UITextViewDelegate {
+extension AdReporterView: TextViewDelegate {
     // MARK: TextView Delegate
 
-    public func textViewDidChange(_ textView: UITextView) {
+    public func textViewDidChange(_ textView: TextView) {
         let deltaHeight = textView.intrinsicContentSize.height - textView.frame.height
 
         if deltaHeight > 0 {

--- a/Sources/Fullscreen/AdReporter/DescriptionView.swift
+++ b/Sources/Fullscreen/AdReporter/DescriptionView.swift
@@ -19,7 +19,7 @@ class DescriptionView: UIView {
         return view
     }()
 
-    weak var delegate: UITextViewDelegate? {
+    weak var delegate: TextViewDelegate? {
         didSet {
             textView.delegate = delegate
         }


### PR DESCRIPTION
# Why?
The type of `TextView`'s delegate was incorrect. It was set to `UITextViewDelegate`, when it should've been `TextViewDelegate`.

# What?
- Changed type of delegate.