### PR TITLE
Subtract safeAreaInset, if set on view

### DIFF
--- a/Sources/Util/KeyboardNotificationInfo.swift
+++ b/Sources/Util/KeyboardNotificationInfo.swift
@@ -34,8 +34,13 @@ public struct KeyboardNotificationInfo {
         guard let frameEnd = frameEnd else { return 0 }
         let frameInWindow = view.convert(view.bounds, to: nil)
         let intersection = frameEnd.intersection(frameInWindow)
+        var safeInsetBottom: CGFloat = 0
 
-        return max(0, intersection.height)
+        if #available(iOS 11.0, *) {
+            safeInsetBottom = view.safeAreaInsets.bottom
+        }
+
+        return max(0, intersection.height - safeInsetBottom)
     }
 }
 


### PR DESCRIPTION
# Why?
We should subtract the view's `safeAreaInset.bottom` from the calculated height, because we don't know if the view is presented modally or in full screen.

# What?
- Subtract safeAreaInset from the intersection between the keyboard and view.