### PR TITLE
Added property to enable/disable text input in MessageForm

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '1.4.1'
+  s.version      = '1.4.2'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
@@ -18,6 +18,11 @@ public class MessageFormBottomSheet: BottomSheet {
 
     public weak var messageFormDelegate: MessageFormBottomSheetDelegate?
 
+    public var inputEnabled: Bool {
+        get { return messageFormViewController.inputEnabled }
+        set { messageFormViewController.inputEnabled = newValue }
+    }
+
     /// This view should be used if you wish to present a toast inside this view controller.
     public var toastPresenterView: UIView {
         return messageFormViewController.toastPresenterView

--- a/Sources/Fullscreen/MessageForm/MessageFormView.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormView.swift
@@ -41,6 +41,16 @@ class MessageFormView: UIView {
         }
     }
 
+    var inputEnabled: Bool = true {
+        didSet {
+            if inputEnabled {
+                _ = becomeFirstResponder()
+            } else {
+                _ = resignFirstResponder()
+            }
+        }
+    }
+
     // MARK: - Private properties
 
     private let viewModel: MessageFormViewModel
@@ -77,6 +87,10 @@ class MessageFormView: UIView {
 
     public override func becomeFirstResponder() -> Bool {
         return textView.becomeFirstResponder()
+    }
+
+    public override func resignFirstResponder() -> Bool {
+        return textView.resignFirstResponder()
     }
 }
 

--- a/Sources/Fullscreen/MessageForm/MessageFormView.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormView.swift
@@ -43,6 +43,7 @@ class MessageFormView: UIView {
 
     var inputEnabled: Bool = true {
         didSet {
+            textView.isUserInteractionEnabled = inputEnabled
             if inputEnabled {
                 _ = becomeFirstResponder()
             } else {

--- a/Sources/Fullscreen/MessageForm/MessageFormView.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormView.swift
@@ -44,11 +44,7 @@ class MessageFormView: UIView {
     var inputEnabled: Bool = true {
         didSet {
             textView.isUserInteractionEnabled = inputEnabled
-            if inputEnabled {
-                _ = becomeFirstResponder()
-            } else {
-                _ = resignFirstResponder()
-            }
+            _ = inputEnabled ? becomeFirstResponder() : resignFirstResponder()
         }
     }
 

--- a/Sources/Fullscreen/MessageForm/MessageFormView.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormView.swift
@@ -44,7 +44,11 @@ class MessageFormView: UIView {
     var inputEnabled: Bool = true {
         didSet {
             textView.isUserInteractionEnabled = inputEnabled
-            _ = inputEnabled ? becomeFirstResponder() : resignFirstResponder()
+            if inputEnabled {
+                becomeFirstResponder()
+            } else {
+                resignFirstResponder()
+            }
         }
     }
 
@@ -82,10 +86,12 @@ class MessageFormView: UIView {
 
     // MARK: - Overrides
 
+    @discardableResult
     public override func becomeFirstResponder() -> Bool {
         return textView.becomeFirstResponder()
     }
 
+    @discardableResult
     public override func resignFirstResponder() -> Bool {
         return textView.resignFirstResponder()
     }

--- a/Sources/Fullscreen/MessageForm/MessageFormViewController.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormViewController.swift
@@ -48,6 +48,11 @@ class MessageFormViewController: UIViewController {
         return messageFormView
     }
 
+    var inputEnabled: Bool {
+        get { return messageFormView.inputEnabled }
+        set { messageFormView.inputEnabled = newValue }
+    }
+
     // MARK: - Private properties
 
     private let viewModel: MessageFormViewModel


### PR DESCRIPTION
# Why?

When showing a `LoadingView` while sending a message in the FINN app, the keyboard can still be interacted with.

# What?

Added a property to `MessageFormView` _(proxied through `MessageFormViewController` and `MessageFormBottomSheet`)_ that handles the first responder status and disables user-interaction on the `TextView`.

Bumped version to 1.4.2.

# Show me

Integrated in the FINN app:

### After

Internet is disconnected for the first couple of attempts, then enabled when the message gets sent, then I disabled it again for the last attempt.

![iphone8-failure-2](https://user-images.githubusercontent.com/919713/60878848-d95f0300-a240-11e9-8cdc-555319f4886d.gif)
