### PR TITLE
Fix overriding dismiss action when dismissing from outside

### DIFF
--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -155,7 +155,6 @@ private extension BottomSheetPresentationController {
     func animate(to position: CGPoint, initialVelocity: CGPoint = .zero) {
         switch stateController.state {
         case .dismissed:
-            dismissAction = .drag
             presentedViewController.dismiss(animated: true)
         default:
             springAnimator.fromPosition = currentPosition
@@ -194,6 +193,11 @@ extension BottomSheetPresentationController: BottomSheetGestureControllerDelegat
     func bottomSheetGestureControllerDidEndGesture(_ controller: BottomSheetGestureController) {
         stateController.updateState(withTranslation: controller.translation)
         guard !hasReachExpandedPosition else { return }
+
+        if stateController.state == .dismissed {
+            dismissAction = .drag
+        }
+
         animate(to: stateController.targetPosition, initialVelocity: -controller.velocity)
     }
 }


### PR DESCRIPTION
# Why?

The dismiss action was overridden when the bottom sheet is dismissed by setting `state = .dismissed`, making the dismiss action incorrect.

# What?

- Moved `dismissAction = .drag` out of `animate(to position)` and into `DidEndGesture()`

# Show me

No UI