### PR TITLE
Refactor: Use AnyObject instead of class

### DIFF
--- a/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
+++ b/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
@@ -4,7 +4,7 @@
 
 import FinniversKit
 
-protocol RootViewControllerDelegate: class {
+protocol RootViewControllerDelegate: AnyObject {
     func rootViewControllerDidPressExpandButton(_ controller: RootViewController)
     func rootViewControllerDidPressCompactButton(_ controller: RootViewController)
     func rootViewControllerDidPressDismissButton(_ controller: RootViewController)

--- a/Sources/Components/BottomSheet/Transition/BottomSheetGestureController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetGestureController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol BottomSheetGestureControllerDelegate: class {
+protocol BottomSheetGestureControllerDelegate: AnyObject {
     // Expects to get the current position of the bottom sheet
     func bottomSheetGestureControllerDidBeginGesture(_ controller: BottomSheetGestureController) -> CGPoint
     func bottomSheetGestureControllerDidChangeGesture(_ controller: BottomSheetGestureController)

--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -14,7 +14,7 @@ import UIKit
  At this point, only the presenting transition is made interactive because the presentation is it self an interactive way of dismissing the bottom sheet.
 **/
 
-protocol BottomSheetPresentationControllerDelegate: class {
+protocol BottomSheetPresentationControllerDelegate: AnyObject {
     func bottomSheetPresentationControllerShouldDismiss(_ presentationController: BottomSheetPresentationController) -> Bool
     func bottomSheetPresentationControllerDidCancelDismiss(_ presentationController: BottomSheetPresentationController)
     func bottomSheetPresentationController(_ presentationController: BottomSheetPresentationController, didDismissPresentedViewController presentedViewController: UIViewController, by action: BottomSheet.DismissAction)

--- a/Sources/Components/Broadcast/Broadcast.swift
+++ b/Sources/Components/Broadcast/Broadcast.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol BroadcastDelegate: class {
+public protocol BroadcastDelegate: AnyObject {
     func broadcast(_ broadcast: Broadcast, didDismiss message: BroadcastMessage)
     func broadcast(_ broadcast: Broadcast, didTapURL url: URL, inItemAtIndex index: Int)
 }

--- a/Sources/Components/Broadcast/BroadcastItem.swift
+++ b/Sources/Components/Broadcast/BroadcastItem.swift
@@ -3,7 +3,7 @@
 //
 import UIKit
 
-protocol BroadcastItemDelegate: class {
+protocol BroadcastItemDelegate: AnyObject {
     func broadcastItemDismissButtonTapped(_ broadcastItem: BroadcastItem)
     func broadcastItem(_ broadcastItem: BroadcastItem, didTapURL url: URL)
 }

--- a/Sources/Components/Feedback/FeedbackView.swift
+++ b/Sources/Components/Feedback/FeedbackView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - FeedbackViewDelegate
 
-public protocol FeedbackViewDelegate: class {
+public protocol FeedbackViewDelegate: AnyObject {
     func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forState state: FeedbackView.State)
 }
 

--- a/Sources/Components/HappinessRating/HappinessRatingView.swift
+++ b/Sources/Components/HappinessRating/HappinessRatingView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol HappinessRatingViewDelegate: class {
+public protocol HappinessRatingViewDelegate: AnyObject {
     func happinessRatingView(_ happinessRatingView: HappinessRatingView, didSelectRating rating: HappinessRating)
 }
 

--- a/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
+++ b/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol HorizontalSlideControllerDelegate: class {
+protocol HorizontalSlideControllerDelegate: AnyObject {
     func horizontalSlideControllerDidDismiss(_ horizontalSlideController: HorizontalSlideController)
 }
 

--- a/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
+++ b/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@objc public protocol HorizontalSlideTransitionDelegate: class {
+@objc public protocol HorizontalSlideTransitionDelegate: AnyObject {
     @objc func horizontalSlideTransitionDidDismiss(_ horizontalSlideTransition: HorizontalSlideTransition)
 }
 

--- a/Sources/Components/SelectionBoxes/Selectionbox.swift
+++ b/Sources/Components/SelectionBoxes/Selectionbox.swift
@@ -6,7 +6,7 @@ import UIKit
 
 /* Selection box for selecting a single item */
 
-public protocol RadioButtonDelegate: class {
+public protocol RadioButtonDelegate: AnyObject {
     func radioButton(_ radioButton: RadioButton, didSelectItem item: RadioButtonItem)
     func radioButton(_ radioButton: RadioButton, didUnselectItem item: RadioButtonItem)
 }
@@ -42,7 +42,7 @@ public class RadioButton: Selectionbox {
 
 /* Selection box for selecting multiple items */
 
-public protocol CheckboxDelegate: class {
+public protocol CheckboxDelegate: AnyObject {
     func checkbox(_ checkbox: Checkbox, didSelectItem item: CheckboxItem)
     func checkbox(_ checkbox: Checkbox, didUnselectItem item: CheckboxItem)
 }

--- a/Sources/Components/Switch/SwitchView.swift
+++ b/Sources/Components/Switch/SwitchView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol SwitchDelegate: class {
+public protocol SwitchDelegate: AnyObject {
     func switchView(_ switchView: SwitchView, didChangeValueFor switch: UISwitch)
 }
 

--- a/Sources/Components/TextField/TextField.swift
+++ b/Sources/Components/TextField/TextField.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - TextFieldDelegate
 
-public protocol TextFieldDelegate: class {
+public protocol TextFieldDelegate: AnyObject {
     func textFieldDidBeginEditing(_ textField: TextField)
     func textFieldDidEndEditing(_ textField: TextField)
     func textFieldShouldReturn(_ textField: TextField) -> Bool

--- a/Sources/Components/Toast/ToastView.swift
+++ b/Sources/Components/Toast/ToastView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol ToastViewDelegate: class {
+public protocol ToastViewDelegate: AnyObject {
     func didTapActionButton(button: UIButton, in toastView: ToastView)
     func didTap(toastView: ToastView)
     func didSwipeDown(on toastView: ToastView)

--- a/Sources/Fullscreen/AdReporter/ConfirmationView.swift
+++ b/Sources/Fullscreen/AdReporter/ConfirmationView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol ConfirmationViewDelegate: class {
+public protocol ConfirmationViewDelegate: AnyObject {
     func confirmationViewDidPressDismissButton(_ confirmationView: ConfirmationView)
 }
 

--- a/Sources/Fullscreen/ConsentActionView/ConsentActionView.swift
+++ b/Sources/Fullscreen/ConsentActionView/ConsentActionView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol ConsentActionViewDelegate: class {
+public protocol ConsentActionViewDelegate: AnyObject {
     func consentActionViewDidPressButton(_ consentActionView: ConsentActionView)
 }
 

--- a/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
+++ b/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
@@ -3,7 +3,7 @@
 //
 import UIKit
 
-public protocol ConsentToggleViewDelegate: class {
+public protocol ConsentToggleViewDelegate: AnyObject {
     func consentToggleView(_ consentToggleView: ConsentToggleView, didToggleSwitch position: Bool)
     func consentToggleViewDidPressButton(_ consentToggleView: ConsentToggleView)
 }

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -5,7 +5,7 @@
 import CoreMotion
 import UIKit
 
-public protocol EmptyViewDelegate: class {
+public protocol EmptyViewDelegate: AnyObject {
     func emptyView(_ emptyView: EmptyView, didSelectActionButton button: Button)
     func emptyView(_ emptyView: EmptyView, didMoveObjectView view: UIView)
 }

--- a/Sources/Fullscreen/Login/LoginView.swift
+++ b/Sources/Fullscreen/Login/LoginView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - LoginViewDelegatew
 
-public protocol LoginViewDelegate: class {
+public protocol LoginViewDelegate: AnyObject {
     func loginView(_ loginView: LoginView, didSelectForgetPasswordButton button: Button)
     func loginView(_ loginView: LoginView, didSelectLoginButton button: Button, with email: String, and password: String)
     func loginView(_ loginView: LoginView, didSelectNewUserButton button: Button, with email: String)

--- a/Sources/Fullscreen/Popup/PopupView.swift
+++ b/Sources/Fullscreen/Popup/PopupView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - PopupViewDelegate
 
-public protocol PopupViewDelegate: class {
+public protocol PopupViewDelegate: AnyObject {
     func popupView(_ popupView: PopupView, didSelectCallToActionButton button: Button)
     func popupView(_ popupView: PopupView, didSelectAlternativeActionButton button: Button)
     func popupView(_ popupView: PopupView, didSelectDismissButton button: Button)

--- a/Sources/Fullscreen/Receipt/ReceiptView.swift
+++ b/Sources/Fullscreen/Receipt/ReceiptView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - ReceiptViewDelegate
 
-public protocol ReceiptViewDelegate: class {
+public protocol ReceiptViewDelegate: AnyObject {
     func receipt(_ : ReceiptView, didTapNavigateToAd button: Button)
     func receipt(_ : ReceiptView, didTapNavigateToMyAds button: Button)
     func receipt(_ : ReceiptView, didTapCreateNewAd button: Button)

--- a/Sources/Fullscreen/Register/RegisterView.swift
+++ b/Sources/Fullscreen/Register/RegisterView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // MARK: - LoginViewDelegatew
 
-public protocol RegisterViewDelegate: class {
+public protocol RegisterViewDelegate: AnyObject {
     func registerView(_ registerView: RegisterView, didSelectLoginButton button: Button, with email: String)
     func registerView(_ registerView: RegisterView, didSelectRegisterButton button: Button, with email: String, and password: String)
     func registerView(_ registerView: RegisterView, didSelectUserTermsButton button: Button)

--- a/Sources/Fullscreen/Review/Cell/ReviewProfileCell.swift
+++ b/Sources/Fullscreen/Review/Cell/ReviewProfileCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol ReviewProfileCellDelegate: class {
+protocol ReviewProfileCellDelegate: AnyObject {
     func reviewProfileCell(_ reviewProfileCell: ReviewProfileCell, loadImageForModel model: ReviewViewProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) -> UIImage?
     func reviewProfileCell(_ reviewProfileCell: ReviewProfileCell, cancelLoadingImageForModel model: ReviewViewProfileModel, imageWidth: CGFloat)
 }

--- a/Sources/Fullscreen/Review/ReviewView.swift
+++ b/Sources/Fullscreen/Review/ReviewView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol ReviewViewDelegate: class {
+public protocol ReviewViewDelegate: AnyObject {
     func reviewView(_ reviewView: ReviewView, loadImageForModel model: ReviewViewProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) -> UIImage?
     func reviewView(_ reviewView: ReviewView, cancelLoadingImageForModel model: ReviewViewProfileModel, imageWidth: CGFloat)
     func reviewView(_ reviewView: ReviewView, didSelect profile: ReviewViewProfileModel)

--- a/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
+++ b/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol AdsGridViewDelegate: class {
+public protocol AdsGridViewDelegate: AnyObject {
     func adsGridViewDidStartRefreshing(_ adsGridView: AdsGridView)
     func adsGridView(_ adsGridView: AdsGridView, didSelectItemAtIndex index: Int)
     func adsGridView(_ adsGridView: AdsGridView, willDisplayItemAtIndex index: Int)
@@ -12,7 +12,7 @@ public protocol AdsGridViewDelegate: class {
     func adsGridView(_ adsGridView: AdsGridView, didSelectFavoriteButton button: UIButton, on cell: AdsGridViewCell, at index: Int)
 }
 
-public protocol AdsGridViewDataSource: class {
+public protocol AdsGridViewDataSource: AnyObject {
     func numberOfItems(inAdsGridView adsGridView: AdsGridView) -> Int
     func adsGridView(_ adsGridView: AdsGridView, modelAtIndex index: Int) -> AdsGridViewModel
     func adsGridView(_ adsGridView: AdsGridView, loadImageForModel model: AdsGridViewModel, imageWidth: CGFloat, completion: @escaping ((AdsGridViewModel, UIImage?) -> Void))

--- a/Sources/Recycling/GridViews/Ads/GridView/AdsGridViewLayout.swift
+++ b/Sources/Recycling/GridViews/Ads/GridView/AdsGridViewLayout.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol AdsGridViewLayoutDelegate: class {
+protocol AdsGridViewLayoutDelegate: AnyObject {
     func adsGridViewLayout(_ adsGridViewLayout: AdsGridViewLayout, imageHeightRatioForItemAtIndexPath indexPath: IndexPath, inCollectionView collectionView: UICollectionView) -> CGFloat
     func adsGridViewLayout(_ adsGridViewLayout: AdsGridViewLayout, itemNonImageHeightForItemAtIndexPath indexPath: IndexPath, inCollectionView collectionView: UICollectionView) -> CGFloat
     func adsGridViewLayout(_ adsGridViewLayout: AdsGridViewLayout, heightForHeaderViewInCollectionView collectionView: UICollectionView) -> CGFloat?

--- a/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
+++ b/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
@@ -4,11 +4,11 @@
 
 import UIKit
 
-public protocol MarketsGridViewDelegate: class {
+public protocol MarketsGridViewDelegate: AnyObject {
     func marketsGridView(_ marketsGridView: MarketsGridView, didSelectItemAtIndex index: Int)
 }
 
-public protocol MarketsGridViewDataSource: class {
+public protocol MarketsGridViewDataSource: AnyObject {
     func numberOfItems(inMarketsGridView marketsGridView: MarketsGridView) -> Int
     func marketsGridView(_ marketsGridView: MarketsGridView, modelAtIndex index: Int) -> MarketsGridViewModel
 }

--- a/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementButtonAndInformationCell.swift
+++ b/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementButtonAndInformationCell.swift
@@ -2,7 +2,7 @@
 //  Copyright © FINN.no AS. All rights reserved.
 //
 
-public protocol UserAdManagementButtonAndInformationCellDelegate: class {
+public protocol UserAdManagementButtonAndInformationCellDelegate: AnyObject {
     func buttonAndInformationCellButtonWasTapped(_ sender: UserAdManagementButtonAndInformationCell)
 }
 

--- a/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementUserActionCell.swift
+++ b/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementUserActionCell.swift
@@ -217,6 +217,6 @@ public class UserAdManagementUserActionCell: UITableViewCell {
     }
 }
 
-public protocol UserAdManagementActionCellDelegate: class {
+public protocol UserAdManagementActionCellDelegate: AnyObject {
     func userAdManagementActionCell(_ cell: UserAdManagementUserActionCell, switchChangedState switchIsOn: Bool)
 }

--- a/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
+++ b/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol FavoritesListViewCellDataSource: class {
+public protocol FavoritesListViewCellDataSource: AnyObject {
     func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
     func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, cancelLoadingImageForModel model: FavoritesListViewModel, imageWidth: CGFloat)
 }

--- a/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
+++ b/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
@@ -4,13 +4,13 @@
 
 import UIKit
 
-public protocol FavoritesListViewDelegate: class {
+public protocol FavoritesListViewDelegate: AnyObject {
     func favoritesListView(_ favoritesListView: FavoritesListView, didSelectItemAtIndex index: Int)
     func favoritesListView(_ favoritesListView: FavoritesListView, willDisplayItemAtIndex index: Int)
     func favoritesListView(_ favoritesListView: FavoritesListView, didScrollInScrollView scrollView: UIScrollView)
 }
 
-public protocol FavoritesListViewDataSource: class {
+public protocol FavoritesListViewDataSource: AnyObject {
     func numberOfItems(inFavoritesListView favoritesListView: FavoritesListView) -> Int
     func favoritesListView(_ favoritesListView: FavoritesListView, modelAtIndex index: Int) -> FavoritesListViewModel
     func favoritesListView(_ favoritesListView: FavoritesListView, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))

--- a/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
+++ b/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol NotificationsListViewCellDataSource: class {
+public protocol NotificationsListViewCellDataSource: AnyObject {
     func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
     func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, cancelLoadingImageForModel model: NotificationsListViewModel, imageWidth: CGFloat)
 }

--- a/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListFooterView.swift
+++ b/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListFooterView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol NotificationsListFooterViewDelegate: class {
+protocol NotificationsListFooterViewDelegate: AnyObject {
     func notificationsListFooterView(_ notificationsListFooterView: NotificationsListFooterView, didSelectFooterViewAtSection section: Int)
 }
 

--- a/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListHeaderView.swift
+++ b/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListHeaderView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol NotificationsListHeaderViewDelegate: class {
+protocol NotificationsListHeaderViewDelegate: AnyObject {
     func notificationsListHeaderView(_ notificationsListHeaderView: NotificationsListHeaderView, didSelectHeaderViewAtSection section: Int)
 }
 

--- a/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
+++ b/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol NotificationsListViewDelegate: class {
+public protocol NotificationsListViewDelegate: AnyObject {
     func notificationsListView(_ notificationsListView: NotificationsListView, didSelectItemAtIndexPath indexPath: IndexPath)
     func notificationsListView(_ notificationsListView: NotificationsListView, willDisplayItemAtIndexPath indexPath: IndexPath)
     func notificationsListView(_ notificationsListView: NotificationsListView, didScrollInScrollView scrollView: UIScrollView)
@@ -12,7 +12,7 @@ public protocol NotificationsListViewDelegate: class {
     func notificationsListView(_ notificationsListView: NotificationsListView, didSelectFooterAtSection section: Int)
 }
 
-public protocol NotificationsListViewDataSource: class {
+public protocol NotificationsListViewDataSource: AnyObject {
     func numberOfSections(inNotificationsListView notificationsListView: NotificationsListView) -> Int
     func notificationsListView(_ notificationsListView: NotificationsListView, numberOfItemsInSection section: Int) -> Int
     func notificationsListView(_ notificationsListView: NotificationsListView, groupModelAtSection section: Int) -> NotificationsGroupListViewModel

--- a/Sources/Recycling/ListViews/SavedSearches/Cell/SavedSearchesListViewCell.swift
+++ b/Sources/Recycling/ListViews/SavedSearches/Cell/SavedSearchesListViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@objc protocol SavedSearchesListViewCellDelegate: class {
+@objc protocol SavedSearchesListViewCellDelegate: AnyObject {
     func savedSearchesListViewCell(_ savedSearchesListViewCell: SavedSearchesListViewCell, didPressSettingsButton button: UIButton)
 }
 

--- a/Sources/Recycling/ListViews/SavedSearches/ListView/SavedSearchesListView.swift
+++ b/Sources/Recycling/ListViews/SavedSearches/ListView/SavedSearchesListView.swift
@@ -4,11 +4,11 @@
 
 import UIKit
 
-public protocol SavedSearchesListViewDelegate: class {
+public protocol SavedSearchesListViewDelegate: AnyObject {
     func savedSearchesListView(_ savedSearchesListView: SavedSearchesListView, didSelectItemAtIndex index: Int)
 }
 
-public protocol SavedSearchesListViewDataSource: class {
+public protocol SavedSearchesListViewDataSource: AnyObject {
     func numberOfItems(inSavedSearchesListView savedSearchesListView: SavedSearchesListView) -> Int
     func savedSearchesListView(_ savedSearchesListView: SavedSearchesListView, modelAtIndex index: Int) -> SavedSearchesListViewModel
 }

--- a/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
+++ b/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
@@ -3,13 +3,13 @@
 //
 import UIKit
 
-public protocol SettingsViewDataSource: class {
+public protocol SettingsViewDataSource: AnyObject {
     func numberOfSections(in settingsView: SettingsView) -> Int
     func settingsView(_ settingsView: SettingsView, numberOfRowsInSection section: Int) -> Int
     func settingsView(_ settingsView: SettingsView, modelForItemAt indexPath: IndexPath) -> SettingsViewCellModel
 }
 
-public protocol SettingsViewDelegate: class {
+public protocol SettingsViewDelegate: AnyObject {
     func settingsView(_ settingsView: SettingsView, titleForHeaderInSection section: Int) -> String?
     func settingsView(_ settingsView: SettingsView, didSelectRowAt indexPath: IndexPath)
 }

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
@@ -18,7 +18,7 @@ public enum UserAdStatus: String {
     case unknown = "Venter på status"
 }
 
-public protocol UserAdsListViewCellDataSource: class {
+public protocol UserAdsListViewCellDataSource: AnyObject {
     func userAdsListViewCellShouldDisplayAsInactive(_ userAdsListViewCell: UserAdsListViewCell) -> Bool
     func userAdsListViewCell(_ userAdsListViewCell: UserAdsListViewCell, loadImageForModel model: UserAdsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
     func userAdsListViewCell(_ userAdsListViewCell: UserAdsListViewCell, cancelLoadingImageForModel model: UserAdsListViewModel, imageWidth: CGFloat)

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewNewAdCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewNewAdCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol UserAdsListViewNewAdCellDelegate: class {
+public protocol UserAdsListViewNewAdCellDelegate: AnyObject {
     func userAdsListViewNewAdCell(_ userAdsListViewNewAdCell: UserAdsListViewNewAdCell, didTapCreateNewAdButton button: Button)
 }
 

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewSeeAllAdsCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewSeeAllAdsCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol UserAdsListViewSeeAllAdsCellDelegate: class {
+public protocol UserAdsListViewSeeAllAdsCellDelegate: AnyObject {
     func userAdsListViewSeeAllAdsCell(_ userAdsListViewSeeAllAdsCell: UserAdsListViewSeeAllAdsCell, didTapSeeAllAdsButton button: Button)
 }
 

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListHeaderView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListHeaderView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol UserAdsListHeaderViewDelegate: class {
+public protocol UserAdsListHeaderViewDelegate: AnyObject {
     func userAdsListHeaderView(_ userAdsListHeaderView: UserAdsListHeaderView, didTapSeeMoreButton button: Button)
 }
 

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol UserAdsListViewDelegate: class {
+public protocol UserAdsListViewDelegate: AnyObject {
     func userAdsListViewDidStartRefreshing(_ userAdsListView: UserAdsListView)
     func userAdsListView(_ userAdsListView: UserAdsListView, userAdsListHeaderView: UserAdsListHeaderView, didTapSeeMoreButton button: Button)
     func userAdsListView(_ userAdsListView: UserAdsListView, didTapCreateNewAdButton button: Button)
@@ -15,7 +15,7 @@ public protocol UserAdsListViewDelegate: class {
     func userAdsListView(_ userAdsListView: UserAdsListView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]?
 }
 
-public protocol UserAdsListViewDataSource: class {
+public protocol UserAdsListViewDataSource: AnyObject {
     func numberOfSections(in userAdsListView: UserAdsListView) -> Int
     func userAdsListView(_ userAdsListView: UserAdsListView, shouldDisplayInactiveSectionAt indexPath: IndexPath) -> Bool
     func userAdsListView(_ userAdsListView: UserAdsListView, numberOfRowsInSection section: Int) -> Int


### PR DESCRIPTION
# Why?

To improve consistency with the already agreed convention of using AnyObject instead of class for protocols.

# What?

Refactors FinniversKit to use AnyObject.

# Show me

Nothing to show.