### PR TITLE
Neighborhood profile: add new delegate method for scrolling events

### DIFF
--- a/Demo/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileDemoView.swift
+++ b/Demo/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileDemoView.swift
@@ -39,6 +39,14 @@ final class NeighborhoodProfileDemoView: UIView {
 // MARK: - NeighborhoodProfileViewDelegate
 
 extension NeighborhoodProfileDemoView: NeighborhoodProfileViewDelegate {
+    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView) {
+        print("Start")
+    }
+
+    func neighborhoodProfileViewDidScrollToEnd(_ view: NeighborhoodProfileView) {
+        print("End")
+    }
+
     func neighborhoodProfileView(_ view: NeighborhoodProfileView, didSelectUrl url: URL?) {
         print("\(String(describing: url)) selected")
     }

--- a/Demo/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileDemoView.swift
+++ b/Demo/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileDemoView.swift
@@ -39,12 +39,8 @@ final class NeighborhoodProfileDemoView: UIView {
 // MARK: - NeighborhoodProfileViewDelegate
 
 extension NeighborhoodProfileDemoView: NeighborhoodProfileViewDelegate {
-    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView) {
-        print("Start")
-    }
-
-    func neighborhoodProfileViewDidScrollToEnd(_ view: NeighborhoodProfileView) {
-        print("End")
+    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView, reachedEnd: Bool) {
+        print("Did scroll, reached end: \(reachedEnd)")
     }
 
     func neighborhoodProfileView(_ view: NeighborhoodProfileView, didSelectUrl url: URL?) {

--- a/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
@@ -6,8 +6,7 @@ import UIKit
 
 public protocol NeighborhoodProfileViewDelegate: AnyObject {
     func neighborhoodProfileView(_ view: NeighborhoodProfileView, didSelectUrl: URL?)
-    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView)
-    func neighborhoodProfileViewDidScrollToEnd(_ view: NeighborhoodProfileView)
+    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView, reachedEnd: Bool)
 }
 
 public final class NeighborhoodProfileView: UIView {
@@ -249,19 +248,18 @@ extension NeighborhoodProfileView: UICollectionViewDelegate {
         withVelocity velocity: CGPoint,
         targetContentOffset: UnsafeMutablePointer<CGPoint>
     ) {
-        let center = CGPoint(x: targetContentOffset.pointee.x + scrollView.frame.midX, y: scrollView.frame.midY)
+        let targetOffsetX = targetContentOffset.pointee.x
+        let center = CGPoint(x: targetOffsetX + scrollView.frame.midX, y: scrollView.frame.midY)
 
         if let indexPath = collectionView.indexPathForItem(at: center) {
             pageControl.currentPage = indexPath.row
         }
 
-        delegate?.neighborhoodProfileViewDidScroll(self)
+        //let isRightScrollDirection = scrollView.panGestureRecognizer.velocity(in: self).x < 0
+        let rightOffset = scrollView.horizontalRightOffset - .mediumLargeSpacing
+        let reachedEnd = targetOffsetX >= rightOffset// && isRightScrollDirection
 
-        if scrollView.panGestureRecognizer.translation(in: self).x < 0 {
-            if collectionView.indexPathsForVisibleItems.contains(IndexPath(item: viewModel.cards.count - 1, section: 0)) {
-                delegate?.neighborhoodProfileViewDidScrollToEnd(self)
-            }
-        }
+        delegate?.neighborhoodProfileViewDidScroll(self, reachedEnd: reachedEnd)
     }
 }
 
@@ -325,5 +323,11 @@ private final class PagingCollectionViewLayout: UICollectionViewFlowLayout {
 private extension UICollectionView {
     var verticalContentInsets: CGFloat {
         return contentInset.top + contentInset.bottom
+    }
+}
+
+private extension UIScrollView {
+    var horizontalRightOffset: CGFloat {
+        return contentSize.width - bounds.width
     }
 }

--- a/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
@@ -255,9 +255,8 @@ extension NeighborhoodProfileView: UICollectionViewDelegate {
             pageControl.currentPage = indexPath.row
         }
 
-        //let isRightScrollDirection = scrollView.panGestureRecognizer.velocity(in: self).x < 0
         let rightOffset = scrollView.horizontalRightOffset - .mediumLargeSpacing
-        let reachedEnd = targetOffsetX >= rightOffset// && isRightScrollDirection
+        let reachedEnd = targetOffsetX >= rightOffset
 
         delegate?.neighborhoodProfileViewDidScroll(self, reachedEnd: reachedEnd)
     }

--- a/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
@@ -6,6 +6,8 @@ import UIKit
 
 public protocol NeighborhoodProfileViewDelegate: AnyObject {
     func neighborhoodProfileView(_ view: NeighborhoodProfileView, didSelectUrl: URL?)
+    func neighborhoodProfileViewDidScroll(_ view: NeighborhoodProfileView)
+    func neighborhoodProfileViewDidScrollToEnd(_ view: NeighborhoodProfileView)
 }
 
 public final class NeighborhoodProfileView: UIView {
@@ -251,6 +253,14 @@ extension NeighborhoodProfileView: UICollectionViewDelegate {
 
         if let indexPath = collectionView.indexPathForItem(at: center) {
             pageControl.currentPage = indexPath.row
+        }
+
+        delegate?.neighborhoodProfileViewDidScroll(self)
+
+        if scrollView.panGestureRecognizer.translation(in: self).x < 0 {
+            if collectionView.indexPathsForVisibleItems.contains(IndexPath(item: viewModel.cards.count - 1, section: 0)) {
+                delegate?.neighborhoodProfileViewDidScrollToEnd(self)
+            }
         }
     }
 }


### PR DESCRIPTION
# Why?

Because we want to handle scrolling events in the iOS app.

# What?

Add new `neighborhoodProfileViewDidScroll(:reachedEnd)` method to notify the delegate when the user scrolled within the collection view and whether the end of the list was reached during scrolling.

# Show me

![iphone_scroll](https://user-images.githubusercontent.com/10529867/63017295-43994200-be96-11e9-9d34-149ba7120d8a.gif)

![ipad_scroll](https://user-images.githubusercontent.com/10529867/63017300-472cc900-be96-11e9-971c-af0e158a1d89.gif)