### PR TITLE
New favorites: send comment text back to delegate

### DIFF
--- a/Demo/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheetDemoDelegate.swift
+++ b/Demo/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheetDemoDelegate.swift
@@ -15,7 +15,8 @@ extension FavoriteAdCommentSheetDemoDelegate: FavoriteAdCommentSheetDelegate {
         sheet.state = .dismissed
     }
 
-    func favoriteAdCommentSheet(_ sheet: FavoriteAdCommentSheet, didSelectSaveWithText text: String?) {
+    func favoriteAdCommentSheet(_ sheet: FavoriteAdCommentSheet, didSelectSaveComment comment: String?) {
+        print(comment ?? "")
         sheet.state = .dismissed
     }
 }

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '6.5.0'
+  s.version      = '6.6.0'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public protocol FavoriteAdCommentSheetDelegate: AnyObject {
     func favoriteAdCommentSheetDidSelectCancel(_ sheet: FavoriteAdCommentSheet)
-    func favoriteAdCommentSheet(_ sheet: FavoriteAdCommentSheet, didSelectSaveWithText text: String?)
+    func favoriteAdCommentSheet(_ sheet: FavoriteAdCommentSheet, didSelectSaveComment comment: String?)
 }
 
 public final class FavoriteAdCommentSheet: BottomSheet {
@@ -41,8 +41,11 @@ extension FavoriteAdCommentSheet: FavoriteAdCommentViewControllerDelegate {
         commentDelegate?.favoriteAdCommentSheetDidSelectCancel(self)
     }
 
-    func favoriteAdCommentViewController(_ viewController: FavoriteAdCommentViewController, didSelectSaveWithText text: String?) {
-        commentDelegate?.favoriteAdCommentSheet(self, didSelectSaveWithText: text)
+    func favoriteAdCommentViewController(
+        _ viewController: FavoriteAdCommentViewController,
+        didSelectSaveComment comment: String?
+    ) {
+        commentDelegate?.favoriteAdCommentSheet(self, didSelectSaveComment: comment)
     }
 }
 

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
@@ -6,7 +6,10 @@ import UIKit
 
 protocol FavoriteAdCommentViewControllerDelegate: AnyObject {
     func favoriteAdCommentViewControllerDidSelectCancel(_ viewController: FavoriteAdCommentViewController)
-    func favoriteAdCommentViewController(_ viewController: FavoriteAdCommentViewController, didSelectSaveWithText text: String?)
+    func favoriteAdCommentViewController(
+        _ viewController: FavoriteAdCommentViewController,
+        didSelectSaveComment comment: String?
+    )
 }
 
 final class FavoriteAdCommentViewController: UIViewController {
@@ -188,7 +191,7 @@ final class FavoriteAdCommentViewController: UIViewController {
     }
 
     @objc private func handleSaveButtonTap() {
-        delegate?.favoriteAdCommentViewController(self, didSelectSaveWithText: "")
+        delegate?.favoriteAdCommentViewController(self, didSelectSaveComment: textView.text)
     }
 }
 


### PR DESCRIPTION
# Why?

We've been always sending empty string back to the delegate, which is obviously wrong 🤦‍♂ 

# What?

Send comment text back to `FavoriteAdCommentSheetDelegate`.

# Show me

No UI changes.