### PR TITLE
Assert missing snapshot tests

### DIFF
--- a/Demo/Demo/Demo.swift
+++ b/Demo/Demo/Demo.swift
@@ -42,7 +42,7 @@ public enum ComponentViews: String, CaseIterable {
     case inlineConsent
     case inlineConsentV2
     case consentTransparencyInfo
-    case bannerTransparency
+    case bannerTransparencyView
     case checkbox
     case radioButton
     case roundedImageView
@@ -54,10 +54,10 @@ public enum ComponentViews: String, CaseIterable {
     case bottomSheetMechanics
     case feedbackView
     case happinessRating
-    case earthHour
-    case klimabrolet
-    case stepIndicator
-    case nativeAdvert
+    case earthHourView
+    case klimabroletView
+    case stepIndicatorView
+    case nativeAdverts
     case callout
     case phaseList
     case iconCollection
@@ -108,7 +108,7 @@ public enum ComponentViews: String, CaseIterable {
             return InlineConsentDemoViewController()
         case .consentTransparencyInfo:
             return DemoViewController<ConsentTransparencyInfoDemoView>()
-        case .bannerTransparency:
+        case .bannerTransparencyView:
             return DemoViewController<BannerTransparencyDemoView>()
         case .checkbox:
             return DemoViewController<CheckboxDemoView>(withDismissButton: true)
@@ -134,13 +134,13 @@ public enum ComponentViews: String, CaseIterable {
             return DemoViewController<FeedbackDemoView>(withDismissButton: true)
         case .happinessRating:
             return DemoViewController<HappinessRatingDemoView>(withDismissButton: true)
-        case .earthHour:
+        case .earthHourView:
             return DemoViewController<EarthHourDemoView>()
-        case .klimabrolet:
+        case .klimabroletView:
             return KlimabroletDemoViewController(usingDoubleTapToDismiss: false)
-        case .stepIndicator:
+        case .stepIndicatorView:
             return DemoViewController<StepIndicatorDemoView>(withDismissButton: true)
-        case .nativeAdvert:
+        case .nativeAdverts:
             return DemoViewController<NativeAdvertDemoView>(withDismissButton: true)
         case .callout:
             return DemoViewController<CalloutDemoView>()
@@ -276,9 +276,9 @@ public enum FullscreenViews: String, CaseIterable {
     case consentToggleView
     case consentActionView
     case loadingView
-    case drumMachine
-    case piano
-    case snowGlobe
+    case drumMachineView
+    case pianoView
+    case snowGlobeView
     case soldView
     case confirmationView
     case fullscreenGallery
@@ -323,11 +323,11 @@ public enum FullscreenViews: String, CaseIterable {
             return DemoViewController<ConsentActionViewDemoView>()
         case .loadingView:
             return DemoViewController<LoadingViewDemoView>()
-        case .drumMachine:
+        case .drumMachineView:
             return DemoViewController<DrumMachineDemoView>()
-        case .piano:
+        case .pianoView:
             return DemoViewController<PianoDemoView>(supportedInterfaceOrientations: .landscape)
-        case .snowGlobe:
+        case .snowGlobeView:
             return DemoViewController<SnowGlobeDemoView>()
         case .soldView:
             return DemoViewController<SoldViewDemoView>()

--- a/Demo/Demo/DemoHelpers.swift
+++ b/Demo/Demo/DemoHelpers.swift
@@ -44,7 +44,7 @@ public struct ContainmentOptions: OptionSet {
                 return nil
             }
             switch screens {
-            case .bannerTransparency:
+            case .bannerTransparencyView:
                 self = .bottomSheet
             case .saveSearchView:
                 self = [.bottomSheet, .navigationController]

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		CFE43E50219B150D00D3D5F7 /* FrontPageViewDefaultData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE43E4D219B149100D3D5F7 /* FrontPageViewDefaultData.swift */; };
 		CFE43E52219B1B2900D3D5F7 /* FrontPageRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE43E51219B1B2900D3D5F7 /* FrontPageRetryView.swift */; };
 		CFEB220F232B96550039421C /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB220E232B96550039421C /* UIBarButtonItemExtensions.swift */; };
+		CFEB2221232BD9240039421C /* FBSnapshotTestsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB2220232BD9240039421C /* FBSnapshotTestsExtensions.swift */; };
 		CFF9727121C3BA1D00C85238 /* BannerTransparencySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726E21C3BA1D00C85238 /* BannerTransparencySectionView.swift */; };
 		CFF9727221C3BA1D00C85238 /* BannerTransparencyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726F21C3BA1D00C85238 /* BannerTransparencyView.swift */; };
 		CFF9727321C3BA2200C85238 /* BannerTransparencyDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726D21C3BA1D00C85238 /* BannerTransparencyDemoView.swift */; };
@@ -826,8 +827,8 @@
 		9BEB287E231D488000D28BAD /* TitleValueSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleValueSliderView.swift; sourceTree = "<group>"; };
 		9BEB2880231D489F00D28BAD /* LoanApplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoanApplyView.swift; sourceTree = "<group>"; };
 		9BEB2904231E4A9500D28BAD /* IntegerNumberSuffixFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerNumberSuffixFormatter.swift; sourceTree = "<group>"; };
-		9F21314635A3AEFBA402B9DC /* IdentityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityView.swift; sourceTree = "<group>"; };
 		9F213007EA6F0918FE24A530 /* ReputationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReputationView.swift; sourceTree = "<group>"; };
+		9F21314635A3AEFBA402B9DC /* IdentityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityView.swift; sourceTree = "<group>"; };
 		9F213333CF113281B18B16BD /* ReputationDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReputationDemoView.swift; sourceTree = "<group>"; };
 		9F2133592F1C81B96801F10C /* FullscreenGalleryDismissalTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenGalleryDismissalTransition.swift; sourceTree = "<group>"; };
 		9F2133D2324BEE366DBA2134 /* FullscreenGalleryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenGalleryViewController.swift; sourceTree = "<group>"; };
@@ -973,6 +974,7 @@
 		CFE43E4D219B149100D3D5F7 /* FrontPageViewDefaultData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontPageViewDefaultData.swift; sourceTree = "<group>"; };
 		CFE43E51219B1B2900D3D5F7 /* FrontPageRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontPageRetryView.swift; sourceTree = "<group>"; };
 		CFEB220E232B96550039421C /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
+		CFEB2220232BD9240039421C /* FBSnapshotTestsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBSnapshotTestsExtensions.swift; sourceTree = "<group>"; };
 		CFF9726D21C3BA1D00C85238 /* BannerTransparencyDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencyDemoView.swift; sourceTree = "<group>"; };
 		CFF9726E21C3BA1D00C85238 /* BannerTransparencySectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencySectionView.swift; sourceTree = "<group>"; };
 		CFF9726F21C3BA1D00C85238 /* BannerTransparencyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencyView.swift; sourceTree = "<group>"; };
@@ -2351,6 +2353,7 @@
 			isa = PBXGroup;
 			children = (
 				9F213CB3556A74594DB59E93 /* KeyboardNotificationInfoTest.swift */,
+				CFEB2220232BD9240039421C /* FBSnapshotTestsExtensions.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -4126,6 +4129,7 @@
 				CF376C1D231D459900ED2B24 /* StepTests.swift in Sources */,
 				14193AAF21380DC800EC7FC0 /* DnaViewTests.swift in Sources */,
 				14193AAE21380DC800EC7FC0 /* FullscreenViewTests.swift in Sources */,
+				CFEB2221232BD9240039421C /* FBSnapshotTestsExtensions.swift in Sources */,
 				14193AB021380DC800EC7FC0 /* RecyclingViewTests.swift in Sources */,
 				9F213830B2F4E5DFE596431F /* KeyboardNotificationInfoTest.swift in Sources */,
 			);

--- a/UnitTests/ComponentViewTests.swift
+++ b/UnitTests/ComponentViewTests.swift
@@ -7,24 +7,13 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class ComponentViewTests: FBSnapshotTestCase {
-    static var allViews = ComponentViews.items
-
     override func setUp() {
         super.setUp()
         recordMode = false
     }
 
-    override class func tearDown() {
-        super.tearDown()
-
-        if ComponentViewTests.allViews.count > 0 {
-            fatalError("Not all elements were implemented, missing: \(ComponentViewTests.allViews.map { $0.rawValue }.joined(separator: ", "))")
-        }
-    }
-
     private func snapshot(_ component: ComponentViews) {
         FBSnapshotVerifyView(component.viewController.view)
-        ComponentViewTests.allViews = ComponentViewTests.allViews.filter { $0 != component }
     }
 
     // MARK: - Tests

--- a/UnitTests/ComponentViewTests.swift
+++ b/UnitTests/ComponentViewTests.swift
@@ -22,9 +22,17 @@ class ComponentViewTests: FBSnapshotTestCase {
         }
     }
 
-    func snapshot(_ component: ComponentViews) {
+    private func snapshot(_ component: ComponentViews) {
         FBSnapshotVerifyView(component.viewController.view)
         ComponentViewTests.allViews = ComponentViewTests.allViews.filter { $0 != component }
+    }
+
+    // MARK: - Tests
+
+    func testMissingSnapshotTests() {
+        for element in elementWithoutTests(for: ComponentViews.self) {
+            XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
+        }
     }
 
     func testButton() {
@@ -112,7 +120,7 @@ class ComponentViewTests: FBSnapshotTestCase {
     }
 
     func testBannerTransparencyView() {
-        snapshot(.bannerTransparency)
+        snapshot(.bannerTransparencyView)
     }
 
     func testBottomSheetMechanics() {
@@ -132,15 +140,15 @@ class ComponentViewTests: FBSnapshotTestCase {
     }
 
     func testEarthHourView() {
-        snapshot(.earthHour)
+        snapshot(.earthHourView)
     }
 
     func testStepIndicatorView() {
-        snapshot(.stepIndicator)
+        snapshot(.stepIndicatorView)
     }
 
     func testNativeAdverts() {
-        snapshot(.nativeAdvert)
+        snapshot(.nativeAdverts)
     }
 
     func testCallout() {
@@ -172,7 +180,7 @@ class ComponentViewTests: FBSnapshotTestCase {
     }
 
     func testKlimabroletView() {
-        snapshot(.klimabrolet)
+        snapshot(.klimabroletView)
     }
 
     func testSaveSearchView() {

--- a/UnitTests/DnaViewTests.swift
+++ b/UnitTests/DnaViewTests.swift
@@ -7,24 +7,13 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class DnaViewTests: FBSnapshotTestCase {
-    static var allViews = DnaViews.items
-
     override func setUp() {
         super.setUp()
         recordMode = false
     }
 
-    override class func tearDown() {
-        super.tearDown()
-
-        if DnaViewTests.allViews.count > 0 {
-            fatalError("Not all elements were implemented, missing: \(DnaViewTests.allViews.map { $0.rawValue }.joined(separator: ", "))")
-        }
-    }
-
     private func snapshot(_ component: DnaViews) {
         FBSnapshotVerifyView(component.viewController.view)
-        DnaViewTests.allViews = DnaViewTests.allViews.filter { $0 != component }
     }
 
     // MARK: - Tests

--- a/UnitTests/DnaViewTests.swift
+++ b/UnitTests/DnaViewTests.swift
@@ -22,9 +22,17 @@ class DnaViewTests: FBSnapshotTestCase {
         }
     }
 
-    func snapshot(_ component: DnaViews) {
+    private func snapshot(_ component: DnaViews) {
         FBSnapshotVerifyView(component.viewController.view)
         DnaViewTests.allViews = DnaViewTests.allViews.filter { $0 != component }
+    }
+
+    // MARK: - Tests
+
+    func testMissingSnapshotTests() {
+        for element in elementWithoutTests(for: DnaViews.self, testMethodPrefix: "testDnaViews") {
+            XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
+        }
     }
 
     func testDnaViewsColor() {

--- a/UnitTests/FullscreenViewTests.swift
+++ b/UnitTests/FullscreenViewTests.swift
@@ -8,7 +8,7 @@ import FinniversKit
 
 class FullscreenViewTests: FBSnapshotTestCase {
     static var allViews = FullscreenViews.items
-    private let excludedComponents: [FullscreenViews] = [.piano]
+    private let excludedComponents: [FullscreenViews] = [.pianoView]
 
     override func setUp() {
         super.setUp()
@@ -27,6 +27,14 @@ class FullscreenViewTests: FBSnapshotTestCase {
         FBSnapshotVerifyView(component.viewController.view)
         FullscreenViewTests.allViews = FullscreenViewTests.allViews.filter {
             $0 != component && !excludedComponents.contains($0)
+        }
+    }
+
+    // MARK: - Tests
+
+    func testMissingSnapshotTests() {
+        for element in elementWithoutTests(for: FullscreenViews.self) where element != .pianoView {
+            XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
         }
     }
 
@@ -59,11 +67,11 @@ class FullscreenViewTests: FBSnapshotTestCase {
     }
 
     func testDrumMachineView() {
-        snapshot(.drumMachine)
+        snapshot(.drumMachineView)
     }
 
     func testSnowGlobeView() {
-        snapshot(.snowGlobe)
+        snapshot(.snowGlobeView)
     }
 
     func testLoadingView() {

--- a/UnitTests/FullscreenViewTests.swift
+++ b/UnitTests/FullscreenViewTests.swift
@@ -7,7 +7,6 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class FullscreenViewTests: FBSnapshotTestCase {
-    static var allViews = FullscreenViews.items
     private let excludedComponents: [FullscreenViews] = [.pianoView]
 
     override func setUp() {
@@ -15,25 +14,14 @@ class FullscreenViewTests: FBSnapshotTestCase {
         recordMode = false
     }
 
-    override class func tearDown() {
-        super.tearDown()
-
-        if FullscreenViewTests.allViews.count > 0 {
-            fatalError("Not all elements were implemented, missing: \(FullscreenViewTests.allViews.map { $0.rawValue }.joined(separator: ", "))")
-        }
-    }
-
     func snapshot(_ component: FullscreenViews) {
         FBSnapshotVerifyView(component.viewController.view)
-        FullscreenViewTests.allViews = FullscreenViewTests.allViews.filter {
-            $0 != component && !excludedComponents.contains($0)
-        }
     }
 
     // MARK: - Tests
 
     func testMissingSnapshotTests() {
-        for element in elementWithoutTests(for: FullscreenViews.self) where element != .pianoView {
+        for element in elementWithoutTests(for: FullscreenViews.self) where !excludedComponents.contains(element) {
             XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
         }
     }

--- a/UnitTests/RecyclingViewTests.swift
+++ b/UnitTests/RecyclingViewTests.swift
@@ -27,6 +27,14 @@ class RecyclingViewTests: FBSnapshotTestCase {
         RecyclingViewTests.allViews = RecyclingViewTests.allViews.filter { $0 != component }
     }
 
+    // MARK: - Tests
+
+    func testMissingSnapshotTests() {
+        for element in elementWithoutTests(for: RecyclingViews.self) {
+            XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
+        }
+    }
+
     func testNotificationsListView() {
         snapshot(.notificationsListView)
     }

--- a/UnitTests/RecyclingViewTests.swift
+++ b/UnitTests/RecyclingViewTests.swift
@@ -7,24 +7,13 @@ import FBSnapshotTestCase
 import FinniversKit
 
 class RecyclingViewTests: FBSnapshotTestCase {
-    static var allViews = RecyclingViews.items
-
     override func setUp() {
         super.setUp()
         recordMode = false
     }
 
-    override class func tearDown() {
-        super.tearDown()
-
-        if RecyclingViewTests.allViews.count > 0 {
-            fatalError("Not all elements were implemented, missing: \(RecyclingViewTests.allViews.map { $0.rawValue }.joined(separator: ", "))")
-        }
-    }
-
     func snapshot(_ component: RecyclingViews) {
         FBSnapshotVerifyView(component.viewController.view)
-        RecyclingViewTests.allViews = RecyclingViewTests.allViews.filter { $0 != component }
     }
 
     // MARK: - Tests

--- a/UnitTests/TableViewCellViewsTests.swift
+++ b/UnitTests/TableViewCellViewsTests.swift
@@ -7,24 +7,13 @@ import FinniversKit
 import Demo
 
 class TableViewCellsViewTests: FBSnapshotTestCase {
-    static var allViews = Cells.items
-
     override func setUp() {
         super.setUp()
         recordMode = false
     }
 
-    override class func tearDown() {
-        super.tearDown()
-
-        if TableViewCellsViewTests.allViews.count > 0 {
-            fatalError("Not all elements were implemented, missing: \(TableViewCellsViewTests.allViews.map { $0.rawValue }.joined(separator: ", "))")
-        }
-    }
-
     func snapshot(_ component: Cells) {
         FBSnapshotVerifyView(component.viewController.view)
-        TableViewCellsViewTests.allViews = TableViewCellsViewTests.allViews.filter { $0 != component }
     }
 
     // MARK: - Tests

--- a/UnitTests/TableViewCellViewsTests.swift
+++ b/UnitTests/TableViewCellViewsTests.swift
@@ -27,6 +27,14 @@ class TableViewCellsViewTests: FBSnapshotTestCase {
         TableViewCellsViewTests.allViews = TableViewCellsViewTests.allViews.filter { $0 != component }
     }
 
+    // MARK: - Tests
+
+    func testMissingSnapshotTests() {
+        for element in elementWithoutTests(for: Cells.self) {
+            XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
+        }
+    }
+
     func testBasicCell() {
         snapshot(.basicCell)
     }

--- a/UnitTests/Util/FBSnapshotTestsExtensions.swift
+++ b/UnitTests/Util/FBSnapshotTestsExtensions.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright © 2018 FINN AS. All rights reserved.
+//
+
+import FBSnapshotTestCase
+import Foundation
+
+extension FBSnapshotTestCase {
+    func assertMissingTests<T>(for caseIterable: T.Type) where T: CaseIterable, T: RawRepresentable, T.RawValue == String {
+        var methodCount: UInt32 = 0
+
+        guard let methodList = class_copyMethodList(type(of: self), &methodCount) else {
+            XCTFail("Cannot copy method list to assert missing tests")
+            return
+        }
+
+        let testMethods = (0..<Int(methodCount))
+            .map({ index -> String in
+                let selName = sel_getName(method_getName(methodList[index]))
+                return String(cString: selName, encoding: .utf8)!.lowercased()
+            })
+            .filter({ $0.starts(with: "test") })
+
+        for element in caseIterable.allCases {
+            if !testMethods.contains("test\(element.rawValue)".lowercased()) {
+                XCTFail("Not all elements were implemented, missing: \(element.rawValue)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Why?

Because we used to call `fatalError` in `tearDown` and apparently it didn't work on CircleCI.

# What?

- Add function `elementWithoutTests`, which tries to match method names with component names using reflection, and then returns all components with missing snapshot tests.

- Rename some components to match test names because the name for tests should be test{componentName) from now on to satisfy the assertion. Ideally we should rename test methods, not components, but I didn't want to run tests in record mode and modify snapshots.

- Remove old implementation with `fatalError`.

# Show me

No UI changes.