### PR TITLE
Expose VerificationActionSheet in delegate method

### DIFF
--- a/Demo/Fullscreen/VerificationView/VerificationActionSheetDemoDelegate.swift
+++ b/Demo/Fullscreen/VerificationView/VerificationActionSheetDemoDelegate.swift
@@ -7,5 +7,7 @@ import FinniversKit
 final class VerificationActionSheetDemoDelegate: VerificationActionSheetDelegate {
     static let shared = VerificationActionSheetDemoDelegate()
 
-    func didTapVerificationActionSheetButton(_: VerificationActionSheet) {}
+    func didTapVerificationActionSheetButton(_ sheet: VerificationActionSheet) {
+        sheet.dismiss(animated: false, completion: nil)
+    }
 }

--- a/Sources/Fullscreen/VerificationActionSheet/VerificationActionSheet.swift
+++ b/Sources/Fullscreen/VerificationActionSheet/VerificationActionSheet.swift
@@ -3,7 +3,7 @@
 //
 
 public protocol VerificationActionSheetDelegate: AnyObject {
-    func didTapVerificationActionSheetButton(_ : VerificationActionSheet)
+    func didTapVerificationActionSheetButton(_ sheet: VerificationActionSheet)
 }
 
 public class VerificationActionSheet: BottomSheet {


### PR DESCRIPTION
# Why?

- Need the ability to call the public API of the `VerificationActionSheet` instance

# What?

- Pass it along in the `delegate` method