### PR TITLE
KeyboardNotificationInfo adjusts for portion of view that's out of bounds

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '1.4.0'
+  s.version      = '1.4.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		9F2133BEBE174152BD809417 /* GalleryPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F213F9DEE0BF048DD9B29FB /* GalleryPreviewView.swift */; };
 		9F213438F5413991D1B3D7CD /* FullscreenGalleryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2135C4606E66A98D140AAC /* FullscreenGalleryViewModel.swift */; };
 		9F21365157F385AC63928150 /* FullscreenGalleryDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2133F39A730EF3068C7DDA /* FullscreenGalleryDemoViewController.swift */; };
+		9F213830B2F4E5DFE596431F /* KeyboardNotificationInfoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F213CB3556A74594DB59E93 /* KeyboardNotificationInfoTest.swift */; };
 		9F2138937E903BEA8F7A8C7C /* FullscreenGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2133D2324BEE366DBA2134 /* FullscreenGalleryViewController.swift */; };
 		9F213ABAE416284A53AC6BA5 /* GalleryPreviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F21399D933575F69DB9DDCE /* GalleryPreviewCell.swift */; };
 		9F213D4043DC51660E6EF81B /* FullscreenGalleryTransitionAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F21354AF1CEB17C6CD55DCE /* FullscreenGalleryTransitionAware.swift */; };
@@ -641,6 +642,7 @@
 		9F21396E3BBAE40481AB6380 /* FullscreenGalleryTransitionDestinationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenGalleryTransitionDestinationDelegate.swift; sourceTree = "<group>"; };
 		9F21399D933575F69DB9DDCE /* GalleryPreviewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryPreviewCell.swift; sourceTree = "<group>"; };
 		9F213B88B6D6E66371A88079 /* FullscreenGalleryTransitionPresenterDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenGalleryTransitionPresenterDelegate.swift; sourceTree = "<group>"; };
+		9F213CB3556A74594DB59E93 /* KeyboardNotificationInfoTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardNotificationInfoTest.swift; sourceTree = "<group>"; };
 		9F213F9DEE0BF048DD9B29FB /* GalleryPreviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryPreviewView.swift; sourceTree = "<group>"; };
 		AA7A854D22255AB200AF5F42 /* DialogueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogueView.swift; sourceTree = "<group>"; };
 		AA864B36222D6F3F00BAE95A /* DialogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogueViewController.swift; sourceTree = "<group>"; };
@@ -1022,6 +1024,7 @@
 				14193AAA21380DC800EC7FC0 /* FullscreenViewTests.swift */,
 				14193AAC21380DC800EC7FC0 /* RecyclingViewTests.swift */,
 				08012BE421832C2E00A04F43 /* TableViewCellViewsTests.swift */,
+				9F213D8A2542DC1D6D998B43 /* Util */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1759,6 +1762,14 @@
 				9F2133F39A730EF3068C7DDA /* FullscreenGalleryDemoViewController.swift */,
 			);
 			path = FullscreenGallery;
+			sourceTree = "<group>";
+		};
+		9F213D8A2542DC1D6D998B43 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				9F213CB3556A74594DB59E93 /* KeyboardNotificationInfoTest.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 		9F213E134EF7C0A184D133F5 /* FullscreenGallery */ = {
@@ -3204,6 +3215,7 @@
 				14193AAF21380DC800EC7FC0 /* DnaViewTests.swift in Sources */,
 				14193AAE21380DC800EC7FC0 /* FullscreenViewTests.swift in Sources */,
 				14193AB021380DC800EC7FC0 /* RecyclingViewTests.swift in Sources */,
+				9F213830B2F4E5DFE596431F /* KeyboardNotificationInfoTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Util/KeyboardNotificationInfo.swift
+++ b/Sources/Util/KeyboardNotificationInfo.swift
@@ -40,7 +40,11 @@ public struct KeyboardNotificationInfo {
             safeInsetBottom = view.safeAreaInsets.bottom
         }
 
-        return max(0, intersection.height - safeInsetBottom)
+        let viewMaxY = frameInWindow.origin.y + frameInWindow.height
+        let keyboardMaxY = frameEnd.origin.y + frameEnd.height
+        let outOfBoundsHeight = max(0, viewMaxY - keyboardMaxY)
+
+        return max(0, intersection.height + outOfBoundsHeight - safeInsetBottom)
     }
 }
 

--- a/UnitTests/Util/KeyboardNotificationInfoTest.swift
+++ b/UnitTests/Util/KeyboardNotificationInfoTest.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+@testable import FinniversKit
+
+private class OrphanMockView: UIView {
+    override func convert(_ rect: CGRect, to view: UIView?) -> CGRect {
+        return frame
+    }
+}
+
+class KeyboardNotificationInfoTest: XCTestCase {
+    private func createView(withFrame frame: CGRect) -> UIView {
+        let view = OrphanMockView()
+        view.frame = frame
+        view.bounds = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
+        return view
+    }
+
+    private func rect(y: CGFloat, height: CGFloat) -> CGRect {
+        return CGRect(x: 0, y: y, width: 1000, height: height)
+    }
+
+    private func createKeyboardInfo(frameEnd: CGRect) -> KeyboardNotificationInfo {
+        let userInfo: [AnyHashable: Any] = [
+            UIWindow.keyboardFrameEndUserInfoKey: frameEnd
+        ]
+
+        let notification = Notification(name: UIResponder.keyboardWillShowNotification, object: nil, userInfo: userInfo)
+        guard let info = KeyboardNotificationInfo(notification) else {
+            XCTFail("Failed to build KeyboardNotificationInfo")
+            fatalError()
+        }
+
+        return info
+    }
+
+    func testKeyboardIntersectionZeroWhenNotOverlappingView() {
+        let viewFrame = rect(y: 100, height: 400)
+        let keyboardFrame = rect(y: 600, height: 400)
+
+        let view = createView(withFrame: viewFrame)
+        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+
+        let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
+        XCTAssertEqual(0, intersection)
+    }
+
+    func testKeyboardIntersectionNonZeroWhenOverlappingView() {
+        let viewFrame = rect(y: 100, height: 600)
+        let keyboardFrame = rect(y: 600, height: 400)
+
+        let view = createView(withFrame: viewFrame)
+        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+
+        let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
+        XCTAssertEqual(100, intersection)
+    }
+
+    func testKeyboardIntersectionWhenOutOfScreenBounds() {
+        let viewFrame = rect(y: 0, height: 1500)
+        let keyboardFrame = rect(y: 500, height: 500)
+
+        let view = createView(withFrame: viewFrame)
+        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+
+        let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
+        XCTAssertEqual(1000, intersection)
+    }
+}

--- a/UnitTests/Util/KeyboardNotificationInfoTest.swift
+++ b/UnitTests/Util/KeyboardNotificationInfoTest.swift
@@ -35,33 +35,24 @@ class KeyboardNotificationInfoTest: XCTestCase {
     }
 
     func testKeyboardIntersectionZeroWhenNotOverlappingView() {
-        let viewFrame = rect(y: 100, height: 400)
-        let keyboardFrame = rect(y: 600, height: 400)
-
-        let view = createView(withFrame: viewFrame)
-        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+        let view = createView(withFrame: rect(y: 100, height: 400))
+        let info = createKeyboardInfo(frameEnd: rect(y: 600, height: 400))
 
         let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
         XCTAssertEqual(0, intersection)
     }
 
     func testKeyboardIntersectionNonZeroWhenOverlappingView() {
-        let viewFrame = rect(y: 100, height: 600)
-        let keyboardFrame = rect(y: 600, height: 400)
-
-        let view = createView(withFrame: viewFrame)
-        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+        let view = createView(withFrame: rect(y: 100, height: 600))
+        let info = createKeyboardInfo(frameEnd: rect(y: 600, height: 400))
 
         let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
         XCTAssertEqual(100, intersection)
     }
 
     func testKeyboardIntersectionWhenOutOfScreenBounds() {
-        let viewFrame = rect(y: 0, height: 1500)
-        let keyboardFrame = rect(y: 500, height: 500)
-
-        let view = createView(withFrame: viewFrame)
-        let info = createKeyboardInfo(frameEnd: keyboardFrame)
+        let view = createView(withFrame: rect(y: 0, height: 1500))
+        let info = createKeyboardInfo(frameEnd: rect(y: 500, height: 500))
 
         let intersection = info.keyboardFrameEndIntersectHeight(inView: view)
         XCTAssertEqual(1000, intersection)


### PR DESCRIPTION
# Why?

The method `KeyboardNotificationInfo.keyboardFrameEndIntersectHeight(inView:)` did not take into account that the `view` might extend below the bottom of the screen. This turned out to be an issue with `BottomSheet`, which does not shrink vertically when the `BottomSheet` is initially presented with the device in portrait mode and then rotated to landscape. The opposite is true — when initially presented in landscape, the `BottomSheet` expands when the device is rotated to portrait.

# What?

- Added unit tests to prove the presence & subsequent resolve of this bug
- Adjusting the intersection height to account for the portion of the view that's out of bounds
- Bumped version to 1.4.1

# Show me

### Before

![before](https://user-images.githubusercontent.com/919713/60862003-9be87e80-a21c-11e9-8b9f-27c6570d3487.gif)

### After

![after](https://user-images.githubusercontent.com/919713/60862017-a0ad3280-a21c-11e9-83c3-c1738c784f95.gif)