### PR TITLE
Decreased sensitivity for panning away the fullscreen gallery

### DIFF
--- a/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
+++ b/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
@@ -186,7 +186,7 @@ extension FullscreenImageViewController: UIGestureRecognizerDelegate {
         guard gestureRecognizer == panGestureRecognizer else { return false }
 
         let translation = panGestureRecognizer.translation(in: panGestureRecognizer.view)
-        return abs(translation.x) * 2 <= abs(translation.y)
+        return abs(translation.y) >= abs(translation.x) * 4
     }
 }
 


### PR DESCRIPTION
# Why?

We received a complaint that the pan-gesture to dismiss the fullscreen gallery was too sensitive, and I agree – I've dismissed it accidentally myself a few times.

# What?

The initial gesture must now move 4 times longer along Y than X in order to register as a dismissive pan.

# Show me

No visual changes.