### PR TITLE
Neighborhood profile: handle page control value changes

### DIFF
--- a/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
@@ -63,6 +63,7 @@ public final class NeighborhoodProfileView: UIView {
         let pageControl = UIPageControl(withAutoLayout: true)
         pageControl.pageIndicatorTintColor = UIColor.primaryBlue.withAlphaComponent(0.2)
         pageControl.currentPageIndicatorTintColor = .primaryBlue
+        pageControl.addTarget(self, action: #selector(handlePageControlValueChange), for: .valueChanged)
         return pageControl
     }()
 
@@ -206,6 +207,16 @@ public final class NeighborhoodProfileView: UIView {
         case let .button(content):
             return NeighborhoodProfileButtonViewCell.height(forContent: content, width: width)
         }
+    }
+
+    // MARK: - Actions
+
+    @objc private func handlePageControlValueChange() {
+        let indexPath = IndexPath(item: pageControl.currentPage, section: 0)
+        let reachedEnd = pageControl.currentPage == viewModel.cards.count - 1
+
+        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+        delegate?.neighborhoodProfileViewDidScroll(self, reachedEnd: reachedEnd)
     }
 }
 


### PR DESCRIPTION
# Why?

Because we had a bug when tapping on the page control didn't change the offset within the collection view.

# What?

Handle page control value changes and scroll to corresponding index path.

# Show me

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/10529867/63577944-c0f83d00-c58f-11e9-8f8c-837703e52225.gif) | ![after](https://user-images.githubusercontent.com/10529867/63577908-af169a00-c58f-11e9-9567-4615a03009df.gif) |





