### PR TITLE
Removal of observer not needed

### DIFF
--- a/Demo/Fullscreen/AdReporter/AdReporterDemoView.swift
+++ b/Demo/Fullscreen/AdReporter/AdReporterDemoView.swift
@@ -31,10 +31,6 @@ public class AdReporterDemoView: UIView {
         setupSubviews()
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     private func setupSubviews() {
         addSubview(adReporterView)
         NSLayoutConstraint.activate([

--- a/Sources/Fullscreen/Login/LoginView.swift
+++ b/Sources/Fullscreen/Login/LoginView.swift
@@ -173,10 +173,6 @@ public class LoginView: UIView {
 
     // MARK: - Setup
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -225,7 +221,6 @@ public class LoginView: UIView {
     fileprivate func adjustKeyboardDown() {
         scrollView.contentInset = .zero
         scrollView.contentOffset = CGPoint(x: 0, y: 0)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     private func setup() {

--- a/Sources/Fullscreen/Register/RegisterView.swift
+++ b/Sources/Fullscreen/Register/RegisterView.swift
@@ -154,10 +154,6 @@ public class RegisterView: UIView {
 
     // MARK: - Setup
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -206,7 +202,6 @@ public class RegisterView: UIView {
     fileprivate func adjustKeyboardDown() {
         scrollView.contentInset = .zero
         scrollView.contentOffset = CGPoint(x: 0, y: 0)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     private func setup() {

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersEmptyView.swift
@@ -67,10 +67,6 @@ class FavoriteFoldersEmptyView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     // MARK: - Setup
 
     private func setup() {


### PR DESCRIPTION
# Why?

Starting iOS 9 removal of observers is not needed.

# What?

Removes the removal of observers.

# Show me

Nothing to show.