### PR TITLE
AddressView: Make it possible to use an alert controller after "get directions"

### DIFF
--- a/Demo/Fullscreen/AddressView/AddressViewDemoView.swift
+++ b/Demo/Fullscreen/AddressView/AddressViewDemoView.swift
@@ -95,7 +95,7 @@ extension AddressViewDemoView: AddressViewDelegate {
         print("addressViewDidSelectCopyButton")
     }
 
-    public func addressViewDidSelectGetDirectionsButton(_ addressView: AddressView) {
+    public func addressViewDidSelectGetDirectionsButton(_ addressView: AddressView, sender: UIView) {
         print("addressViewDidSelectGetDirectionsButton")
     }
 

--- a/Sources/Fullscreen/AddressView/AddressCardView.swift
+++ b/Sources/Fullscreen/AddressView/AddressCardView.swift
@@ -7,7 +7,7 @@ import MapKit
 
 protocol AddressCardViewDelegate: AnyObject {
     func addressCardViewDidSelectCopyButton(_ addressCardView: AddressCardView)
-    func addressCardViewDidSelectGetDirectionsButton(_ addressCardView: AddressCardView)
+    func addressCardViewDidSelectGetDirectionsButton(_ addressCardView: AddressCardView, sender: UIView)
 }
 
 class AddressCardView: UIView {
@@ -106,7 +106,7 @@ extension AddressCardView {
     }
 
     @objc private func getDirectionsAction() {
-        delegate?.addressCardViewDidSelectGetDirectionsButton(self)
+        delegate?.addressCardViewDidSelectGetDirectionsButton(self, sender: getDirectionsButton)
     }
 
     @objc private func copyAction() {

--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -7,7 +7,7 @@ import MapKit
 
 public protocol AddressViewDelegate: AnyObject {
     func addressViewDidSelectCopyButton(_ addressView: AddressView)
-    func addressViewDidSelectGetDirectionsButton(_ addressView: AddressView)
+    func addressViewDidSelectGetDirectionsButton(_ addressView: AddressView, sender: UIView)
     func addressViewDidSelectCenterMapButton(_ addressView: AddressView)
     func addressView(_ addressView: AddressView, didSelectMapTypeAtIndex index: Int)
 }
@@ -204,8 +204,8 @@ extension AddressView: AddressCardViewDelegate {
         delegate?.addressViewDidSelectCopyButton(self)
     }
 
-    func addressCardViewDidSelectGetDirectionsButton(_ addressCardView: AddressCardView) {
-        delegate?.addressViewDidSelectGetDirectionsButton(self)
+    func addressCardViewDidSelectGetDirectionsButton(_ addressCardView: AddressCardView, sender: UIView) {
+        delegate?.addressViewDidSelectGetDirectionsButton(self, sender: sender)
     }
 }
 


### PR DESCRIPTION
# Why?
If we want to present an alert controller with different options on iPad we need to know which the source view was.

# What?
Adding a "sender: UIView" parameter to delegate for get directions action.
