### PR TITLE
Made StepIndicator an open class

### DIFF
--- a/Sources/Components/Broadcast/StepIndicator.swift
+++ b/Sources/Components/Broadcast/StepIndicator.swift
@@ -8,7 +8,7 @@ public protocol StepIndicatorDelegate: AnyObject {
     func stepIndicator(_ stepIndicator: StepIndicator, stepTappedAtIndex index: Int)
 }
 
-public class StepIndicator: UIView {
+open class StepIndicator: UIView {
 
     // MARK: - Public properties
 


### PR DESCRIPTION
# Why?

In order to properly integrate the `StepIndicator` with the T&R SDK, I need to extend it.

# What?

`StepIndicator` is now open.

# Show me

```
open class StepIndicator: UIView {
```