### PR TITLE
Renamed MessageFormBottomSheet's dismiss method

### DIFF
--- a/Demo/Fullscreen/MessageForm/MessageFormDemoPresenter.swift
+++ b/Demo/Fullscreen/MessageForm/MessageFormDemoPresenter.swift
@@ -9,7 +9,7 @@ class MessageFormDemoPresenter {
 }
 
 extension MessageFormDemoPresenter: MessageFormBottomSheetDelegate {
-    func messageFormBottomSheetDidCancel(_ form: MessageFormBottomSheet) { }
+    func messageFormBottomSheetDidDismiss(_ form: MessageFormBottomSheet) { }
 
     func messageFormBottomSheet(_ form: MessageFormBottomSheet, didFinishWithText text: String, templateState: MessageFormTemplateState, template: MessageFormTemplate?) {
         var templateString = ""

--- a/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
@@ -5,11 +5,14 @@
 import Foundation
 
 public protocol MessageFormBottomSheetDelegate: AnyObject {
-    func messageFormBottomSheetDidCancel(_ form: MessageFormBottomSheet)
+    /// Called when the "send"-button was tapped
     func messageFormBottomSheet(_ form: MessageFormBottomSheet,
                                 didFinishWithText text: String,
                                 templateState: MessageFormTemplateState,
                                 template: MessageFormTemplate?)
+
+    /// Called after the MessageFormBottomSheet disappeared from view
+    func messageFormBottomSheetDidDismiss(_ form: MessageFormBottomSheet)
 }
 
 public class MessageFormBottomSheet: BottomSheet {
@@ -105,7 +108,7 @@ extension MessageFormBottomSheet: BottomSheetDelegate {
     }
 
     public func bottomSheet(_ bottomSheet: BottomSheet, didDismissBy action: BottomSheet.DismissAction) {
-        messageFormDelegate?.messageFormBottomSheetDidCancel(self)
+        messageFormDelegate?.messageFormBottomSheetDidDismiss(self)
     }
 }
 


### PR DESCRIPTION
# Why?

The name was quite misleading, as the delegate method was called even when the Message Form was dismissed successfully. As such, it's been renamed to `messageFormBottomSheetDidDismiss(...)`.