### PR TITLE
Add method to focus a MKMapRect and rename focusAnnotations for clarity

### DIFF
--- a/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
+++ b/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
@@ -113,7 +113,7 @@ public final class SearchResultMapView: UIView {
         mapView.showAnnotations(annotationsToShow, animated: animated)
     }
 
-    /// Set the visible region to a MKMapRect that fitts the passed region
+    /// Set the visible region to a MKMapRect that fits the passed region
     ///
     /// - Parameters:
     ///   - mapRect: MKMapRect to fit and focus

--- a/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
+++ b/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
@@ -105,9 +105,22 @@ public final class SearchResultMapView: UIView {
         mapView.removeAnnotations(mapView.annotations)
     }
 
-    public func focusAnnotations() {
+    /// Set the visible region so that the map focuses all annotations of the type SearchResultMapViewAnnotation
+    ///
+    /// - Parameter animated: optionaly present animated
+    public func focusVisibleAnnotations(_ animated: Bool) {
         let annotationsToShow = mapView.annotations.filter { $0 is SearchResultMapViewAnnotation }
-        mapView.showAnnotations(annotationsToShow, animated: true)
+        mapView.showAnnotations(annotationsToShow, animated: animated)
+    }
+
+    /// Set the visible region to a MKMapRect that fitts the passed region
+    ///
+    /// - Parameters:
+    ///   - mapRect: MKMapRect to fit and focus
+    ///   - animated: optinaly present animated
+    public func focusMapRect(_ mapRect: MKMapRect, animated: Bool) {
+        let fittedMapRect = mapView.mapRectThatFits(mapRect)
+        mapView.setVisibleMapRect(fittedMapRect, animated: animated)
     }
 
     // MARK: - Setup


### PR DESCRIPTION
# Why?

Needed a method to focus a specific `MKMapRect`, not only the visible annotations. 

# What?

Added a method `focusMapRect(mapRect: MKMapRect, animated: Bool)` to focus a specific `MKMapRect` and thus renamed `focusAnnotations` too `focusVisibleAnnotations` to avoid confusion. Also added documentation comments, as I felt these methods didn't explain them selfs clearly.

# Show me

No UI changes