### PR TITLE
Add DismissAction.none

### DIFF
--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -45,6 +45,7 @@ extension BottomSheet {
     public enum DismissAction {
         case tap
         case drag
+        case none
     }
 }
 

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -40,7 +40,7 @@ class BottomSheetPresentationController: UIPresentationController {
     private lazy var stateController = BottomSheetStateController(height: height)
 
     private var hasReachExpandedPosition = false
-    private var dismissAction: BottomSheet.DismissAction = .drag
+    private var dismissAction: BottomSheet.DismissAction = .none
 
     private var currentPosition: CGPoint {
         guard let constraint = constraint else { return .zero }


### PR DESCRIPTION
# Why?

When dismissing the bottom sheet from outside there should not be any dismiss action. The action should be specified some where else in that case.

# What?

- Added `case none` to `DismissAction`

# Show me

No UI