### PR TITLE
Support Xcode 10.2

### DIFF
--- a/Sources/Fullscreen/EasterEggs/Piano/Extensions/AVAudioSession+Swift.h
+++ b/Sources/Fullscreen/EasterEggs/Piano/Extensions/AVAudioSession+Swift.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVAudioSession (Swift)
 
-- (BOOL)swift_setCategory:(AVAudioSessionCategory)category error:(NSError **)outError NS_SWIFT_NAME(setCategory(_:));
+- (BOOL)swift_setCategory:(AVAudioSessionCategory)category error:(NSError **)outError NS_SWIFT_NAME(swift_setCategory(_:)) __attribute__((deprecated("Remove when everyone is using Xcode 10.2 or above")));
 
 @end
 

--- a/Sources/Fullscreen/EasterEggs/Piano/PianoView.swift
+++ b/Sources/Fullscreen/EasterEggs/Piano/PianoView.swift
@@ -136,7 +136,7 @@ public final class PianoView: UIView {
         // start engine, set up audio session
         do {
             try audioEngine.start()
-            try audioSession.setCategory(.playback)
+            try audioSession.swift_setCategory(.playback)
             try audioSession.setActive(true)
         } catch {
             print("set up failed")


### PR DESCRIPTION
# Why?
The project doesn't build on Xcode 10.2.

# What?
Temporary fix that should make project build on both Xcode 10.1 and 10.2. Later we can remove the AVAudioSession+Swift files (when we no longer need Xcode 10.1 support).
