### PR TITLE
Bring colors from superview into bottom sheet

### DIFF
--- a/Demo/Tweakable/TweakingOptionsTableViewController.swift
+++ b/Demo/Tweakable/TweakingOptionsTableViewController.swift
@@ -51,6 +51,7 @@ class TweakingOptionsTableViewController: UIViewController {
         case .dark:
             interfaceBackgroundColor = .midnightBackground
         }
+        view.backgroundColor = interfaceBackgroundColor
         tableView.backgroundColor = interfaceBackgroundColor
     }
 }

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -142,7 +142,7 @@ public class BottomSheet: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = rootViewController.view.backgroundColor ?? .milk
         view.clipsToBounds = true
         if #available(iOS 11.0, *) {
             view.layer.cornerRadius = cornerRadius


### PR DESCRIPTION
# Why?

Because having the handle in a different color than the background looks ugly.

![](https://media.giphy.com/media/3kL1wTX4ACUoiECanf/giphy.gif)

# What?

Uses the color from the superview's background instead of defaulting to white.

# Show me

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone Xs - 2019-08-05 at 12 17 24](https://user-images.githubusercontent.com/1088217/62457507-4bacff80-b77b-11e9-95a5-d5102ed29683.png)| ![Simulator Screen Shot - iPhone Xs - 2019-08-05 at 12 13 37](https://user-images.githubusercontent.com/1088217/62457515-51a2e080-b77b-11e9-98c5-b589c99026e6.png) |
