### PR TITLE
Changed the fullscreen-gallery preview cell sizes

### DIFF
--- a/Sources/Fullscreen/FullscreenGallery/GalleryPreviewView.swift
+++ b/Sources/Fullscreen/FullscreenGallery/GalleryPreviewView.swift
@@ -35,7 +35,7 @@ class GalleryPreviewView: UIView {
     private lazy var cellSize: CGSize = {
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:
-            return CGSize(width: 115, height: 80)
+            return CGSize(width: 107, height: 71)
         default:
             return CGSize(width: 160, height: 120)
         }


### PR DESCRIPTION
# Why?

On the regular series of iPhones (X, 8, 7, ...), the fullscreen gallery preview-view showed exactly 3 thumbnails in the width. This looked slightly off, and did not communicate that the thumbnail view is scrollable as originally intended.

# What?

Changed the size of the thumbnails to 107x71. Thuy found this size to be a good compromise between what's visible on regular series & plus/max series devices.

# Show me

### Before

iPhone X:
<img width="487" alt="iphonex-before" src="https://user-images.githubusercontent.com/919713/57283071-9fda1200-70ae-11e9-8f57-a65a78403ce6.png">


### After

X:
<img width="487" alt="iphonex-after" src="https://user-images.githubusercontent.com/919713/57283098-a8324d00-70ae-11e9-8c7c-dd6b74eaed75.png">

8:
<img width="488" alt="iphone8-after" src="https://user-images.githubusercontent.com/919713/57283106-acf70100-70ae-11e9-9f8e-03836a681c16.png">
