### PR TITLE
Bottom sheet: don't set bottomSafeAreaInset

### DIFF
--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -95,23 +95,15 @@ public class BottomSheet: UIViewController {
 
     // Only necessary if iOS < 11.0
     private let maskLayer = CAShapeLayer()
-    private let bottomSafeAreaInset: CGFloat
 
     // MARK: - Setup
 
     public init(rootViewController: UIViewController,
-                appWindow: UIWindow? = UIApplication.shared.delegate?.window ?? nil,
                 height: Height = .defaultFilterHeight,
-                draggableArea: DraggableArea = .everything
-                ) {
+                draggableArea: DraggableArea = .everything) {
         self.rootViewController = rootViewController
         self.transitionDelegate = BottomSheetTransitioningDelegate(height: height)
         self.draggableArea = draggableArea
-        if #available(iOS 11.0, *) {
-            self.bottomSafeAreaInset = appWindow?.safeAreaInsets.bottom ?? 0
-        } else {
-            self.bottomSafeAreaInset = 0
-        }
         super.init(nibName: nil, bundle: nil)
         transitionDelegate.presentationControllerDelegate = self
         transitioningDelegate = transitionDelegate
@@ -162,7 +154,7 @@ public class BottomSheet: UIViewController {
             rootViewController.view.topAnchor.constraint(equalTo: notch.bottomAnchor),
             rootViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             rootViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            rootViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomSafeAreaInset)
+            rootViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 }
@@ -215,6 +207,6 @@ private class Notch: UIView {
             notch.centerYAnchor.constraint(equalTo: centerYAnchor),
             notch.heightAnchor.constraint(equalToConstant: notchSize.height),
             notch.widthAnchor.constraint(equalToConstant: notchSize.width)
-        ])
+            ])
     }
 }


### PR DESCRIPTION
# Why?

Because the bottom sheet is supposed to be constrained to the bottom of the screen, not to the safe area. It will make table view cells go all the way to the bottom, which is more natural look for iPhone X(s).

# What?

Don't set `bottomSafeAreaInset` from `UIWindow` when  adding the bottom constraint to the view of `rootViewController`. 

**Note than if you ever use `safeAreaLayoutGuide` for adding constraints to any view within the bottom sheet, it will result in a weird jump animation. When the view is not yet visible onscreen, the layout guide edges are equal to the edges of the view. That's just how `safeAreaLayoutGuide` works
and I don't think we can do anything about it.**

# Show me

### Before

![before](https://user-images.githubusercontent.com/10529867/57147442-d7537080-6dc7-11e9-8486-43cba2f8b262.png)

### After

![after](https://user-images.githubusercontent.com/10529867/57147444-d91d3400-6dc7-11e9-9244-f94b4cff19c9.png)