### PR TITLE
Remove complexity warning in setupRibbonView

### DIFF
--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
@@ -158,8 +158,7 @@ public class UserAdsListViewCell: UITableViewCell {
         ribbonView?.removeFromSuperview()
         switch status {
         // Draft ad states
-        case .draft: ribbonView = RibbonView(style: .warning, with: status.rawValue)
-        case .denied: ribbonView = RibbonView(style: .warning, with: status.rawValue)
+        case .draft, .denied: ribbonView = RibbonView(style: .warning, with: status.rawValue)
         case .awaitingPayment: ribbonView = RibbonView(style: .warning, with: status.rawValue)
 
         // Active ad states
@@ -167,8 +166,7 @@ public class UserAdsListViewCell: UITableViewCell {
         case .control: ribbonView = RibbonView(style: .success, with: status.rawValue)
 
         // Inactive ad states
-        case .deactive: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
-        case .dateExpiry: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
+        case .deactive, .dateExpiry: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .expired: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .inactive: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .sold: ribbonView = RibbonView(style: .warning, with: status.rawValue)


### PR DESCRIPTION
# Why?

- Warnings, warnings and warnings

# What?

- Move `enum` cases around to match alphabetically and on similar styling.

# Show me
No UI changes