### PR TITLE
Fixed race-condition in AdsGridViewCell's handling of image-fetching

### DIFF
--- a/Demo/Fullscreen/FrontPage/FrontPageViewDemoView.swift
+++ b/Demo/Fullscreen/FrontPage/FrontPageViewDemoView.swift
@@ -5,7 +5,7 @@
 import FinniversKit
 
 public class FrontpageViewDemoView: UIView {
-    private let ads = AdFactory.create(numberOfModels: 6)
+    private let ads = AdFactory.create(numberOfModels: 60)
     private let markets = Market.allMarkets
     private var didSetupView = false
 
@@ -68,19 +68,20 @@ extension FrontpageViewDemoView: AdsGridViewDataSource {
         return ads[index]
     }
 
-    public func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void)) {
         guard let path = model.imagePath, let url = URL(string: path) else {
-            completion(nil)
+            completion(model, nil)
             return
         }
 
         // Demo code only.
         let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+            usleep(50_000)
             DispatchQueue.main.async {
                 if let data = data, let image = UIImage(data: data) {
-                    completion(image)
+                    completion(model, image)
                 } else {
-                    completion(nil)
+                    completion(model, nil)
                 }
             }
         }

--- a/Demo/Recycling/GridViews/Ads/AdsGridViewDemoView.swift
+++ b/Demo/Recycling/GridViews/Ads/AdsGridViewDemoView.swift
@@ -55,18 +55,18 @@ extension AdsGridViewDemoView: AdsGridViewDataSource {
         return dataSource.models[index]
     }
 
-    public func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void)) {
         guard let path = model.imagePath, let url = URL(string: path) else {
-            completion(nil)
+            completion(model, nil)
             return
         }
 
         let task = URLSession.shared.dataTask(with: url) { data, _, _ in
             DispatchQueue.main.async {
                 if let data = data, let image = UIImage(data: data) {
-                    completion(image)
+                    completion(model, image)
                 } else {
-                    completion(nil)
+                    completion(model, nil)
                 }
             }
         }

--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public protocol AdsGridViewCellDataSource: AnyObject {
-    func adsGridViewCell(_ adsGridViewCell: AdsGridViewCell, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func adsGridViewCell(_ adsGridViewCell: AdsGridViewCell, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void))
     func adsGridViewCell(_ adsGridViewCell: AdsGridViewCell, cancelLoadingImageForModel model: AdsGridViewModel, imageWidth: CGFloat)
 }
 
@@ -234,17 +234,8 @@ public class AdsGridViewCell: UICollectionViewCell {
 
     // MARK: - Public
 
-    /// Loads the image for the `model` if imagePath is set
     public func loadImage() {
-        if let model = model {
-            loadImage(model: model)
-        }
-    }
-
-    // MARK: - Private
-
-    private func loadImage(model: AdsGridViewModel) {
-        guard let dataSource = dataSource, model.imagePath != nil else {
+        guard let viewModel = model, let dataSource = dataSource, viewModel.imagePath != nil else {
             loadingColor = .clear
             imageView.image = defaultImage
             return
@@ -252,7 +243,10 @@ public class AdsGridViewCell: UICollectionViewCell {
 
         imageView.backgroundColor = loadingColor
 
-        dataSource.adsGridViewCell(self, loadImageForModel: model, imageWidth: frame.size.width) { [weak self] image in
+        dataSource.adsGridViewCell(self, loadImageForModel: viewModel, imageWidth: frame.size.width) { [weak self] (fetchedModel, image) in
+            guard let model = self?.model else { return }
+            guard fetchedModel.imagePath == model.imagePath else { return }
+
             self?.imageView.backgroundColor = .clear
 
             if let image = image {

--- a/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
+++ b/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
@@ -15,7 +15,7 @@ public protocol AdsGridViewDelegate: class {
 public protocol AdsGridViewDataSource: class {
     func numberOfItems(inAdsGridView adsGridView: AdsGridView) -> Int
     func adsGridView(_ adsGridView: AdsGridView, modelAtIndex index: Int) -> AdsGridViewModel
-    func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void))
     func adsGridView(_ adsGridView: AdsGridView, cancelLoadingImageForModel model: AdsGridViewModel, imageWidth: CGFloat)
 }
 
@@ -183,7 +183,7 @@ extension AdsGridView: UICollectionViewDataSource {
 // MARK: - AdsGridViewCellDataSource
 
 extension AdsGridView: AdsGridViewCellDataSource {
-    public func adsGridViewCell(_ adsGridViewCell: AdsGridViewCell, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func adsGridViewCell(_ adsGridViewCell: AdsGridViewCell, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void)) {
         dataSource?.adsGridView(self, loadImageForModel: model, imageWidth: imageWidth, completion: completion)
     }
 


### PR DESCRIPTION
# Why?

When the image-requests takes more than a non-trivial duration, we frequently run into race-conditions with reuse of images.

# What?

`AdsGridViewCell` will only show the returned image if it matches the **last** one it requested.

# Show me
### Before
![frontpage-raceracerace3](https://user-images.githubusercontent.com/919713/56793652-c37a9e00-680c-11e9-89f6-663b569a3e1c.gif)

### After
![frontpage-no-race](https://user-images.githubusercontent.com/919713/56793656-c5dcf800-680c-11e9-8d3b-47d3abfab114.gif)
