### PR TITLE
Bumped podspec

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '6.1.0'
+  s.version      = '6.1.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'


### PR DESCRIPTION
# Why?

I'm trying to tie together a bunch of knots in integrating the `IdentityView` _(and upcoming `ReputationView`)_, and would like to use a non-local version of FinniversKit in doing so.

The only diff from 6.1.0 is #552.