### PR TITLE
Favorite folders: hide checkmarks during cell transition from the edit mode

### DIFF
--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -136,8 +136,7 @@ public class FavoriteFoldersListView: UIView {
         let indices = indices.filter({ $0 >= 0 && $0 < tableView(tableView, numberOfRowsInSection: section) })
         let indexPaths = indices.map({ IndexPath(row: $0, section: section) })
 
-        guard indexPaths.count > 0 else {
-            assertionFailure("Trying to delete cells at invalid index paths")
+        guard !indexPaths.isEmpty else {
             return
         }
 

--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -131,6 +131,19 @@ public class FavoriteFoldersListView: UIView {
         tableView.reloadRows(at: [indexPath], with: animation)
     }
 
+    public func deleteRows(at indices: [Int], with animation: UITableView.RowAnimation = .automatic) {
+        let section = Section.folders.rawValue
+        let indices = indices.filter({ $0 >= 0 && $0 < tableView(tableView, numberOfRowsInSection: section) })
+        let indexPaths = indices.map({ IndexPath(row: $0, section: section) })
+
+        guard indexPaths.count > 0 else {
+            assertionFailure("Trying to delete cells at invalid index paths")
+            return
+        }
+
+        tableView.deleteRows(at: indexPaths, with: animation)
+    }
+
     public func setEditing(_ editing: Bool) {
         guard tableView.isEditing != editing else {
             return

--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -34,6 +34,11 @@ public class FavoriteFoldersListView: UIView {
         case folders
     }
 
+    public struct UpdateContext {
+        public let tableView: UITableView
+        public let section: Int
+    }
+
     public static let estimatedRowHeight: CGFloat = 64.0
 
     // MARK: - Public properties
@@ -119,6 +124,11 @@ public class FavoriteFoldersListView: UIView {
         tableView.reloadData()
     }
 
+    /// Perform necessary updates using an instance of UITableView and folders section
+    public func performUpdates(using closure: (UpdateContext) -> Void) {
+        closure(UpdateContext(tableView: tableView, section: Section.folders.rawValue))
+    }
+
     public func reloadRow(at index: Int, with animation: UITableView.RowAnimation = .none) {
         let section = Section.folders.rawValue
 
@@ -129,18 +139,6 @@ public class FavoriteFoldersListView: UIView {
 
         let indexPath = IndexPath(row: index, section: section)
         tableView.reloadRows(at: [indexPath], with: animation)
-    }
-
-    public func deleteRows(at indices: [Int], with animation: UITableView.RowAnimation = .automatic) {
-        let section = Section.folders.rawValue
-        let indices = indices.filter({ $0 >= 0 && $0 < tableView(tableView, numberOfRowsInSection: section) })
-        let indexPaths = indices.map({ IndexPath(row: $0, section: section) })
-
-        guard !indexPaths.isEmpty else {
-            return
-        }
-
-        tableView.deleteRows(at: indexPaths, with: animation)
     }
 
     public func setEditing(_ editing: Bool) {

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
@@ -55,13 +55,18 @@ public class FavoriteFolderSelectableViewCell: RemoteImageTableViewCell {
         super.prepareForReuse()
 
         titleLabel.font = titleLabelDefaultFont
-        hideCheckmarks()
+        setCheckmarksHidden(true)
     }
 
     public override func willTransition(to state: UITableViewCell.StateMask) {
         super.willTransition(to: state)
         bringSubviewToFront(editModeView)
-        hideCheckmarks()
+        setCheckmarksHidden(true)
+    }
+
+    public override func didTransition(to state: UITableViewCell.StateMask) {
+        super.didTransition(to: state)
+        setCheckmarksHidden(state != .showingEditControl)
     }
 
     // MARK: - Public
@@ -117,9 +122,9 @@ public class FavoriteFolderSelectableViewCell: RemoteImageTableViewCell {
         rightCheckmarkView.isSelected = selected
     }
 
-    private func hideCheckmarks() {
-        leftCheckmarkView.isHidden = true
-        rightCheckmarkView.isHidden = true
+    private func setCheckmarksHidden(_ hidden: Bool) {
+        leftCheckmarkView.isHidden = hidden
+        rightCheckmarkView.isHidden = hidden
     }
 
     private func updateCheckmarks() {

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
@@ -55,13 +55,13 @@ public class FavoriteFolderSelectableViewCell: RemoteImageTableViewCell {
         super.prepareForReuse()
 
         titleLabel.font = titleLabelDefaultFont
-        leftCheckmarkView.isHidden = true
-        rightCheckmarkView.isHidden = true
+        hideCheckmarks()
     }
 
     public override func willTransition(to state: UITableViewCell.StateMask) {
         super.willTransition(to: state)
         bringSubviewToFront(editModeView)
+        hideCheckmarks()
     }
 
     // MARK: - Public
@@ -115,6 +115,11 @@ public class FavoriteFolderSelectableViewCell: RemoteImageTableViewCell {
     private func selectCheckmarks( _ selected: Bool) {
         leftCheckmarkView.isSelected = selected
         rightCheckmarkView.isSelected = selected
+    }
+
+    private func hideCheckmarks() {
+        leftCheckmarkView.isHidden = true
+        rightCheckmarkView.isHidden = true
     }
 
     private func updateCheckmarks() {


### PR DESCRIPTION
# Why?

Because checkmarks were visible during cell transition from the edit mode and it didn't look good.

# What?

- Hide checkmarks during cell transition from the edit mode. Now there is only nice "move" animation of the content view.

- Add a method to perform updates on table view directly. This might be useful in the app if we want to do diffing and perform batch updates accordingly.

# Show me

| Before | After |
| --- | --- |
| ![folders_edit_before](https://user-images.githubusercontent.com/10529867/62359699-9f1f1380-b517-11e9-9ae8-e62fea8f5508.gif) | ![folders_edit_after](https://user-images.githubusercontent.com/10529867/62359720-aba36c00-b517-11e9-92a3-e7c3d3c3048d.gif) |