### PR TITLE
Animate night mode transition

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
 
-        updateColors()
+        updateColors(animated: false)
         NotificationCenter.default.addObserver(self, selector: #selector(userInterfaceStyleDidChange(_:)), name: .didChangeUserInterfaceStyle, object: nil)
 
         return true
@@ -26,32 +26,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 private extension AppDelegate {
     @objc func userInterfaceStyleDidChange(_ userInterfaceStyle: UserInterfaceStyle) {
-        updateColors()
+        updateColors(animated: true)
     }
 
-    func updateColors() {
-        let separatorColor: UIColor
-        let barTintColor: UIColor
-        let tintColor: UIColor
-        let barStyle: UIBarStyle
-        switch State.currentUserInterfaceStyle {
-        case .light:
-            separatorColor = .sardine
-            barTintColor = .milk
-            tintColor = .primaryBlue
-            barStyle = .default
-        case .dark:
-            separatorColor = .midnightSectionSeparator
-            barTintColor = .midnightBackground
-            tintColor = .secondaryBlue
-            barStyle = .black
-        }
+    func updateColors(animated: Bool) {
+        UIView.animate(withDuration: animated ? 0.3 : 0) {
+            let separatorColor: UIColor
+            let barTintColor: UIColor
+            let tintColor: UIColor
+            let barStyle: UIBarStyle
+            switch State.currentUserInterfaceStyle {
+            case .light:
+                separatorColor = .sardine
+                barTintColor = .milk
+                tintColor = .primaryBlue
+                barStyle = .default
+            case .dark:
+                separatorColor = .midnightSectionSeparator
+                barTintColor = .midnightBackground
+                tintColor = .secondaryBlue
+                barStyle = .black
+            }
 
-        if let navigationController = window?.rootViewController as? UINavigationController {
-            setBottomBorderColor(navigationBar: navigationController.navigationBar, color: separatorColor, height: 0.5)
-            navigationController.navigationBar.barTintColor = barTintColor
-            navigationController.navigationBar.tintColor = tintColor
-            navigationController.navigationBar.barStyle = barStyle
+            if let navigationController = self.window?.rootViewController as? UINavigationController {
+                self.setBottomBorderColor(navigationBar: navigationController.navigationBar, color: separatorColor, height: 0.5)
+                navigationController.navigationBar.barTintColor = barTintColor
+                navigationController.navigationBar.tintColor = tintColor
+                navigationController.navigationBar.barStyle = barStyle
+                navigationController.navigationBar.layoutIfNeeded()
+            }
         }
     }
 

--- a/Demo/Demo/DemoViewsTableViewController.swift
+++ b/Demo/Demo/DemoViewsTableViewController.swift
@@ -46,7 +46,7 @@ class DemoViewsTableViewController: UITableViewController {
     }
 
     @objc private func userInterfaceStyleDidChange(_ userInterfaceStyle: UserInterfaceStyle) {
-        updateColors()
+        updateColors(animated: true)
         evaluateIndexAndValues()
         tableView.reloadData()
     }
@@ -57,7 +57,7 @@ class DemoViewsTableViewController: UITableViewController {
         tableView.separatorStyle = .none
         navigationItem.titleView = selectorTitleView
         selectorTitleView.title = Sections.title(for: State.lastSelectedSection).uppercased()
-        updateColors()
+        updateColors(animated: false)
     }
 
     private func updateMoonButton() {
@@ -69,23 +69,25 @@ class DemoViewsTableViewController: UITableViewController {
         NotificationCenter.default.post(name: .didChangeUserInterfaceStyle, object: nil)
     }
 
-    private func updateColors() {
-        let interfaceBackgroundColor: UIColor
-        let sectionIndexColor: UIColor
-        switch State.currentUserInterfaceStyle {
-        case .light:
-            interfaceBackgroundColor = .milk
-            sectionIndexColor = .primaryBlue
-        case .dark:
-            interfaceBackgroundColor = .midnightBackground
-            sectionIndexColor = .secondaryBlue
-        }
+    private func updateColors(animated: Bool) {
+        UIView.animate(withDuration: animated ? 0.3 : 0) {
+            let interfaceBackgroundColor: UIColor
+            let sectionIndexColor: UIColor
+            switch State.currentUserInterfaceStyle {
+            case .light:
+                interfaceBackgroundColor = .milk
+                sectionIndexColor = .primaryBlue
+            case .dark:
+                interfaceBackgroundColor = .midnightBackground
+                sectionIndexColor = .secondaryBlue
+            }
 
-        tableView.sectionIndexColor = sectionIndexColor
-        tableView.backgroundColor = interfaceBackgroundColor
-        selectorTitleView.updateColors()
-        updateMoonButton()
-        setNeedsStatusBarAppearanceUpdate()
+            self.tableView.sectionIndexColor = sectionIndexColor
+            self.tableView.backgroundColor = interfaceBackgroundColor
+            self.selectorTitleView.updateColors()
+            self.updateMoonButton()
+            self.setNeedsStatusBarAppearanceUpdate()
+        }
     }
 
     private func evaluateIndexAndValues() {


### PR DESCRIPTION
# Why?

Feels better to animate the transition instead of doing a hard switch.

# What?

Animated the night mode transition.

Note: There's a little jump in the navigation bar but besides that the fade in / fade out looks much better.

# Show me

| Before | After |
| --- | --- |
| ![night-old](https://user-images.githubusercontent.com/1088217/62410082-2d130100-b5e1-11e9-8303-102e136a1e8a.gif) | ![night](https://user-images.githubusercontent.com/1088217/62410078-26848980-b5e1-11e9-9345-6b3a6b901832.gif) |
