### PR TITLE
Fix SwiftLint warnings

### DIFF
--- a/Demo/Components/Profile/IdentityDemoView.swift
+++ b/Demo/Components/Profile/IdentityDemoView.swift
@@ -8,7 +8,7 @@ class IdentityDemoView: UIView, Tweakable {
 
     // MARK: - UI properties
 
-    private var identityViews: [(IdentityView,ViewModel)] = []
+    private var identityViews: [(IdentityView, ViewModel)] = []
 
     // MARK: - Private properties
 
@@ -103,8 +103,8 @@ extension IdentityDemoView: IdentityViewDelegate {
 
 // MARK: - View model
 
-fileprivate class ViewModel: IdentityViewModel {
-    var profileImage: UIImage? = nil
+private class ViewModel: IdentityViewModel {
+    var profileImage: UIImage?
     let profileImageUrl: URL? = URL(string: "https://images.finncdn.no/dynamic/220x220c/2019/7/profilbilde/05/8/214/710/286/8_352525950.jpg")
 
     let displayName: String = "Finn Nordmann"

--- a/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
+++ b/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoView.swift
@@ -58,11 +58,11 @@ extension UserAdsListViewDemoView: UserAdsListViewDelegate {
     func userAdsListViewEmphasizedActionWasTapped(_ userAdsListView: UserAdsListView) {
         emphasizedActionHasBeenCollapsed = true
     }
-    
+
     func userAdsListViewEmphasizedActionWasCancelled(_ userAdsListView: UserAdsListView) {
         emphasizedActionHasBeenCollapsed = true
     }
-    
+
     func userAdsListView(_ userAdsListView: UserAdsListView, didTapCreateNewAdButton button: Button) {}
     func userAdsListView(_ userAdsListView: UserAdsListView, userAdsListHeaderView: UserAdsListHeaderView, didTapSeeMoreButton button: Button) {}
     func userAdsListView(_ userAdsListView: UserAdsListView, didTapSeeAllAdsButton button: Button) {}
@@ -76,7 +76,7 @@ extension UserAdsListViewDemoView: UserAdsListViewDataSource {
     func sectionNumberForEmphasizedAction(in userAdsListView: UserAdsListView) -> Int? {
         return 1
     }
-    
+
     func userAdsListView(_ userAdsListView: UserAdsListView, shouldDisplayInactiveSectionAt indexPath: IndexPath) -> Bool {
         return false
     }

--- a/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoViewHelpers.swift
+++ b/Demo/Recycling/ListViews/UserAds/UserAdsListViewDemoViewHelpers.swift
@@ -35,7 +35,7 @@ public struct UserAdCell: UserAdsListViewModel {
     }
 
     public init(imagePath: String? = nil, imageSize: CGSize = CGSize(width: 0, height: 0),
-                title: String = "", price: String? = nil, detail: String = "", status: String = "", actionModel: UserAdsListActionModel? = nil)  {
+                title: String = "", price: String? = nil, detail: String = "", status: String = "", actionModel: UserAdsListActionModel? = nil) {
         self.imagePath = imagePath
         self.imageSize = imageSize
         self.title = title
@@ -74,7 +74,7 @@ public struct UserAdsFactory {
         let ads: [UserAdCell] =  [UserAdCell(title: "Lag ny annonse")]
         return (header: header, ads: ads)
     }
-    
+
     private static func createEmphasizedAds() -> (header: UserAdHeaderCell, ads: [UserAdCell]) {
         let imageSource = imageSources[0]
         let action = UserAdCellAction(title: "Her går det unna!", description: "Nå er det mange som selger Rancho Cuccamonga! For 89 kr kan du løfte annonsen din øverst i resultatlista, akkurat som da den var ny", buttonTitle: "Løft annonsen", cancelButtonTitle: "Nei takk!")

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
@@ -10,31 +10,30 @@ public protocol UserAdsListEmphasizedActionCellDelegate: class {
     func userAdsListEmphasizedActionCell(_ cell: UserAdsListEmphasizedActionCell, cancelButtonWasTapped: Button)
 }
 
-
 public class UserAdsListEmphasizedActionCell: UITableViewCell {
     // MARK: - External properties
-    
+
     /// The loading color is used to fill the image view while we load the image.
-    
+
     public var loadingColor: UIColor?
-    
+
     /// A data source for the loading of the image
-    
+
     public weak var dataSource: UserAdsListViewCellDataSource?
-    
+
     public weak var delegate: UserAdsListEmphasizedActionCellDelegate?
 
     /// Informs the cell whether it should display the available action or not
     public var shouldShowAction = true
-    
+
     // MARK: - Internal properties
-    
+
     private static let cornerRadius: CGFloat = 12
     private static let imageSize: CGFloat = 104
     private let defaultImage = UIImage(named: .noImage)
-    
+
     private lazy var userAdStatus: UserAdStatus = .unknown
-    
+
     private lazy var adImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -43,7 +42,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()
-    
+
     private lazy var titleLabel: Label = {
         let label = Label(style: .bodyStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -51,7 +50,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
         label.backgroundColor = .clear
         return label
     }()
-    
+
     private lazy var priceLabel: Label? = {
         let label = Label(style: .detailStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -59,7 +58,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
-    
+
     private lazy var detailLabel: Label = {
         let label = Label(style: .detail)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -68,121 +67,121 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
-    
+
     private lazy var ribbonView: RibbonView? = nil
-    
+
     private lazy var adWrapperView: UIView = {
         let view = UIView(withAutoLayout: true)
         view.backgroundColor = .milk
         view.layer.cornerRadius = UserAdsListEmphasizedActionCell.cornerRadius
         return view
     }()
-    
+
     private lazy var actionWrapper: UIView = {
         let view = UIView(withAutoLayout: true)
         view.backgroundColor = .clear
         view.clipsToBounds = true
         return view
     }()
-    
+
     private lazy var actionTitleLabel: Label = {
         let label = Label(style: .bodyStrong)
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-    
+
     private lazy var actionDescriptionLabel: Label = {
         let label = Label(style: .caption)
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-    
+
     private lazy var button: Button = {
         let button = Button(style: .default, size: .small)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
         return button
     }()
-    
+
     private lazy var cancelButton: Button = {
         let button = Button(style: .default, size: .small)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(cancelButtonTapped(_:)), for: .touchUpInside)
         return button
     }()
-    
+
     private var actionWrapperHideConstraint = NSLayoutConstraint()
     private var actionWrapperHeightConstraint = NSLayoutConstraint()
-    
+
     // MARK: - Setup
-    
+
     private func setupView() {
         isAccessibilityElement = true
         contentView.backgroundColor = .marble
         accessoryType = .none
         selectionStyle = .none
         separatorInset = UIEdgeInsets(top: 0, left: (UserAdsListEmphasizedActionCell.imageSize + .mediumSpacing), bottom: 0, right: 0)
-        
+
         contentView.addSubview(adWrapperView)
         adWrapperView.addSubview(adImageView)
         adWrapperView.addSubview(titleLabel)
         adWrapperView.addSubview(detailLabel)
-        
+
         contentView.addSubview(actionWrapper)
         actionWrapper.addSubview(actionTitleLabel)
         actionWrapper.addSubview(actionDescriptionLabel)
         actionWrapper.addSubview(button)
-        actionWrapperHideConstraint = NSLayoutConstraint(item: actionWrapper, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant:0)
+        actionWrapperHideConstraint = NSLayoutConstraint(item: actionWrapper, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 0)
         actionWrapperHeightConstraint = NSLayoutConstraint(item: actionWrapper, attribute: .bottomMargin, relatedBy: .equal, toItem: button, attribute: .bottomMargin, multiplier: 1, constant: .largeSpacing)
 
         NSLayoutConstraint.activate([
             contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 120),
             contentView.bottomAnchor.constraint(greaterThanOrEqualTo: actionWrapper.bottomAnchor),
-            
+
             adWrapperView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: .mediumLargeSpacing),
             adWrapperView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             adWrapperView.widthAnchor.constraint(equalTo: contentView.widthAnchor, constant: -.largeSpacing),
             adWrapperView.heightAnchor.constraint(greaterThanOrEqualToConstant: 120),
-            
+
             adImageView.heightAnchor.constraint(equalToConstant: UserAdsListEmphasizedActionCell.imageSize),
             adImageView.widthAnchor.constraint(equalToConstant: UserAdsListEmphasizedActionCell.imageSize),
             adImageView.topAnchor.constraint(equalTo: adWrapperView.topAnchor, constant: .mediumSpacing),
             adImageView.leadingAnchor.constraint(equalTo: adWrapperView.leadingAnchor, constant: .mediumSpacing),
-            
+
             titleLabel.topAnchor.constraint(equalTo: adImageView.topAnchor, constant: -.mediumSpacing),
             titleLabel.bottomAnchor.constraint(equalTo: (ribbonView?.topAnchor ?? detailLabel.topAnchor), constant: -.smallSpacing),
             titleLabel.leadingAnchor.constraint(equalTo: adImageView.trailingAnchor, constant: .mediumSpacing),
             titleLabel.trailingAnchor.constraint(equalTo: adWrapperView.trailingAnchor),
-            
+
             detailLabel.leadingAnchor.constraint(equalTo: adImageView.trailingAnchor, constant: .mediumSpacing),
-            
+
             actionWrapper.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             actionWrapper.topAnchor.constraint(equalTo: adWrapperView.bottomAnchor, constant: .mediumLargeSpacing),
             actionWrapper.widthAnchor.constraint(equalTo: contentView.widthAnchor),
-            
+
             actionTitleLabel.leadingAnchor.constraint(equalTo: actionWrapper.leadingAnchor, constant: .mediumLargeSpacing),
             actionTitleLabel.trailingAnchor.constraint(equalTo: actionWrapper.trailingAnchor, constant: -.mediumLargeSpacing),
             actionTitleLabel.topAnchor.constraint(equalTo: actionWrapper.topAnchor),
-            
+
             actionDescriptionLabel.leadingAnchor.constraint(equalTo: actionWrapper.leadingAnchor, constant: .mediumLargeSpacing),
             actionDescriptionLabel.trailingAnchor.constraint(equalTo: actionWrapper.trailingAnchor, constant: -.mediumLargeSpacing),
             actionDescriptionLabel.topAnchor.constraint(equalTo: actionTitleLabel.bottomAnchor, constant: .mediumSpacing),
-            
+
             button.leadingAnchor.constraint(equalTo: actionWrapper.leadingAnchor, constant: .mediumLargeSpacing),
             button.topAnchor.constraint(equalTo: actionDescriptionLabel.bottomAnchor, constant: 24)
             ])
-        
+
         if shouldShowAction {
             actionWrapperHeightConstraint.isActive = true
         } else {
             actionWrapperHideConstraint.isActive = true
         }
-        
+
         // If price is not provided
         // then the detailLabel should be centered with the ribbonView
-        
+
         if model?.price == nil {
             NSLayoutConstraint.activate([
                 detailLabel.centerYAnchor.constraint(equalTo: (ribbonView?.centerYAnchor ?? centerYAnchor)),
@@ -195,12 +194,12 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
                 priceLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
                 priceLabel.leadingAnchor.constraint(equalTo: adImageView.trailingAnchor, constant: .mediumSpacing),
                 priceLabel.trailingAnchor.constraint(lessThanOrEqualTo: ribbonView?.leadingAnchor ?? trailingAnchor, constant: -.mediumSpacing),
-                
+
                 detailLabel.topAnchor.constraint(equalTo: (ribbonView?.bottomAnchor ?? titleLabel.bottomAnchor), constant: .smallSpacing),
                 detailLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
                 ])
         }
-        
+
         if model?.actionModel?.cancelButtonTitle != nil {
             actionWrapper.addSubview(cancelButton)
             NSLayoutConstraint.activate([
@@ -209,7 +208,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
                 ])
         }
     }
-    
+
     private func teardownView() {
         adImageView.removeFromSuperview()
         titleLabel.removeFromSuperview()
@@ -217,35 +216,35 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
         ribbonView?.removeFromSuperview()
         detailLabel.removeFromSuperview()
     }
-    
+
     private func setupRibbonView(with status: UserAdStatus) {
         ribbonView?.removeFromSuperview()
         switch status {
         // Draft ad states
         case .draft, .denied: ribbonView = RibbonView(style: .warning, with: status.rawValue)
         case .awaitingPayment: ribbonView = RibbonView(style: .warning, with: status.rawValue)
-            
+
         // Active ad states
         case .active: ribbonView = RibbonView(style: .success, with: status.rawValue)
         case .control: ribbonView = RibbonView(style: .success, with: status.rawValue)
-            
+
         // Inactive ad states
         case .deactive, .dateExpiry: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .expired: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .inactive: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         case .sold: ribbonView = RibbonView(style: .warning, with: status.rawValue)
-            
+
         // Edge case - the provided status is not supported in the UserAdStatus enum
         case .unknown: ribbonView = RibbonView(style: .disabled, with: status.rawValue)
         }
-        
+
         if let ribbon = ribbonView {
             ribbon.translatesAutoresizingMaskIntoConstraints = false
-            
+
             ribbon.setContentCompressionResistancePriority(.required, for: .horizontal)
             ribbon.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
             ribbon.setContentHuggingPriority(.fittingSizeLevel, for: .vertical)
-            
+
             adWrapperView.addSubview(ribbon)
             NSLayoutConstraint.activate([
                 ribbon.trailingAnchor.constraint(equalTo: adWrapperView.trailingAnchor, constant: -.mediumSpacing),
@@ -253,67 +252,67 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
                 ])
         }
     }
-    
+
     // MARK: - Superclass Overrides
-    
+
     public override func prepareForReuse() {
         super.prepareForReuse()
         teardownView()
-        
+
         let unusedCell = UserAdsListViewCell()
-        
+
         if let model = model {
             dataSource?.userAdsListViewCell(unusedCell, cancelLoadingImageForModel: model, imageWidth: adImageView.frame.size.width)
         }
     }
-    
+
     // MARK: - Dependency injection
-    
+
     public var model: UserAdsListViewModel? {
         didSet {
             guard let model = model else { return }
             teardownView()
-            
+
             titleLabel.text = model.title
             priceLabel?.text = model.price
             detailLabel.text = model.detail
             userAdStatus = UserAdStatus(rawValue: model.status) ?? .unknown
             accessibilityLabel = model.accessibilityLabel
-            
+
             actionTitleLabel.text = model.actionModel?.title
             actionDescriptionLabel.text = model.actionModel?.description
             button.setTitle(model.actionModel?.buttonTitle, for: .normal)
             cancelButton.setTitle(model.actionModel?.cancelButtonTitle, for: .normal)
-            
+
             setupRibbonView(with: userAdStatus)
             setupView()
         }
     }
-    
+
     // MARK: - Public
     /// Loads a given image provided that the imagePath in the `model` is valid.
-    
+
     private func loadImage(_ model: UserAdsListViewModel) {
         guard let dataSource = dataSource, model.imagePath != nil else {
             loadingColor = .clear
             adImageView.image = defaultImage
             return
         }
-        
+
         adImageView.backgroundColor = loadingColor
-           
+
         let unusedCell = UserAdsListViewCell()
         dataSource.userAdsListViewCell(unusedCell, loadImageForModel: model, imageWidth: frame.size.width) { [weak self] image in
             self?.adImageView.backgroundColor = .clear
             self?.adImageView.image = image ?? self?.defaultImage
         }
- 
+
     }
-    
+
     @objc private func buttonTapped(_ sender: Button) {
         delegate?.userAdsListEmphasizedActionCell(self, buttonWasTapped: sender)
     }
-    
+
     @objc private func cancelButtonTapped(_ sender: Button) {
         delegate?.userAdsListEmphasizedActionCell(self, cancelButtonWasTapped: sender)
     }

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
@@ -30,7 +30,7 @@ public protocol ImageLoading {
 
 public class UserAdsListViewCell: UITableViewCell {
     // MARK: - External properties
-    
+
     /// The loading color is used to fill the image view while we load the image.
 
     public var loadingColor: UIColor?

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
@@ -221,7 +221,7 @@ extension UserAdsListView: UITableViewDataSource {
 
                 return cell
             }
-            
+
             let cell = tableView.dequeue(UserAdsListViewCell.self, for: indexPath)
             cell.loadingColor = color
             cell.dataSource = self
@@ -298,7 +298,7 @@ extension UserAdsListView: UserAdsListEmphasizedActionCellDelegate {
         delegate?.userAdsListViewEmphasizedActionWasTapped(self)
         tableView.reloadSections(IndexSet(integer: emphasizedSection), with: .automatic)
     }
-    
+
     public func userAdsListEmphasizedActionCell(_ cell: UserAdsListEmphasizedActionCell, cancelButtonWasTapped: Button) {
         guard let emphasizedSection = dataSource?.sectionNumberForEmphasizedAction(in: self) else { return }
         delegate?.userAdsListViewEmphasizedActionWasCancelled(self)


### PR DESCRIPTION
# Why?

Because there were a lot of warnings after building the project, especially "Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)".

# What?

Fixed all `SwiftLint` warnings. 

**N.B. Since we have enabled linting rules for the project, it would be nice if everyone has `SwiftLint` installed on their machines, so the warnings annoy everyone 😄**

# Show me

No UI changes.