### PR TITLE
Favorite folders: show footer view on reload data only during search

### DIFF
--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -120,15 +120,13 @@ public class FavoriteFoldersListView: UIView {
     public func reloadData() {
         showEmptyViewIfNeeded()
 
-        if !tableView.isEditing {
+        if isSearchActive {
             UIView.animate(withDuration: 0.35, animations: { [weak self] in
                 guard let self = self else { return }
-                self.footerViewTop.constant = self.isSearchActive ? -self.footerHeight : 0
+                self.footerViewTop.constant = -self.footerHeight
                 self.layoutIfNeeded()
             })
-        }
 
-        if !refreshControl.isRefreshing && tableView.isEditing {
             tableView.setContentOffset(.zero, animated: false)
         }
 


### PR DESCRIPTION
# Why?

Because we don't want to change constraints of the footer view on every `reloadData`.

# What?

Show footer view on reload data only during search.

# Show me

No UI changes.