### PR TITLE
Fix/receipt view crash

### DIFF
--- a/Demo/Fullscreen/Receipt/ReceiptViewDemoView.swift
+++ b/Demo/Fullscreen/Receipt/ReceiptViewDemoView.swift
@@ -12,14 +12,6 @@ class ReceiptViewDemoView: UIView {
         return receiptView
     }()
 
-    private lazy var questionnaireView: QuestionnaireView = {
-        let questionnaireView = QuestionnaireView(style: .normal(backgroundColor: .ice, primaryButtonIcon: UIImage(named: .webview)))
-        questionnaireView.translatesAutoresizingMaskIntoConstraints = false
-        questionnaireView.delegate = self
-        questionnaireView.model = QuestionnaireDemoData()
-        return questionnaireView
-    }()
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -47,6 +39,10 @@ extension ReceiptViewDemoView: ReceiptViewDelegate {
     }
 
     func receiptInsertViewBelowDetailText(_ : ReceiptView) -> UIView? {
+        let questionnaireView = QuestionnaireView(style: .normal(backgroundColor: .ice, primaryButtonIcon: UIImage(named: .webview)))
+        questionnaireView.translatesAutoresizingMaskIntoConstraints = false
+        questionnaireView.delegate = self
+        questionnaireView.model = QuestionnaireDemoData()
         return questionnaireView
     }
 }
@@ -60,7 +56,7 @@ extension ReceiptViewDemoView: QuestionnaireViewDelegate {
         print("questionnaireViewDidSelectCancelButton")
 
         UIView.animate(withDuration: 0.25) {
-            self.questionnaireView.alpha = 0.0
+            view.alpha = 0.0
         }
     }
 }

--- a/Sources/Fullscreen/LoadingView/LoadingView.swift
+++ b/Sources/Fullscreen/LoadingView/LoadingView.swift
@@ -167,7 +167,7 @@ private extension LoadingView {
                     widthAnchor.constraint(equalToConstant: boxedSize),
                     centerXAnchor.constraint(equalTo: window.centerXAnchor),
                     centerYAnchor.constraint(equalTo: window.centerYAnchor)
-                    ])                
+                ])
             }
         }
     }

--- a/Sources/Fullscreen/Receipt/ReceiptView.swift
+++ b/Sources/Fullscreen/Receipt/ReceiptView.swift
@@ -140,17 +140,20 @@ public class ReceiptView: UIView {
                 view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumSpacing),
                 view.heightAnchor.constraint(equalToConstant: 160),
             ])
+            setupButtonContentView(below: view)
+        } else {
+            setupButtonContentView(below: detailLabel)
         }
+    }
 
+    private func setupButtonContentView(below view: UIView) {
         contentView.addSubview(buttonContentView)
         buttonContentView.addSubview(navigateToAdButton)
         buttonContentView.addSubview(navigateToMyAdsButton)
         buttonContentView.addSubview(createNewAdButton)
 
-        let insertedViewOrBodyLabel = delegate?.receiptInsertViewBelowDetailText(self) ?? detailLabel
-
         NSLayoutConstraint.activate([
-            buttonContentView.topAnchor.constraint(equalTo: insertedViewOrBodyLabel.bottomAnchor, constant: .largeSpacing),
+            buttonContentView.topAnchor.constraint(equalTo: view.bottomAnchor, constant: .largeSpacing),
             buttonContentView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             buttonContentView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             buttonContentView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),


### PR DESCRIPTION
# Why?

- The `receiptView` did not add the received from the `delegate` to the view hierarchy causing a crash when laying out the `ButtonContentView` constraints

# What?

- Move setting up the `ButtonContentView` into a function that is called during `setup`.

# Show me
No UI changes