### PR TITLE
Allow setting contentInset in SettingsView

### DIFF
--- a/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
+++ b/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
@@ -37,6 +37,15 @@ public class SettingsView: UIView {
     public weak var dataSource: SettingsViewDataSource?
     public weak var delegate: SettingsViewDelegate?
 
+    public var contentInset: UIEdgeInsets {
+        get {
+            return tableView.contentInset
+        }
+        set {
+            tableView.contentInset = newValue
+        }
+    }
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()


### PR DESCRIPTION
# Why?

The settings view is used both in the settings for logged in users and
the one for logged out users, in the latter, the design specifies a
different content inset than the default, reason why i exposed this
property as a computed one.

# What?

Expose `contentInset` property in `SettingsView`

# Show me

No UI changes, as the default it's maintained, with the possibility of setting a new value for the inset