### PR TITLE
Set ReceiptView background color to milk

### DIFF
--- a/Sources/Fullscreen/Receipt/ReceiptView.swift
+++ b/Sources/Fullscreen/Receipt/ReceiptView.swift
@@ -18,6 +18,7 @@ public class ReceiptView: UIView {
 
     private lazy var scrollView: UIScrollView = {
         let view = UIScrollView(withAutoLayout: true)
+        view.backgroundColor = .milk
         view.showsVerticalScrollIndicator = false
         view.showsHorizontalScrollIndicator = false
         return view


### PR DESCRIPTION
# Why?

- Forgot to set the background colour rendering it black.

# What?

- Set the `backgroundColor` property to `milk` in the `scrollView`