### PR TITLE
Bumped version to 1.4.0

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '1.3.0'
+  s.version      = '1.4.0'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'


### PR DESCRIPTION
# Why?

I already created a release for 1.4.0, but forgot that the podspec file exists.