### PR TITLE
Make it possible to create an instance of AnimatedRadiobuttonView

### DIFF
--- a/Sources/Components/SelectionBoxes/AnimatedRadiobuttonView.swift
+++ b/Sources/Components/SelectionBoxes/AnimatedRadiobuttonView.swift
@@ -10,13 +10,13 @@ public class AnimatedRadioButtonView: AnimatedSelectionView {
     var unselectedImage: UIImage?
     var unselectedImages: [UIImage]?
 
-    required init(frame: CGRect) {
+    public required init(frame: CGRect) {
         super.init(frame: frame)
         setup()
         setImages()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/Components/SelectionBoxes/AnimatedSelectionView.swift
+++ b/Sources/Components/SelectionBoxes/AnimatedSelectionView.swift
@@ -34,7 +34,7 @@ open class AnimatedSelectionView: UIImageView {
         addSubview(reverseImageView)
     }
 
-    func animateSelection(selected: Bool) {
+    public func animateSelection(selected: Bool) {
         if isAnimating {
             cancelAnimation()
             isHighlighted = selected


### PR DESCRIPTION
# Why?

Because it wasn't possible to create an instance of `AnimatedRadiobuttonView` outside of `FinniversKit`.

# What?

Make `init` and `animateSelection` method public.

# Show me

No UI changes.