### PR TITLE
Make public init for AnimatedCheckboxView

### DIFF
--- a/Sources/Components/SelectionBoxes/AnimatedCheckboxView.swift
+++ b/Sources/Components/SelectionBoxes/AnimatedCheckboxView.swift
@@ -10,13 +10,13 @@ public class AnimatedCheckboxView: AnimatedSelectionView {
     var unselectedImage: UIImage?
     var unselectedImages: [UIImage]?
 
-    required init(frame: CGRect) {
+    public required init(frame: CGRect) {
         super.init(frame: frame)
         setup()
         setImages()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 


### PR DESCRIPTION
# Why?

Because it should be possible to create an instance of a public class.

# What?

Make public init for `AnimatedCheckboxView`.

# Show me

No UI changes.