### PR TITLE
Fix: Install Bundler dependencies locally

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "bundler"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ FinniversKit.framework.zip
 # Snapshot tests
 FailureDiffs/
 
+# Bundler
+bin/
+bundler/


### PR DESCRIPTION
# Why?
Bundler defaults to install depencies globally. For our workflow, and to not install things globally, I believe it's better to keep versions installed locally within the `FinniversKit` folder.

# What?
- Install bundler depencies locally to `[FinniversKit folder]/.bundler`.
- Add folders `.bundler/` and `bin/` to `.gitignore`.
  - The latter is where binstubs would be installed.

# Show me
_No UI._