### PR TITLE
Fix/icon collection view system layout size fitting

### DIFF
--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -51,6 +51,19 @@ public final class IconCollectionView: UIView {
         addSubview(collectionView)
         collectionView.fillInSuperview()
     }
+
+    // MARK: - Overrides
+
+    // This override exists because of how we calculate view sizes in our objectPage.
+    // The objectPage needs to know the size of this view before it's added to the view hierarchy, aka. before
+    // the collectionView itself knows it's own contentSize, so we need to calculate the total height of the view manually.
+    //
+    // All we're given to answer this question is the width attribute in `targetSize`.
+    //
+    // This implementation may not work for any place other than the objectPage, because:
+    //   - it assumes `targetSize` contains an accurate targetWidth for this view.
+    //   - it ignores any potential targetHeight.
+    //   - it ignores both horizontal and vertical fitting priority.
     public override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
         let targetWidth = targetSize.width
         let cellWidths = viewModels.map { cellWidth(forWidth: targetWidth, viewModel: $0) }

--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -78,7 +78,8 @@ public final class IconCollectionView: UIView {
         let cellRows = cellSizes.chunked(into: numberOfCellsInRow)
         let totalHeight = cellRows.compactMap { $0.max(by: { $0.height < $1.height }) }.reduce(0, { $0 + $1.height })
 
-        return CGSize(width: targetWidth, height: totalHeight + .mediumLargeSpacing)
+        let extraSpacing: CGFloat = .mediumSpacing * CGFloat(cellRows.count)
+        return CGSize(width: targetWidth, height: totalHeight + extraSpacing)
     }
 }
 

--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -74,12 +74,17 @@ extension IconCollectionView: UICollectionViewDelegateFlowLayout {
                                layout collectionViewLayout: UICollectionViewLayout,
                                sizeForItemAt indexPath: IndexPath) -> CGSize {
         let viewModel = viewModels[indexPath.item]
-        let width = UIDevice.isIPad()
-            ? max(collectionView.frame.width / CGFloat(viewModels.count), viewModel.image.size.width * 2)
-            : collectionView.frame.width / 2
+        let width = cellWidth(forWidth: collectionView.frame.width, viewModel: viewModel)
         let height = IconCollectionViewCell.height(for: viewModel, withWidth: width)
 
         return CGSize(width: width, height: height)
+    }
+
+    private func cellWidth(forWidth width: CGFloat, viewModel: IconCollectionViewModel) -> CGFloat {
+        let width = UIDevice.isIPad()
+            ? max(width / CGFloat(viewModels.count), viewModel.image.size.width * 2)
+            : width / 2
+        return width
     }
 }
 

--- a/Sources/Components/IconCollection/IconCollectionViewCell.swift
+++ b/Sources/Components/IconCollection/IconCollectionViewCell.swift
@@ -5,9 +5,11 @@
 import UIKit
 
 public class IconCollectionViewCell: UICollectionViewCell {
+    private static let titleSideMargin = CGFloat.mediumSpacing
+
     static func height(for viewModel: IconCollectionViewModel, withWidth width: CGFloat) -> CGFloat {
         let titleRect = viewModel.title.boundingRect(
-            with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude),
+            with: CGSize(width: width - (2 * titleSideMargin), height: CGFloat.greatestFiniteMagnitude),
             options: .usesLineFragmentOrigin,
             attributes: [.font: UIFont.body],
             context: nil
@@ -78,8 +80,8 @@ public class IconCollectionViewCell: UICollectionViewCell {
             iconImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
 
             titleLabel.topAnchor.constraint(equalTo: iconImageView.bottomAnchor, constant: .smallSpacing),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumSpacing),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumSpacing)
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: IconCollectionViewCell.titleSideMargin),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -IconCollectionViewCell.titleSideMargin)
         ])
     }
 }


### PR DESCRIPTION
# Why?
We need the collectionView to calculate its own height before it's added to the view hierarchy. This is because of how we calculate the size of each view on our objectPage.

# What?
- Override method `systemLayoutSizeFitting(_:withHorizontalFittingPriority:verticalFittingPriority:)`

# Show me
_No UI._