### PR TITLE
Quick implementation for using semantic dynamic colors on iOS 13

### DIFF
--- a/Demo/Demo/DemoViewsTableViewController.swift
+++ b/Demo/Demo/DemoViewsTableViewController.swift
@@ -53,28 +53,28 @@ class DemoViewsTableViewController: UITableViewController {
     }
 
     private func updateMoonButton() {
-        if #available(iOS 13.0, *) {
-        } else {
-            guard FinniversKit.isDarkModeSupported else { return }
+        guard FinniversKit.isDarkModeSupported else { return }
 
-            let image: UIImage
-            switch UserInterfaceStyle(traitCollection: traitCollection) {
-            case .light:
-                image = UIImage(named: "emptyMoon")!
-            case .dark:
-                image = UIImage(named: "filledMoon")!
-            }
-            navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .done, target: self, action: #selector(moonTapped))
+        let image: UIImage
+        switch UserInterfaceStyle(traitCollection: traitCollection) {
+        case .light:
+            image = UIImage(named: "emptyMoon")!
+        case .dark:
+            image = UIImage(named: "filledMoon")!
         }
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .done, target: self, action: #selector(moonTapped))
     }
 
     // Moon is used to trigger dark mode in iOS 12 and bellow, in iOS 13 the moon is hidden.
     @objc private func moonTapped() {
         let newUserInterfaceStyle: UserInterfaceStyle = UserInterfaceStyle(traitCollection: traitCollection) == .light ? .dark : .light
-        UserInterfaceStyle.setCurrentUserInterfaceStyle(newUserInterfaceStyle)
+        UserInterfaceStyle.setCurrentUserInterfaceStyle(newUserInterfaceStyle, in: self.view.window)
 
-        let alertView = UIAlertController(title: "Updated style!", message: "Restart app to apply", preferredStyle: .alert)
-        present(alertView, animated: true, completion: nil)
+        if #available(iOS 13.0, *) {
+        } else {
+            let alertView = UIAlertController(title: "Updated style!", message: "Restart app to apply", preferredStyle: .alert)
+            present(alertView, animated: true, completion: nil)
+        }
     }
 
     private func updateColors(animated: Bool) {

--- a/Demo/Demo/DemoViewsTableViewController.swift
+++ b/Demo/Demo/DemoViewsTableViewController.swift
@@ -148,7 +148,7 @@ extension DemoViewsTableViewController {
         cell.textLabel?.font = .bodyRegular
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        cell.textLabel?.textColor = .primaryLabelColor
+        cell.textLabel?.textColor = .primaryLabelTextColor
         return cell
     }
 

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -224,10 +224,19 @@ extension CGColor {
     }
 }
 
-// MARK: - Semantic colors
-
+// MARK: - Semantic colors that will support dark and light mode
 @objc extension UIColor {
     public class var foregroundColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
+                switch traitCollection.userInterfaceStyle {
+                case .dark:
+                    return .charcoal
+                default:
+                    return .milk
+                }
+            })
+        }
         switch Theme.currentStyle {
         case .light: return .milk
         case .dark: return .charcoal
@@ -235,6 +244,16 @@ extension CGColor {
     }
 
     public class var foregroundTintColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
+                switch traitCollection.userInterfaceStyle {
+                case .dark:
+                    return .secondaryBlue
+                default:
+                    return .primaryBlue
+                }
+            })
+        }
         switch Theme.currentStyle {
         case .light: return .primaryBlue
         case .dark: return .secondaryBlue
@@ -242,13 +261,33 @@ extension CGColor {
     }
 
     public class var primaryLabelColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
+                switch traitCollection.userInterfaceStyle {
+                case .dark:
+                    return .milk
+                default:
+                    return .licorice
+                }
+            })
+        }
         switch Theme.currentStyle {
         case .light: return .licorice
         case .dark: return .milk
         }
     }
 
-    public class var secondaryLabelColor: UIColor {
+    public class var secondaryLabelTextColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
+                switch traitCollection.userInterfaceStyle {
+                case .dark:
+                    return .milk
+                default:
+                    return .licorice
+                }
+            })
+        }
         switch Theme.currentStyle {
         case .light: return .licorice
         case .dark: return .milk

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -227,70 +227,42 @@ extension CGColor {
 // MARK: - Semantic colors that will support dark and light mode
 @objc extension UIColor {
     public class var foregroundColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
-                switch traitCollection.userInterfaceStyle {
-                case .dark:
-                    return .charcoal
-                default:
-                    return .milk
-                }
-            })
-        }
-        switch Theme.currentStyle {
-        case .light: return .milk
-        case .dark: return .charcoal
-        }
+        return dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: .charcoal)
     }
 
     public class var foregroundTintColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
-                switch traitCollection.userInterfaceStyle {
-                case .dark:
-                    return .secondaryBlue
-                default:
-                    return .primaryBlue
-                }
-            })
-        }
-        switch Theme.currentStyle {
-        case .light: return .primaryBlue
-        case .dark: return .secondaryBlue
-        }
+        return dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: .secondaryBlue)
     }
 
     public class var primaryLabelColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
-                switch traitCollection.userInterfaceStyle {
-                case .dark:
-                    return .milk
-                default:
-                    return .licorice
-                }
-            })
-        }
-        switch Theme.currentStyle {
-        case .light: return .licorice
-        case .dark: return .milk
-        }
+        return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
     }
 
     public class var secondaryLabelTextColor: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
+    }
+
+
+}
+
+// MARK: - Private helper for creating dynamic color
+extension UIColor {
+    private class func dynamicColorIfAvailable(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
         if #available(iOS 13.0, *) {
+            #if swift(>=5.1)
             return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
                 switch traitCollection.userInterfaceStyle {
                 case .dark:
-                    return .milk
+                    return darkModeColor
                 default:
-                    return .licorice
+                    return defaultColor
                 }
             })
+            #endif
         }
         switch Theme.currentStyle {
-        case .light: return .licorice
-        case .dark: return .milk
+        case .light: return defaultColor
+        case .dark: return darkModeColor
         }
     }
 }

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -234,15 +234,13 @@ extension CGColor {
         return dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: .secondaryBlue)
     }
 
-    public class var primaryLabelColor: UIColor {
+    public class var primaryLabelTextColor: UIColor {
         return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
     }
 
     public class var secondaryLabelTextColor: UIColor {
         return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
     }
-
-
 }
 
 // MARK: - Private helper for creating dynamic color
@@ -250,14 +248,14 @@ extension UIColor {
     private class func dynamicColorIfAvailable(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
         if #available(iOS 13.0, *) {
             #if swift(>=5.1)
-            return UIColor(dynamicProvider: { (traitCollection) -> UIColor in
+            return UIColor { traitCollection -> UIColor in
                 switch traitCollection.userInterfaceStyle {
                 case .dark:
                     return darkModeColor
                 default:
                     return defaultColor
                 }
-            })
+            }
             #endif
         }
         switch Theme.currentStyle {

--- a/Sources/DNA/Color/UserInterfaceStyle.swift
+++ b/Sources/DNA/Color/UserInterfaceStyle.swift
@@ -24,8 +24,16 @@ public class Theme {
         }
     }
 
+    /// Needs to be called from main thread on iOS 13
     public static func setCurrentUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle) {
-        UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
-        UserDefaults.standard.synchronize()
+        if #available(iOS 13.0, *) {
+            // Untested, this might change mode live (but not remember the setting)
+            let uiUserInterfaceStyle: UIUserInterfaceStyle = userInterfaceStyle == .dark ? .dark : .light
+            let updatedTraits = UITraitCollection(traitsFrom: [UITraitCollection.current, UITraitCollection(userInterfaceStyle: uiUserInterfaceStyle)])
+            UITraitCollection.current = updatedTraits
+        } else {
+            UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
+            UserDefaults.standard.synchronize()
+        }
     }
 }

--- a/Sources/DNA/Color/UserInterfaceStyle.swift
+++ b/Sources/DNA/Color/UserInterfaceStyle.swift
@@ -27,13 +27,14 @@ public class Theme {
     /// Needs to be called from main thread on iOS 13
     public static func setCurrentUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle) {
         if #available(iOS 13.0, *) {
-            // Untested, this might change mode live (but not remember the setting)
+            #if swift(>=5.1)
+            // Untested, this might change mode live
             let uiUserInterfaceStyle: UIUserInterfaceStyle = userInterfaceStyle == .dark ? .dark : .light
             let updatedTraits = UITraitCollection(traitsFrom: [UITraitCollection.current, UITraitCollection(userInterfaceStyle: uiUserInterfaceStyle)])
             UITraitCollection.current = updatedTraits
-        } else {
-            UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
-            UserDefaults.standard.synchronize()
+            #endif
         }
+        UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
+        UserDefaults.standard.synchronize()
     }
 }

--- a/Sources/DNA/Color/UserInterfaceStyle.swift
+++ b/Sources/DNA/Color/UserInterfaceStyle.swift
@@ -25,13 +25,13 @@ public class Theme {
     }
 
     /// Needs to be called from main thread on iOS 13
-    public static func setCurrentUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle) {
+    public static func setCurrentUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle, in window: UIWindow?) {
         if #available(iOS 13.0, *) {
             #if swift(>=5.1)
-            // Untested, this might change mode live
             let uiUserInterfaceStyle: UIUserInterfaceStyle = userInterfaceStyle == .dark ? .dark : .light
             let updatedTraits = UITraitCollection(traitsFrom: [UITraitCollection.current, UITraitCollection(userInterfaceStyle: uiUserInterfaceStyle)])
             UITraitCollection.current = updatedTraits
+            window?.overrideUserInterfaceStyle = uiUserInterfaceStyle
             #endif
         }
         UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)

--- a/Sources/Fullscreen/AddressView/AddressCardView.swift
+++ b/Sources/Fullscreen/AddressView/AddressCardView.swift
@@ -104,7 +104,7 @@ extension AddressCardView {
 
         backgroundColor = .foregroundColor
         titleLabel.textColor = .primaryLabelColor
-        subtitleLabel.textColor = .secondaryLabelColor
+        subtitleLabel.textColor = .secondaryLabelTextColor
     }
 
     @objc private func getDirectionsAction() {

--- a/Sources/Fullscreen/AddressView/AddressCardView.swift
+++ b/Sources/Fullscreen/AddressView/AddressCardView.swift
@@ -103,7 +103,7 @@ extension AddressCardView {
             ])
 
         backgroundColor = .foregroundColor
-        titleLabel.textColor = .primaryLabelColor
+        titleLabel.textColor = .primaryLabelTextColor
         subtitleLabel.textColor = .secondaryLabelTextColor
     }
 


### PR DESCRIPTION
Note: This is not a PR to master, it is an example of how #517 might be improved.

# Why?
Wanted to try using `init(dynamicProvider: @escaping (UITraitCollection) -> UIColor)` to see if we could avoid listening to `traitCollectionDidChange` and still get our colors to change "live".

# What?
Changed implementation for iOS 13 to have dynamic colors based on dark/light mode. 

Only tested on iOS 13 too, so it might break everything else. And needs cleanup.

# Show me
![dark-demo](https://user-images.githubusercontent.com/3169203/62983040-5415d200-be2e-11e9-8a43-36aef94a5c72.gif)
