### PR TITLE
Add HairlineView to StatisticsEmptyView

### DIFF
--- a/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -79,6 +79,7 @@ extension AdManagementDemoView: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        statisticsCellModels.removeAll()
         if indexPath.section == 0 {
             if indexPath.row == 0 && statisticsCellModels.isEmpty == true {
                 let cell = tableView.dequeue(UserAdManagementStatisticsEmptyViewCell.self, for: indexPath)

--- a/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -79,7 +79,6 @@ extension AdManagementDemoView: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        statisticsCellModels.removeAll()
         if indexPath.section == 0 {
             if indexPath.row == 0 && statisticsCellModels.isEmpty == true {
                 let cell = tableView.dequeue(UserAdManagementStatisticsEmptyViewCell.self, for: indexPath)

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -9,7 +9,7 @@ public class StatisticsItemEmptyView: UIView {
     // MARK: - Private
 
     private lazy var hairlineView: UIView = {
-        let label = UILabel(withAutoLayout: true)
+        let label = UIView(withAutoLayout: true)
         label.backgroundColor = .sardine
         return label
     }()

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -56,6 +56,8 @@ public class StatisticsItemEmptyView: UIView {
     // MARK: - Private methods
 
     private func setup() {
+        let hairLineSize = 1.0/UIScreen.main.scale
+
         addSubview(hairlineView)
         addSubview(imageView)
         addSubview(titleLabel)
@@ -65,7 +67,7 @@ public class StatisticsItemEmptyView: UIView {
             hairlineView.topAnchor.constraint(equalTo: topAnchor),
             hairlineView.leadingAnchor.constraint(equalTo: leadingAnchor),
             hairlineView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            hairlineView.heightAnchor.constraint(equalToConstant: 1),
+            hairlineView.heightAnchor.constraint(equalToConstant: hairLineSize),
 
             imageView.topAnchor.constraint(equalTo: hairlineView.bottomAnchor, constant: .mediumSpacing),
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -9,9 +9,9 @@ public class StatisticsItemEmptyView: UIView {
     // MARK: - Private
 
     private lazy var hairlineView: UIView = {
-        let label = UIView(withAutoLayout: true)
-        label.backgroundColor = .sardine
-        return label
+        let view = UIView(withAutoLayout: true)
+        view.backgroundColor = .sardine
+        return view
     }()
 
     private lazy var imageView: UIImageView = {

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -8,7 +8,7 @@ public class StatisticsItemEmptyView: UIView {
 
     // MARK: - Private
 
-    private lazy var hairlineView: UILabel = {
+    private lazy var hairlineView: UIView = {
         let label = UILabel(withAutoLayout: true)
         label.backgroundColor = .sardine
         return label

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -8,6 +8,12 @@ public class StatisticsItemEmptyView: UIView {
 
     // MARK: - Private
 
+    private lazy var hairlineView: UILabel = {
+        let label = UILabel(withAutoLayout: true)
+        label.backgroundColor = .sardine
+        return label
+    }()
+
     private lazy var imageView: UIImageView = {
         let view = UIImageView(image: UIImage(named: .statsEmpty))
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -50,12 +56,18 @@ public class StatisticsItemEmptyView: UIView {
     // MARK: - Private methods
 
     private func setup() {
+        addSubview(hairlineView)
         addSubview(imageView)
         addSubview(titleLabel)
         addSubview(descriptionLabel)
 
         NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),
+            hairlineView.topAnchor.constraint(equalTo: topAnchor),
+            hairlineView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hairlineView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hairlineView.heightAnchor.constraint(equalToConstant: 1),
+
+            imageView.topAnchor.constraint(equalTo: hairlineView.bottomAnchor, constant: .mediumSpacing),
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
 


### PR DESCRIPTION
# Why?

- Was missing a `HairlineView` at the top of the `StatisticsEmptyView` 

# What?

- Implement the `HairlineView` in the`StatisticsEmptyView`

# Show me
|     Before              |            After               |
| -------------------- | ----------------------- |
| ![before-fk](https://user-images.githubusercontent.com/8507719/55796344-185aac80-5aca-11e9-8262-f173564335b8.png) | ![after-fk](https://user-images.githubusercontent.com/8507719/55796358-227cab00-5aca-11e9-904a-95a771bc90c8.png) |