### PR TITLE
Turning off rotate and pitch for address view

### DIFF
--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -52,6 +52,8 @@ public class AddressView: UIView {
 
     private lazy var mapView: MKMapView = {
         let view = MKMapView(withAutoLayout: true)
+        view.isRotateEnabled = false
+        view.isPitchEnabled = false
         view.delegate = self
         return view
     }()


### PR DESCRIPTION
# Why?
Noticed rotate and pitch was allowed in this view, but it isn't in any of our other map views.

# What?
Turning off rotate and pitch for address view. We would need to verify that this will actually work with our custom tiles first. Also UI might need an update since the compass that appears in map view is currently semi-covered.
