### PR TITLE
ContactFormView keyboard inset

### DIFF
--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		08796D9121CB97F40023A441 /* BasicTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08796D9021CB97F40023A441 /* BasicTableViewCellViewModel.swift */; };
 		08796D9321CB982F0023A441 /* SelectableTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08796D9221CB982F0023A441 /* SelectableTableViewCellViewModel.swift */; };
 		08796D9521CB984E0023A441 /* IconTitleTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08796D9421CB984E0023A441 /* IconTitleTableViewCellViewModel.swift */; };
+		087A5BB622A7D85500184640 /* KeyboardNotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087A5BB522A7D85500184640 /* KeyboardNotificationInfo.swift */; };
 		089DF42321C13178008A8711 /* RectangleGiftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089DF42221C13178008A8711 /* RectangleGiftView.swift */; };
 		08D70A0E21832546003E2222 /* BasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D70A0A21832546003E2222 /* BasicTableViewCell.swift */; };
 		08D70A15218328C6003E2222 /* CheckboxTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D70A14218328C6003E2222 /* CheckboxTableViewCell.swift */; };
@@ -411,6 +412,7 @@
 		08796D9021CB97F40023A441 /* BasicTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		08796D9221CB982F0023A441 /* SelectableTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		08796D9421CB984E0023A441 /* IconTitleTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconTitleTableViewCellViewModel.swift; sourceTree = "<group>"; };
+		087A5BB522A7D85500184640 /* KeyboardNotificationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardNotificationInfo.swift; sourceTree = "<group>"; };
 		089DF42221C13178008A8711 /* RectangleGiftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleGiftView.swift; sourceTree = "<group>"; };
 		08D70A0A21832546003E2222 /* BasicTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTableViewCell.swift; sourceTree = "<group>"; };
 		08D70A14218328C6003E2222 /* CheckboxTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckboxTableViewCell.swift; sourceTree = "<group>"; };
@@ -805,6 +807,14 @@
 				08796D9421CB984E0023A441 /* IconTitleTableViewCellViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		087A5BB422A7D84600184640 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				087A5BB522A7D85500184640 /* KeyboardNotificationInfo.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 		089DF42121C13064008A8711 /* ChristmasViews */ = {
@@ -1229,6 +1239,7 @@
 				4447F6B61FDB2B110033DBC1 /* Protocols */,
 				441FE414209A24E500B04EF1 /* Recycling */,
 				4447F6B81FDB2B110033DBC1 /* Resources */,
+				087A5BB422A7D84600184640 /* Util */,
 				4447F6C51FDB2B110033DBC1 /* FinniversKit.h */,
 				4447F6C61FDB2B110033DBC1 /* FinniversKit.swift */,
 				4447F6B51FDB2B110033DBC1 /* Info.plist */,
@@ -3242,6 +3253,7 @@
 				44D912632077AC8A00486848 /* TriangleView.swift in Sources */,
 				CF13D6CD2292D2300087DA37 /* PhaseListView.swift in Sources */,
 				144959DC2122C4400084549F /* FinniversImageAsset.m in Sources */,
+				087A5BB622A7D85500184640 /* KeyboardNotificationInfo.swift in Sources */,
 				DA8EF1262164E7EC0028740C /* ConsentToggleViewModel.swift in Sources */,
 				441FE450209A2F2C00B04EF1 /* NotificationsListViewModel.swift in Sources */,
 				08796D8A21CB8AB90023A441 /* HeartTableViewCell.swift in Sources */,

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -43,3 +43,18 @@ public extension UIView {
         layer.rasterizationScale = UIScreen.main.scale
     }
 }
+
+// MARK: - Animate alongside keyboard
+
+public extension UIView {
+    class func animateAlongsideKeyboard(keyboardInfo: KeyboardNotificationInfo, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
+        let animationDuration = keyboardInfo.animationDuration
+        let animationOptions = keyboardInfo.animationOptions
+
+        UIView.animate(withDuration: animationDuration, delay: 0, options: animationOptions, animations: animations, completion: completion)
+    }
+
+    class func animateAlongsideKeyboard(keyboardInfo: KeyboardNotificationInfo, animations: @escaping () -> Void) {
+        UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo, animations: animations, completion: nil)
+    }
+}

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -51,10 +51,10 @@ public extension UIView {
         let animationDuration = keyboardInfo.animationDuration
         let animationOptions = keyboardInfo.animationOptions
 
-        UIView.animate(withDuration: animationDuration, delay: 0, options: animationOptions, animations: animations, completion: completion)
+        animate(withDuration: animationDuration, delay: 0, options: animationOptions, animations: animations, completion: completion)
     }
 
     class func animateAlongsideKeyboard(keyboardInfo: KeyboardNotificationInfo, animations: @escaping () -> Void) {
-        UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo, animations: animations, completion: nil)
+        animateAlongsideKeyboard(keyboardInfo: keyboardInfo, animations: animations, completion: nil)
     }
 }

--- a/Sources/Util/KeyboardNotificationInfo.swift
+++ b/Sources/Util/KeyboardNotificationInfo.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public struct KeyboardNotificationInfo {
+    public enum KeyboardAction {
+        case willShow
+        case willHide
+    }
+
+    public let animationOptions: UIView.AnimationOptions
+    public let animationDuration: Double
+    public let frameStart: CGRect?
+    public let frameEnd: CGRect?
+    public let action: KeyboardAction
+
+    public init?(_ notification: Notification) {
+        guard let keyboardAction = notification.keyboardNotificationAction, let userInfo = notification.userInfo else { return nil }
+        action = keyboardAction
+
+        if let animationCurve = userInfo[UIWindow.keyboardAnimationCurveUserInfoKey] as? NSNumber {
+            animationOptions = UIView.AnimationOptions(rawValue: animationCurve.uintValue)
+        } else {
+            animationOptions = []
+        }
+
+        animationDuration = (userInfo[UIWindow.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0
+        frameStart = userInfo[UIWindow.keyboardFrameBeginUserInfoKey] as? CGRect
+        frameEnd = userInfo[UIWindow.keyboardFrameEndUserInfoKey] as? CGRect
+    }
+
+    /// Calculate the total intersection between the keyboard and a view. The value returned
+    /// will be between 0 and whatever intersection occurs. This is in case the user has
+    /// an iPad with an external keyboard connected, which would've returned a negative value.
+    public func keyboardFrameEndIntersectHeight(inView view: UIView) -> CGFloat {
+        guard let windowHeight = view.window?.frame.size.height, let frameEnd = frameEnd else { return 0 }
+        let keyboardHeight = frameEnd.size.height
+        let frameInWindow = view.convert(view.bounds, to: nil)
+
+        // Calculate the intersection between the keyboard and this view.
+        let intersection = keyboardHeight - (windowHeight - frameInWindow.origin.y - frameInWindow.size.height)
+        return max(0, intersection)
+    }
+}
+
+// MARK: - Private extensions
+
+private extension Notification {
+    var keyboardNotificationAction: KeyboardNotificationInfo.KeyboardAction? {
+        switch self.name {
+        case UIResponder.keyboardWillHideNotification:
+            return .willHide
+        case UIResponder.keyboardWillShowNotification:
+            return .willShow
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Util/KeyboardNotificationInfo.swift
+++ b/Sources/Util/KeyboardNotificationInfo.swift
@@ -31,13 +31,11 @@ public struct KeyboardNotificationInfo {
     /// will be between 0 and whatever intersection occurs. This is in case the user has
     /// an iPad with an external keyboard connected, which would've returned a negative value.
     public func keyboardFrameEndIntersectHeight(inView view: UIView) -> CGFloat {
-        guard let windowHeight = view.window?.frame.size.height, let frameEnd = frameEnd else { return 0 }
-        let keyboardHeight = frameEnd.size.height
+        guard let frameEnd = frameEnd else { return 0 }
         let frameInWindow = view.convert(view.bounds, to: nil)
+        let intersection = frameEnd.intersection(frameInWindow)
 
-        // Calculate the intersection between the keyboard and this view.
-        let intersection = keyboardHeight - (windowHeight - frameInWindow.origin.y - frameInWindow.size.height)
-        return max(0, intersection)
+        return max(0, intersection.height)
     }
 }
 


### PR DESCRIPTION
# Why?
The class `ContactFormView` handles insetting the content within its scrollView once a keyboard is presented. This worked on iPhones and iPads in fullscreen, but not on iPads when presented with `UIModalPresentationStyle.formSheet`.

The issue is the same as we had in our main app for the messaging popup on iPad, which was solved in PR#1383.

This solution also copies the `KeyboardInfo` struct that was included in PR#1437 into FinniversKit, but modifies it to be able to calculate the inset based on the view's frame within the window.

By using `KeyboardNotificationInfo` we should also be able to fix some of the issues we're having if the user has connected an external keyboard to his/hers iPad.

## Example
**Check if keyboard is presented or hidden.**
```swift
guard let keyboardInfo = KeyboardNotificationInfo(notification) else { return }

switch keyboardInfo.action {
case .willShow:
	print("Showing keyboard")
case .willHide:
	print("Hiding keyboard")
}
```

**Get the intersection between the keyboard and some view.**
```swift
guard let keyboardInfo = KeyboardNotificationInfo(notification) else { return }

let intersection = keyboardInfo.keyboardFrameEndIntersectHeight(inView: someView)
```

**Animate something alongside the keyboard.**
```swift
guard let keyboardInfo = KeyboardNotificationInfo(notification) else { return }

let intersection = keyboardInfo.keyboardFrameEndIntersectHeight(inView: someView)

UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo) {
	switch keyboardInfo.action {
	case .willShow:
		someView.transform = CGAffineTransform(translationX: 0, y: -intersection)
	case .willHide:
		someView.transform = .identity
	}
}
```

# What?
- Added struct `KeyboardNotificationInfo` that handles keyboard notifications.
- Added extensions to `UIView` for animating alongside a keyboard animation.
- Updated `ContactFormView` to use these two things.

# Show me
| Before | After |
| --- | --- |
| ![contactform-ipad-before](https://user-images.githubusercontent.com/1901556/58953242-2a895c00-8796-11e9-807c-c3f12219ee1b.gif) | ![contactform-ipad-after](https://user-images.githubusercontent.com/1901556/58953245-2cebb600-8796-11e9-9445-a065b4bd7749.gif) |

