### PR TITLE
Use closures for Toast actions

### DIFF
--- a/Demo/Components/Toast/ToastDemoView.swift
+++ b/Demo/Components/Toast/ToastDemoView.swift
@@ -4,16 +4,6 @@
 
 import FinniversKit
 
-class ToastClass: NSObject, ToastViewDelegate {
-    func didTapActionButton(button: UIButton, in toastView: ToastView) {
-        print("Button tapped \(toastView.style)")
-    }
-
-    func didTap(toastView: ToastView) {
-        print("Toast view tapped \(toastView.style)")
-    }
-}
-
 public class ToastDemoView: UIView {
     private lazy var bottomToastButton: Button = {
         let button = Button(style: .callToAction)
@@ -53,7 +43,6 @@ public class ToastDemoView: UIView {
     }
 
     public required init?(coder aDecoder: NSCoder) { fatalError() }
-    let delegate = ToastClass()
 
     private func setup() {
         let successToast = ToastView(style: .success)
@@ -74,23 +63,27 @@ public class ToastDemoView: UIView {
 
         let successButtonToast = ToastView(style: .successButton)
         successButtonToast.text = "Action success"
-        successButtonToast.buttonText = "Action"
-        successButtonToast.delegate = delegate
+        successButtonToast.action = ToastAction(title: "Action") {
+            print("Action button tapped")
+        }
 
         let errorButtonToast = ToastView(style: .errorButton)
         errorButtonToast.text = "Action error"
-        errorButtonToast.buttonText = "Undo"
-        errorButtonToast.delegate = delegate
+        errorButtonToast.action = ToastAction(title: "Undo") {
+            print("Undo button tapped")
+        }
 
         let successPromotedButtonToast = ToastView(style: .successButton, buttonStyle: .promoted)
         successPromotedButtonToast.text = "Action success"
-        successPromotedButtonToast.buttonText = "Action"
-        successPromotedButtonToast.delegate = delegate
+        successPromotedButtonToast.action = ToastAction(title: "Action") {
+            print("Promoted action button tapped")
+        }
 
         let errorPromotedButtonToast = ToastView(style: .errorButton, buttonStyle: .promoted)
         errorPromotedButtonToast.text = "Action error"
-        errorPromotedButtonToast.buttonText = "Undo"
-        errorPromotedButtonToast.delegate = delegate
+        errorPromotedButtonToast.action = ToastAction(title: "Undo") {
+            print("Promoted undo button tapped")
+        }
 
         stackView.addArrangedSubview(successToast)
         stackView.addArrangedSubview(attributedTextSuccessToast)
@@ -141,7 +134,6 @@ public class ToastDemoView: UIView {
     private func animateSuccess(in toastPresenterView: UIView) {
         let animatedToast = ToastView(style: .success)
         animatedToast.text = "Animated success"
-        animatedToast.delegate = delegate
         animatedToast.presentFromBottom(view: toastPresenterView, animateOffset: 0, timeOut: 5)
     }
 }

--- a/Sources/Components/Toast/ToastView.swift
+++ b/Sources/Components/Toast/ToastView.swift
@@ -89,6 +89,7 @@ public class ToastView: UIView {
     public var action: ToastAction? {
         didSet {
             actionButton.setTitle(action?.title, for: .normal)
+            accessibilityHint = action?.title
         }
     }
 
@@ -108,6 +109,9 @@ public class ToastView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
+        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(swipeAction))
+        swipeGesture.direction = .down
+        addGestureRecognizer(swipeGesture)
 
         backgroundColor = style.color
         imageView.backgroundColor = style.imageBackgroundColor
@@ -145,6 +149,10 @@ public class ToastView: UIView {
     }
 
     // MARK: - Actions
+
+    @objc private func swipeAction() {
+        dismissToast()
+    }
 
     @objc private func buttonAction() {
         action?.action()

--- a/Sources/Components/Toast/ToastView.swift
+++ b/Sources/Components/Toast/ToastView.swift
@@ -156,6 +156,7 @@ public class ToastView: UIView {
 
     @objc private func buttonAction() {
         action?.action()
+        dismissToast()
     }
 
     public func presentFromBottom(view: UIView, animateOffset: CGFloat, timeOut: Double? = nil) {

--- a/Sources/Components/Toast/ToastView.swift
+++ b/Sources/Components/Toast/ToastView.swift
@@ -4,23 +4,13 @@
 
 import UIKit
 
-public protocol ToastViewDelegate: AnyObject {
-    func didTapActionButton(button: UIButton, in toastView: ToastView)
-    func didTap(toastView: ToastView)
-    func didSwipeDown(on toastView: ToastView)
-}
+public class ToastAction: NSObject {
+    public private(set) var title: String
+    public private(set) var action: (() -> Void)
 
-public extension ToastViewDelegate {
-    func didTapActionButton(button: UIButton, in toastView: ToastView) {
-        // Default nothing happens
-    }
-
-    func didTap(toastView: ToastView) {
-        // Default nothing happens
-    }
-
-    func didSwipeDown(on toastView: ToastView) {
-        toastView.dismissToast()
+    public init(title: String, action: @escaping (() -> Void)) {
+        self.title = title
+        self.action = action
     }
 }
 
@@ -96,13 +86,11 @@ public class ToastView: UIView {
         }
     }
 
-    public var buttonText: String = "" {
+    public var action: ToastAction? {
         didSet {
-            actionButton.setTitle(buttonText, for: .normal)
+            actionButton.setTitle(action?.title, for: .normal)
         }
     }
-
-    public weak var delegate: ToastViewDelegate?
 
     // MARK: - Setup
 
@@ -120,10 +108,6 @@ public class ToastView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapAction))
-        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(swipeAction))
-        swipeGesture.direction = .down
-        gestureRecognizers = [tapGesture, swipeGesture]
 
         backgroundColor = style.color
         imageView.backgroundColor = style.imageBackgroundColor
@@ -163,15 +147,7 @@ public class ToastView: UIView {
     // MARK: - Actions
 
     @objc private func buttonAction() {
-        delegate?.didTapActionButton(button: actionButton, in: self)
-    }
-
-    @objc private func tapAction() {
-        delegate?.didTap(toastView: self)
-    }
-
-    @objc private func swipeAction() {
-        delegate?.didSwipeDown(on: self)
+        action?.action()
     }
 
     public func presentFromBottom(view: UIView, animateOffset: CGFloat, timeOut: Double? = nil) {


### PR DESCRIPTION
# Why?

Dealing with actions in our current toasts is quite cumbersome, at the moment we are using delegates which gives resembles the old UIAlertView way of doing things.

# What?

This PR makes use of ToastAction which resembles the UIAlertController way of doing things. This makes actions easier to implement since the action is where the toast is created.

# Show me

#### Before

```swift
let successButtonToast = ToastView(style: .successButton)
successButtonToast.buttonText = "Action success"
successButtonToast.delegate = ToastClass()

class ToastClass: NSObject, ToastViewDelegate {
    func didTap(toastView: ToastView) {
        print("Toast view tapped \(toastView.style)")
    }
}
```

#### After

```swift
let successButtonToast = ToastView(style: .successButton)
successButtonToast.text = "Action success"
successButtonToast.action = ToastAction(title: "Action") {
    print("Action button tapped")
}
```