### PR TITLE
Fixed iPad crash when replacing message content with a template

### DIFF
--- a/Sources/Fullscreen/MessageForm/MessageFormViewController.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormViewController.swift
@@ -199,9 +199,10 @@ extension MessageFormViewController: MessageFormToolbarDelegate {
             messageFormView.text = template.text
             lastUsedTemplate = template
         } else {
+            let alertStyle: UIAlertController.Style = UIDevice.isIPad() ? .alert : .actionSheet
             let alertController = UIAlertController(title: viewModel.replaceAlertTitle,
                                                     message: viewModel.replaceAlertMessage,
-                                                    preferredStyle: .actionSheet)
+                                                    preferredStyle: alertStyle)
 
             let cancelAction = UIAlertAction(title: viewModel.replaceAlertCancelText, style: .cancel)
             let replaceAction = UIAlertAction(title: viewModel.replaceAlertActionText, style: .default, handler: { [weak self] _ in


### PR DESCRIPTION
# Why?

There's a crash on iPad when attempting to replace the contents of the message form input text view with a template because we were displaying the confirmation dialog as an action-sheet, but did not specify a source-rectangle.

# What?

Displaying the confirmation as `.alert` on iPad.

# Show me

<img width="807" alt="Screen Shot 2019-08-14 at 11 43 32" src="https://user-images.githubusercontent.com/919713/63012061-d54e8280-be89-11e9-8a34-4446fd3cdab9.png">
