### PR TITLE
Improved the sensitivity for gallery-dismissal drastically

### DIFF
--- a/Demo/Fullscreen/FullscreenGallery/FullscreenGalleryDemoViewController.swift
+++ b/Demo/Fullscreen/FullscreenGallery/FullscreenGalleryDemoViewController.swift
@@ -115,10 +115,16 @@ class FullscreenGalleryDemoViewController: DemoViewController<UIView>, UICollect
 
     let imageUrls: [String] = [
         "https://i.pinimg.com/736x/73/de/32/73de32f9e5a0db66ec7805bb7cb3f807--navy-blue-houses-blue-and-white-houses-exterior.jpg",
-        "http://i3.au.reastatic.net/home-ideas/raw/a96671bab306bcb39783bc703ac67f0278ffd7de0854d04b7449b2c3ae7f7659/facades.jpg",
-        "http://jonvilma.com/images/house-6.jpg",
         "https://i.pinimg.com/736x/11/f0/79/11f079c03af31321fd5029f72a4586b1--exterior-houses-house-exteriors.jpg",
-        "https://i.pinimg.com/736x/bf/6d/73/bf6d73ab0234f3ba1a615b22d2dc7e74--home-exterior-design-contemporary-houses.jpg"
+        "http://i3.au.reastatic.net/home-ideas/raw/a96671bab306bcb39783bc703ac67f0278ffd7de0854d04b7449b2c3ae7f7659/facades.jpg",
+        "https://i.pinimg.com/736x/11/f0/79/11f079c03af31321fd5029f72a4586b1--exterior-houses-house-exteriors.jpg",
+        "https://i.pinimg.com/736x/bf/6d/73/bf6d73ab0234f3ba1a615b22d2dc7e74--home-exterior-design-contemporary-houses.jpg",
+        "https://i.pinimg.com/736x/11/f0/79/11f079c03af31321fd5029f72a4586b1--exterior-houses-house-exteriors.jpg",
+        "http://i3.au.reastatic.net/home-ideas/raw/a96671bab306bcb39783bc703ac67f0278ffd7de0854d04b7449b2c3ae7f7659/facades.jpg",
+        "https://i.pinimg.com/736x/73/de/32/73de32f9e5a0db66ec7805bb7cb3f807--navy-blue-houses-blue-and-white-houses-exterior.jpg",
+        "https://i.pinimg.com/736x/11/f0/79/11f079c03af31321fd5029f72a4586b1--exterior-houses-house-exteriors.jpg",
+        "https://i.pinimg.com/736x/73/de/32/73de32f9e5a0db66ec7805bb7cb3f807--navy-blue-houses-blue-and-white-houses-exterior.jpg",
+        "http://i3.au.reastatic.net/home-ideas/raw/a96671bab306bcb39783bc703ac67f0278ffd7de0854d04b7449b2c3ae7f7659/facades.jpg"
     ]
 
     let imageCaptions: [String] = [
@@ -127,6 +133,12 @@ class FullscreenGalleryDemoViewController: DemoViewController<UIView>, UICollect
         "Dette er den lang tekst. Det er mange som den, men denne er min. Uten den lange teksten min er jeg ingenting. Uten meg er den lange teksten min ingenting.",
         "Herskapelig og fint.\nMerk mangelen på rovdyr i hagen.",
         "Live here or be square 📦",
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
     ]
 
     private var selectedIndex: Int?

--- a/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
+++ b/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
@@ -185,8 +185,8 @@ extension FullscreenImageViewController: UIGestureRecognizerDelegate {
 
         guard gestureRecognizer == panGestureRecognizer else { return false }
 
-        let translation = panGestureRecognizer.translation(in: panGestureRecognizer.view)
-        return abs(translation.y) >= abs(translation.x) * 4
+        let velocity = panGestureRecognizer.velocity(in: panGestureRecognizer.view)
+        return velocity.length >= 1.0 && abs(velocity.y) > abs(velocity.x * 2)
     }
 }
 


### PR DESCRIPTION
# Why & what?

It was way too sensitive because it was based on the `UIPanGestureRecognizer`'s translation-properties, which is horribly imprecise. The dismissal trigger is now based mostly on the **velocity** property, which has a much finer resolution and precision than the translation.

# Show me
No visual changes.

## Before
Imagine an annoyed user.

## After
Imagine that same user, but not annoyed.