### PR TITLE
Fix: FavoriteAdCell touch area for more button

### DIFF
--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
@@ -126,7 +126,7 @@ public class FavoriteAdTableViewCell: UITableViewCell {
 
             moreButton.widthAnchor.constraint(equalToConstant: 40),
             moreButton.heightAnchor.constraint(equalToConstant: 44),
-            moreButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumSpacing),
+            moreButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             moreButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),

--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
@@ -52,6 +52,7 @@ public class FavoriteAdTableViewCell: UITableViewCell {
         button.imageView?.contentMode = .scaleAspectFit
         button.tintColor = .stone
         button.addTarget(self, action: #selector(moreButtonTapped), for: .touchUpInside)
+        button.contentEdgeInsets = UIEdgeInsets(vertical: 10, horizontal: 8)
         return button
     }()
 
@@ -123,14 +124,14 @@ public class FavoriteAdTableViewCell: UITableViewCell {
             statusRibbon.topAnchor.constraint(equalTo: contentView.topAnchor, constant: .mediumSpacing),
             statusRibbon.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumSpacing),
 
-            moreButton.widthAnchor.constraint(equalToConstant: 24),
-            moreButton.heightAnchor.constraint(equalToConstant: 24),
+            moreButton.widthAnchor.constraint(equalToConstant: 40),
+            moreButton.heightAnchor.constraint(equalToConstant: 44),
             moreButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.mediumSpacing),
             moreButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
             stackView.leadingAnchor.constraint(equalTo: remoteImageView.trailingAnchor, constant: .mediumLargeSpacing),
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: moreButton.leadingAnchor, constant: -.mediumSpacing),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: moreButton.leadingAnchor),
             stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -24),
 
             addressLabel.trailingAnchor.constraint(lessThanOrEqualTo: statusRibbon.leadingAnchor, constant: -.mediumSpacing)


### PR DESCRIPTION
# Why?
As I mentioned in the last comment in #487 I noticed the touchable area for the more button was only 24x24pts.

I've set the content inset for the button and removed some constraint constants so we keep the spacing between elements as in the design spec. The touchable area is now 40x44pts.

# What?
- Change touchable area for button from 24x24pts to 40x44pts.

# Show me

| Before | After |
| --- | --- |
| ![Screenshot 2019-07-30 at 15 00 33](https://user-images.githubusercontent.com/1901556/62131300-364b5780-b2db-11e9-8eb0-e65c4389d398.png) | ![Screenshot 2019-07-30 at 14 59 15](https://user-images.githubusercontent.com/1901556/62131308-3ba8a200-b2db-11e9-9e41-230d976f0860.png) |