### PR TITLE
Added inter-page spacing to FullscreenGallery

### DIFF
--- a/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
+++ b/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
@@ -78,7 +78,7 @@ public class FullscreenGalleryViewController: UIPageViewController {
         self.previewViewInitiallyVisible = previewVisible
         self.viewModel = viewModel
         self.currentImageIndex = viewModel.selectedIndex
-        super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
+        super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: [.interPageSpacing: CGFloat.largeSpacing])
 
         modalPresentationStyle = .overCurrentContext
         delegate = self


### PR DESCRIPTION
# Why?

The child-view controllers have no spacing between them, and it looks weird.

# What?

Added `.largeSpacing` as inter-page spacing.

# Show me

| Before | After |
|-|-|
|![gallery-spacing-before](https://user-images.githubusercontent.com/919713/55324298-e7eb9080-5481-11e9-8c08-1fff17c60506.gif)|![gallery-spacing-after](https://user-images.githubusercontent.com/919713/55324303-ecb04480-5481-11e9-925d-4f69d8f7687e.gif)|