### PR TITLE
Add refresh control to UserAdsListView

### DIFF
--- a/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
+++ b/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
@@ -31,6 +31,12 @@ class UserAdsListViewDemoView: UIView {
 }
 
 extension UserAdsListViewDemoView: UserAdsListViewDelegate {
+    func userAdsListViewDidStartRefreshing(_ userAdsListView: UserAdsListView) {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
+            userAdsListView.reloadData()
+        }
+    }
+
     func userAdsListView(_ userAdsListView: UserAdsListView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         let deleteAction = UITableViewRowAction(style: .destructive, title: "Delete") { [weak self] (_, indexPath) in
             guard let self = self else { return }

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
@@ -73,22 +73,20 @@ public class UserAdsListView: UIView {
         self.delegate = delegate
         self.dataSource = dataSource
         setup()
-        setupRefreshControl()
     }
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
-        setupRefreshControl()
     }
 
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
-        setupRefreshControl()
     }
 
     private func setup() {
+        setupRefreshControl()
         tableView.register(UserAdsListViewNewAdCell.self)
         tableView.register(UserAdsListViewCell.self)
         tableView.register(UserAdsListViewSeeAllAdsCell.self)


### PR DESCRIPTION
# Why?

- So the user can refresh their list of ads voluntarily. This is especially useful when the backend sometimes returns deleted ads.

# What?

- Add a `UIRefreshControl` to the `UserAdsListView`

# Show me

### Before
![Simulator Screen Shot - iPhone XS Max - 2019-03-18 at 15 08 18](https://user-images.githubusercontent.com/8507719/54535856-bfe33400-498f-11e9-9a2a-507ee0135411.png)

### After
![Simulator Screen Shot - iPhone XS Max - 2019-03-18 at 14 56 19](https://user-images.githubusercontent.com/8507719/54535701-5f53f700-498f-11e9-88a9-59f451dc0522.png)
