### PR TITLE
New favorites: add a method to get cached image

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -123,6 +123,12 @@ public class FavoriteAdsListView: UIView {
         tableView.setContentOffset(.zero, animated: false)
         tableView.reloadData()
     }
+
+    // MARK: - Images
+
+    public func cachedImage(forPath path: String) -> UIImage? {
+        return imageCache.image(forKey: path)
+    }
 }
 
 // MARK: - UITableViewDelegate


### PR DESCRIPTION
# Why?

In order to reuse already downloaded ad image in the action bottom sheet.

# What?

 Add a method to get cached image from `FavoriteAdsListView`

# Show me

No UI changes.