### PR TITLE
Fading in frontpage recommendation images

### DIFF
--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -28,24 +28,21 @@ public class AdsGridViewCell: UICollectionViewCell {
     private static let iconSize: CGFloat = 23.0
 
     private lazy var imageBackgroundView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
+        let view = UIView(withAutoLayout: true)
         view.layer.cornerRadius = AdsGridViewCell.cornerRadius
         view.layer.masksToBounds = true
         return view
     }()
 
     private lazy var imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        let imageView = UIImageView(withAutoLayout: true)
         imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
 
     private lazy var iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        let imageView = UIImageView(withAutoLayout: true)
         imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFit
         imageView.tintColor = .milk
@@ -76,8 +73,7 @@ public class AdsGridViewCell: UICollectionViewCell {
     }()
 
     private lazy var imageDescriptionView: UIView = {
-        let view = UILabel()
-        view.translatesAutoresizingMaskIntoConstraints = false
+        let view = UILabel(withAutoLayout: true)
         view.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
         view.alpha = 1.0
         view.layer.cornerRadius = AdsGridViewCell.cornerRadius
@@ -275,7 +271,7 @@ public class AdsGridViewCell: UICollectionViewCell {
 
         UIView.animate(withDuration: 0.2, delay: 0.0, options: [.curveEaseOut], animations: {
             self.imageView.alpha = 1.0
-        }, completion: nil)
+        })
     }
 
     private var defaultImage: UIImage? {


### PR DESCRIPTION
# Why?

In high-latency situations, the instant fade-into-existence is quite eye-gnawing... 🙂

# What?

Fading in images for frontpage recommendations. Note that I also don't clear the background color when there is no image, I haven't spoken to Thuy or anyone else about this yet. I think it looks kickass FWIW 🔥

# Show me

### Before
![frontpage-highlatency-no-fade](https://user-images.githubusercontent.com/919713/56803640-7a821400-6823-11e9-879f-469550f8aea1.gif)

### After
![frontpage-highlatency-fade](https://user-images.githubusercontent.com/919713/56803610-6ccc8e80-6823-11e9-9ecc-788b0d129f55.gif)