### PR TITLE
Enabled scrolling in the MessageFormView's TextView

### DIFF
--- a/Sources/Fullscreen/MessageForm/MessageFormView.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormView.swift
@@ -15,6 +15,7 @@ class MessageFormView: UIView {
     private lazy var textView: TextView = {
         let textView = TextView(withAutoLayout: true)
         textView.delegate = self
+        textView.isScrollEnabled = true
         return textView
     }()
 


### PR DESCRIPTION
# Why?

As a user so eloquently put it, _"[...] Kan ikke en gang bla nedover og oppover i skrivefeltet lengre!  [...]"_

I didn't realize the `TextView` wasn't scrollable by default. On iPhone SE, the TextView currently only displays 5 lines of text, while iPhone 7/8 can hold 10.