### PR TITLE
Fix TextView delegate, part two

### DIFF
--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -6,6 +6,9 @@ import UIKit
 
 public protocol TextViewDelegate: class {
     func textViewDidChange(_ textView: TextView)
+    func textViewDidBeginEditing(_ textView: TextView)
+    func textViewDidEndEditing(_ textView: TextView)
+}
 }
 
 public class TextView: UIView {
@@ -120,11 +123,11 @@ public class TextView: UIView {
 
 extension TextView: UITextViewDelegate {
     public func textViewDidBeginEditing(_ textView: UITextView) {
-        delegate?.textViewDidBeginEditing?(textView)
+        delegate?.textViewDidBeginEditing(self)
     }
 
     public func textViewDidChange(_ textView: UITextView) {
-        delegate?.textViewDidChange?(textView)
+        delegate?.textViewDidChange(self)
 
         if textView.text.isEmpty {
             placeholderLabel.isHidden = false
@@ -134,6 +137,6 @@ extension TextView: UITextViewDelegate {
     }
 
     public func textViewDidEndEditing(_ textView: UITextView) {
-        delegate?.textViewDidEndEditing?(textView)
+        delegate?.textViewDidEndEditing(self)
     }
 }

--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -9,6 +9,17 @@ public protocol TextViewDelegate: class {
     func textViewDidBeginEditing(_ textView: TextView)
     func textViewDidEndEditing(_ textView: TextView)
 }
+
+public extension TextViewDelegate {
+    func textViewDidChange(_ textView: TextView) {
+        // Default empty implementation.
+    }
+    func textViewDidBeginEditing(_ textView: TextView) {
+        // Default empty implementation.
+    }
+    func textViewDidEndEditing(_ textView: TextView) {
+        // Default empty implementation.
+    }
 }
 
 public class TextView: UIView {

--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol TextViewDelegate: class {
+public protocol TextViewDelegate: AnyObject {
     func textViewDidChange(_ textView: TextView)
     func textViewDidBeginEditing(_ textView: TextView)
     func textViewDidEndEditing(_ textView: TextView)

--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol TextViewDelegate: UITextViewDelegate {
+public protocol TextViewDelegate: class {
     func textViewDidChange(_ textView: TextView)
 }
 


### PR DESCRIPTION
# Why?
After my last PR (#349) I noticed it was ambiguous which delegate method would be called from `TextView` when it called `delegate?.textViewDidChange(_:)`. This was due to the delegate protocol inheriting from `UITextViewDelegate`.

# What?
- Removed inheritance from `UITextViewDelegate`, so we may send a `TextView` instance to the delegate calls, instead of `UITextView`.
- Added new methods to protocol, with empty implementations.