### PR TITLE
Integration with `pr_changelog`

### DIFF
--- a/.pr_changelog.json
+++ b/.pr_changelog.json
@@ -1,0 +1,3 @@
+{
+  "strategy": "squash"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem 'pr_changelog', '~> 0.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pr_changelog (0.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pr_changelog (~> 0.4.0)
+
+BUNDLED WITH
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ If the view isn't recyclable then we use ViewModels. There are tradeoffs when yo
 
 Our Demo project has been setup in a way that every component is isolated, we initally started by using Xcode's playgrounds but we quickly outgrew it's capacitiy, reloading times weren't quicker than making the change and running the project again, also it wasn't possible to debug and set breakpoint on things and we couldn't use many of Xcode's useful utilities such as View herarchy inspector. Finally, the fact that we had to rebuild the project after making any change in the framework meant that we weren't as efficient as using plain Xcode projects (where rebuilding isn't necesary after making a change).
 
+### Changelogs
+
+This project has a `Gemfile` that specify some development dependencies, one of those is `pr_changelog` which is a tool that helps you to generate changelogs from the Git history of the repo. You install this by running `bundle install`.
+
+To get the changes that have not been released yet just run:
+
+```
+$ pr_changelog
+```
+
+If you want to see what changes were released in the last version, run:
+
+```
+$ pr_changelog --last-release
+```
+
+You can always run the command with the `--help` flag when needed.
+
 ### Accessibility
 
 Everything we do we aim it to be accessible, our two main areas of focus have been VoiceOver and Dynamic Type.


### PR DESCRIPTION
# Why?

In order to effortlessly to create a list of changes from the merged PRs

# What?

- Add a `Gemfile` to the project and the gem `pr_changelog`
- Add README instructions for getting the changelog for FinniversKit
- I didn't add cocoapods to the Gemfile as we control the used version in the Finn app and for podspec purposes we don't need to specify the cocoapods version. Also in this way, we don't need to sync all the time the version specified in the Finn Gemfile and the finnivers one.

# Show me

At this point in time, the non released changes of FinniversKit are:

```
## Changes since 3.2.0 to master (squash)

- #531: Drop iOS 10
- #533: Favorite folders: add action sheet
```