### PR TITLE
Support hiding the description on IdentityView

### DIFF
--- a/Demo/Components/Profile/IdentityDemoView.swift
+++ b/Demo/Components/Profile/IdentityDemoView.swift
@@ -8,7 +8,7 @@ class IdentityDemoView: UIView, Tweakable {
 
     // MARK: - UI properties
 
-    private var identityViews: [(IdentityView, IdentityViewModel)] = []
+    private var identityViews: [(IdentityView,ViewModel)] = []
 
     // MARK: - Private properties
 
@@ -22,6 +22,18 @@ class IdentityDemoView: UIView, Tweakable {
             }),
             TweakingOption(title: "Toggle descriptions", action: {
                 self.identityViews.forEach { $0.0.hideDescription.toggle() }
+            }),
+            TweakingOption(title: "Use profile image from memory", action: {
+                self.identityViews.forEach {
+                    $0.1.profileImage = UIImage(named: .ratingCat)
+                    $0.0.viewModel = $0.1
+                }
+            }),
+            TweakingOption(title: "Use profile image from URL", action: {
+                self.identityViews.forEach {
+                    $0.1.profileImage = nil
+                    $0.0.viewModel = $0.1
+                }
             })
         ]
         return options
@@ -65,15 +77,6 @@ class IdentityDemoView: UIView, Tweakable {
             nextAnchor = view.bottomAnchor
         }
     }
-
-    // MARK: - Private methods
-
-    private func identityView(withDescription desc: String?, tappable: Bool, verified: Bool) -> UIView {
-        let view = IdentityView(viewModel: ViewModel(description: desc, isTappable: tappable, isVerified: verified))
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.delegate = self
-        return view
-    }
 }
 
 extension IdentityDemoView: IdentityViewDelegate {
@@ -100,12 +103,20 @@ extension IdentityDemoView: IdentityViewDelegate {
 
 // MARK: - View model
 
-private struct ViewModel: IdentityViewModel {
+fileprivate class ViewModel: IdentityViewModel {
+    var profileImage: UIImage? = nil
     let profileImageUrl: URL? = URL(string: "https://images.finncdn.no/dynamic/220x220c/2019/7/profilbilde/05/8/214/710/286/8_352525950.jpg")
+
     let displayName: String = "Finn Nordmann"
     let subtitle: String = "Har vært på FINN siden 1952"
 
     let description: String?
     let isTappable: Bool
     let isVerified: Bool
+
+    init(description: String?, isTappable: Bool, isVerified: Bool) {
+        self.description = description
+        self.isTappable = isTappable
+        self.isVerified = isVerified
+    }
 }

--- a/Demo/Components/Profile/IdentityDemoView.swift
+++ b/Demo/Components/Profile/IdentityDemoView.swift
@@ -20,6 +20,9 @@ class IdentityDemoView: UIView, Tweakable {
             TweakingOption(title: "Assign view models", action: {
                 self.identityViews.forEach { $0.0.viewModel = $0.1 }
             }),
+            TweakingOption(title: "Toggle descriptions", action: {
+                self.identityViews.forEach { $0.0.hideDescription.toggle() }
+            })
         ]
         return options
     }()

--- a/Sources/Components/Profile/IdentityView.swift
+++ b/Sources/Components/Profile/IdentityView.swift
@@ -209,7 +209,10 @@ public class IdentityView: UIView {
             return
         }
 
-        guard let url = viewModel?.profileImageUrl else { return }
+        guard let url = viewModel?.profileImageUrl else {
+            profileImageView.image = defaultProfileImage
+            return
+        }
 
         delegate?.identityView(self, loadImageWithUrl: url, completionHandler: { [weak self] image in
             guard let self = self else { return }

--- a/Sources/Components/Profile/IdentityView.swift
+++ b/Sources/Components/Profile/IdentityView.swift
@@ -36,6 +36,12 @@ public class IdentityView: UIView {
         }
     }
 
+    public var hideDescription: Bool = false {
+        didSet {
+            viewModelChanged()
+        }
+    }
+
     // MARK: - UI properties
 
     private let profileImageSize: CGFloat = 40.0
@@ -183,7 +189,7 @@ public class IdentityView: UIView {
 
         subtitleLabel.text = viewModel.subtitle
 
-        let showDescription = viewModel.description != nil
+        let showDescription = viewModel.description != nil && !hideDescription
         descriptionLabel.isHidden = !showDescription
         descriptionLabel.text = viewModel.description
         descriptionLabelConstraints.forEach { $0.isActive = showDescription }

--- a/Sources/Components/Profile/IdentityView.swift
+++ b/Sources/Components/Profile/IdentityView.swift
@@ -5,7 +5,13 @@
 import UIKit
 
 public protocol IdentityViewModel {
+    /// If defined, `profileImage` will take precedense over the image located at `profileImageUrl`.
+    var profileImage: UIImage? { get }
+
+    /// If `profileImage` is not defined, the `delegate` will be queried to download the image
+    /// located at this URL.
     var profileImageUrl: URL? { get }
+
     var displayName: String { get }
     var subtitle: String { get }
     var description: String? { get }
@@ -44,12 +50,12 @@ public class IdentityView: UIView {
 
     // MARK: - UI properties
 
-    private let profileImageSize: CGFloat = 40.0
+    public static let profileImageSize: CGFloat = 40.0
     private lazy var defaultProfileImage = UIImage(named: FinniversImageAsset.avatar)
 
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
-        imageView.layer.cornerRadius = profileImageSize / 2
+        imageView.layer.cornerRadius = IdentityView.profileImageSize / 2
         imageView.layer.masksToBounds = true
         return imageView
     }()
@@ -122,8 +128,8 @@ public class IdentityView: UIView {
             profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
             profileImageView.topAnchor.constraint(equalTo: topAnchor, constant: .mediumLargeSpacing),
             profileImageView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -.mediumLargeSpacing),
-            profileImageView.widthAnchor.constraint(equalToConstant: profileImageSize),
-            profileImageView.heightAnchor.constraint(equalToConstant: profileImageSize),
+            profileImageView.widthAnchor.constraint(equalToConstant: IdentityView.profileImageSize),
+            profileImageView.heightAnchor.constraint(equalToConstant: IdentityView.profileImageSize),
 
             profileNameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: .mediumSpacing),
             profileNameLabel.topAnchor.constraint(equalTo: profileImageView.topAnchor),
@@ -198,6 +204,11 @@ public class IdentityView: UIView {
     // MARK: - Private methods
 
     private func loadProfileImage() {
+        if let profileImage = viewModel?.profileImage {
+            profileImageView.image = profileImage
+            return
+        }
+
         guard let url = viewModel?.profileImageUrl else { return }
 
         delegate?.identityView(self, loadImageWithUrl: url, completionHandler: { [weak self] image in


### PR DESCRIPTION
# UPDATE

I also need the option to override the profile image directly from an `UIImage`-instance, so I added a field `profileImage: UIImage?` to the `IdentityViewModel`. If present, the `IdentityView` will not trigger a network call when setting up the profile image.

# Why?

I forgot about this detail — whether or not we should show the profile description should be configurable to make the existing view easier to replace. The existing implementation supports it in this way.

<img width="487" alt="Screen Shot 2019-08-29 at 11 30 35" src="https://user-images.githubusercontent.com/919713/63928893-bb4b9d00-ca50-11e9-83d9-f3c8ac3914b0.png">