### PR TITLE
Fix: gesture recognizers

### DIFF
--- a/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
+++ b/Demo/Components/BottomSheet/BottomSheetMechanicsDemoViewController.swift
@@ -186,7 +186,6 @@ class BottomSheetMechanicsDemoViewController: UIViewController {
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap))
         tapGesture.numberOfTapsRequired = 2
-        tapGesture.numberOfTouchesRequired = 2
         view.addGestureRecognizer(tapGesture)
     }
 

--- a/Sources/Fullscreen/FullscreenGallery/FullscreenImageView.swift
+++ b/Sources/Fullscreen/FullscreenGallery/FullscreenImageView.swift
@@ -30,7 +30,6 @@ class FullscreenImageView: UIScrollView {
     private lazy var doubleTapRecognizer: UITapGestureRecognizer = {
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(onDoubleTap))
         recognizer.numberOfTapsRequired = 2
-        recognizer.numberOfTouchesRequired = 1
         return recognizer
     }()
 


### PR DESCRIPTION
# Why?

Small refactors.

# What?

- `numberOfTouchesRequired` is 1 by default
- Making `numberOfTouchesRequired` 2 blocks the dismissal of the component, making it 1 again makes it work

# Show me

Nothing to show.