### PR TITLE
Add editActionsForRowAt to the public API

### DIFF
--- a/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
+++ b/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
@@ -31,6 +31,15 @@ class UserAdsListViewDemoView: UIView {
 }
 
 extension UserAdsListViewDemoView: UserAdsListViewDelegate {
+    func userAdsListView(_ userAdsListView: UserAdsListView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        let deleteAction = UITableViewRowAction(style: .destructive, title: "Delete") { [weak self] (_, indexPath) in
+            guard let self = self else { return }
+            self.dataSource.userAds[indexPath.section].ads.remove(at: indexPath.row)
+            userAdsListView.deleteRows(at: [indexPath], with: .automatic)
+        }
+        return [deleteAction]
+    }
+
     func userAdsListView(_ userAdsListView: UserAdsListView, didTapCreateNewAdButton button: Button) {}
     func userAdsListView(_ userAdsListView: UserAdsListView, userAdsListHeaderView: UserAdsListHeaderView, didTapSeeMoreButton button: Button) {}
     func userAdsListView(_ userAdsListView: UserAdsListView, didTapSeeAllAdsButton button: Button) {}

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
@@ -11,6 +11,7 @@ public protocol UserAdsListViewDelegate: class {
     func userAdsListView(_ userAdsListView: UserAdsListView, didSelectItemAtIndex indexPath: IndexPath)
     func userAdsListView(_ userAdsListView: UserAdsListView, willDisplayItemAtIndex indexPath: IndexPath)
     func userAdsListView(_ userAdsListView: UserAdsListView, didScrollInScrollView scrollView: UIScrollView)
+    func userAdsListView(_ userAdsListView: UserAdsListView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]?
 }
 
 public protocol UserAdsListViewDataSource: class {
@@ -124,6 +125,10 @@ extension UserAdsListView: UITableViewDelegate {
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.userAdsListView(self, didScrollInScrollView: scrollView)
+    }
+    
+    public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        return delegate?.userAdsListView(self, editActionsForRowAt: indexPath)
     }
 }
 


### PR DESCRIPTION
# Why?

- To have the possibility of showing custom actions on cell swiping

# What?

- Add the `editActionsForRowAt` to the public API 

# Show me
No UI changes