### PR TITLE
New favourites: add swipe actions for favourite ads

### DIFF
--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
@@ -22,6 +22,8 @@ class FavoriteAdsListDemoView: UIView {
         view.subtitle = "\(viewModels.count) favoritter"
         view.searchBarPlaceholder = "Søk etter en av dine favoritter"
         view.sortingTitle = currentSorting.rawValue
+        view.commentActionTitle = "Notere"
+        view.deleteActionTitle = "Slett"
         return view
     }()
 
@@ -43,8 +45,15 @@ class FavoriteAdsListDemoView: UIView {
 
 extension FavoriteAdsListDemoView: FavoriteAdsListViewDelegate {
     func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectItemAt indexPath: IndexPath) {}
-
     func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectMoreButtonForItemAt indexPath: IndexPath) {}
+
+    func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectDeleteItemAt indexPath: IndexPath) {
+        print("Delete button selected")
+    }
+
+    func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectCommentForItemAt indexPath: IndexPath) {
+        print("Comment button selected")
+    }
 
     func favoriteAdsListViewDidSelectSortButton(_ view: FavoriteAdsListView) {
         switch currentSorting {

--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
@@ -15,15 +15,13 @@ class FavoriteAdsListDemoView: UIView {
     private var currentSorting: AdsSorting = .lastAdded
 
     private lazy var favoritesListView: FavoriteAdsListView = {
-        let view = FavoriteAdsListView(withAutoLayout: true)
+        let view = FavoriteAdsListView(viewModel: .default)
+        view.translatesAutoresizingMaskIntoConstraints = false
         view.dataSource = self
         view.delegate = self
         view.title = "Mine funn"
         view.subtitle = "\(viewModels.count) favoritter"
-        view.searchBarPlaceholder = "Søk etter en av dine favoritter"
         view.sortingTitle = currentSorting.rawValue
-        view.commentActionTitle = "Notere"
-        view.deleteActionTitle = "Slett"
         return view
     }()
 
@@ -122,4 +120,15 @@ extension FavoriteAdsListDemoView: FavoriteAdsListViewDataSource {
     }
 
     func favoriteAdsListView(_ view: FavoriteAdsListView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat) {}
+}
+
+// MARK: - Private
+
+extension FavoriteAdsListViewModel {
+    static let `default` = FavoriteAdsListViewModel(
+        searchBarPlaceholder: "Søk etter en av dine favoritter",
+        addCommentActionTitle: "Skriv\nnotat",
+        editCommentActionTitle: "Rediger\nnotat",
+        deleteAdActionTitle: "Slett"
+    )
 }

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		CFE43E52219B1B2900D3D5F7 /* FrontPageRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE43E51219B1B2900D3D5F7 /* FrontPageRetryView.swift */; };
 		CFEB220F232B96550039421C /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB220E232B96550039421C /* UIBarButtonItemExtensions.swift */; };
 		CFEB2221232BD9240039421C /* FBSnapshotTestsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB2220232BD9240039421C /* FBSnapshotTestsExtensions.swift */; };
+		CFEB22252330D1420039421C /* FavoriteAdsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEB22242330D1420039421C /* FavoriteAdsListViewModel.swift */; };
 		CFF9727121C3BA1D00C85238 /* BannerTransparencySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726E21C3BA1D00C85238 /* BannerTransparencySectionView.swift */; };
 		CFF9727221C3BA1D00C85238 /* BannerTransparencyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726F21C3BA1D00C85238 /* BannerTransparencyView.swift */; };
 		CFF9727321C3BA2200C85238 /* BannerTransparencyDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF9726D21C3BA1D00C85238 /* BannerTransparencyDemoView.swift */; };
@@ -979,6 +980,7 @@
 		CFE43E51219B1B2900D3D5F7 /* FrontPageRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontPageRetryView.swift; sourceTree = "<group>"; };
 		CFEB220E232B96550039421C /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		CFEB2220232BD9240039421C /* FBSnapshotTestsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBSnapshotTestsExtensions.swift; sourceTree = "<group>"; };
+		CFEB22242330D1420039421C /* FavoriteAdsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteAdsListViewModel.swift; sourceTree = "<group>"; };
 		CFF9726D21C3BA1D00C85238 /* BannerTransparencyDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencyDemoView.swift; sourceTree = "<group>"; };
 		CFF9726E21C3BA1D00C85238 /* BannerTransparencySectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencySectionView.swift; sourceTree = "<group>"; };
 		CFF9726F21C3BA1D00C85238 /* BannerTransparencyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTransparencyView.swift; sourceTree = "<group>"; };
@@ -2133,6 +2135,7 @@
 			isa = PBXGroup;
 			children = (
 				9A37DD79F67FC522D64A127E /* FavoriteAdsListView.swift */,
+				CFEB22242330D1420039421C /* FavoriteAdsListViewModel.swift */,
 				9A37DC15387F0A2DC34714C0 /* Subviews */,
 			);
 			path = FavoriteAdsList;
@@ -4203,6 +4206,7 @@
 				DAC7DCAA21538608004602A3 /* SettingsView.swift in Sources */,
 				91846C4A22E735D80001410F /* SearchResultMapView.swift in Sources */,
 				CF7C460922257A8A001FB92C /* EarthHourViewModel.swift in Sources */,
+				CFEB22252330D1420039421C /* FavoriteAdsListViewModel.swift in Sources */,
 				08796D8821CB89400023A441 /* AnimatedHeartView.swift in Sources */,
 				CF3D5EEA215A6723006E4D08 /* DrumPadCollectionViewCell.swift in Sources */,
 				89A7A63D225337B50053D33B /* NativeAdvertViewModel.swift in Sources */,

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -7,6 +7,8 @@ import UIKit
 public protocol FavoriteAdsListViewDelegate: AnyObject {
     func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectItemAt indexPath: IndexPath)
     func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectMoreButtonForItemAt indexPath: IndexPath)
+    func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectDeleteItemAt indexPath: IndexPath)
+    func favoriteAdsListView(_ view: FavoriteAdsListView, didSelectCommentForItemAt indexPath: IndexPath)
     func favoriteAdsListViewDidSelectSortButton(_ view: FavoriteAdsListView)
     func favoriteAdsListViewDidFocusSearchBar(_ view: FavoriteAdsListView)
     func favoriteAdsListView(_ view: FavoriteAdsListView, didChangeSearchText searchText: String)
@@ -181,8 +183,9 @@ extension FavoriteAdsListView: UITableViewDelegate {
         let commentAction = UIContextualAction(
             style: .normal,
             title: commentActionTitle,
-            handler: { (action, view, completionHandler) in
-
+            handler: { [weak self] _, _, completionHandler in
+                guard let self = self else { return }
+                self.delegate?.favoriteAdsListView(self, didSelectCommentForItemAt: indexPath)
                 completionHandler(true)
             })
 
@@ -192,8 +195,9 @@ extension FavoriteAdsListView: UITableViewDelegate {
         let deleteAction = UIContextualAction(
             style: .normal,
             title: deleteActionTitle,
-            handler: { (action, view, completionHandler) in
-
+            handler: { [weak self] _, _, completionHandler in
+                guard let self = self else { return }
+                self.delegate?.favoriteAdsListView(self, didSelectDeleteItemAt: indexPath)
                 completionHandler(true)
             })
 

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -45,10 +45,6 @@ public class FavoriteAdsListView: UIView {
         didSet { tableHeaderView.subtitle = subtitle }
     }
 
-    public var searchBarPlaceholder = "" {
-        didSet { tableHeaderView.searchBarPlaceholder = searchBarPlaceholder }
-    }
-
     public var searchBarText: String {
         get { return tableHeaderView.searchBarText }
         set { tableHeaderView.searchBarText = newValue }
@@ -58,11 +54,9 @@ public class FavoriteAdsListView: UIView {
         didSet { tableHeaderView.sortingTitle = sortingTitle }
     }
 
-    public var commentActionTitle = ""
-    public var deleteActionTitle = ""
-
     // MARK: - Private properties
 
+    private let viewModel: FavoriteAdsListViewModel
     private let imageCache = ImageMemoryCache()
     private var didSetTableHeader = false
 
@@ -87,8 +81,9 @@ public class FavoriteAdsListView: UIView {
 
     // MARK: - Init
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    public init(viewModel: FavoriteAdsListViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
         setup()
     }
 
@@ -99,6 +94,8 @@ public class FavoriteAdsListView: UIView {
     private func setup() {
         addSubview(tableView)
         tableView.fillInSuperview()
+
+        tableHeaderView.searchBarPlaceholder = viewModel.searchBarPlaceholder
     }
 
     // MARK: - Overrides
@@ -180,9 +177,11 @@ extension FavoriteAdsListView: UITableViewDelegate {
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
+        let comment = dataSource?.favoriteAdsListView(self, viewModelFor: indexPath).comment
+
         let commentAction = UIContextualAction(
             style: .normal,
-            title: commentActionTitle,
+            title: comment == nil ? viewModel.addCommentActionTitle : viewModel.editCommentActionTitle,
             handler: { [weak self] _, _, completionHandler in
                 guard let self = self else { return }
                 self.delegate?.favoriteAdsListView(self, didSelectCommentForItemAt: indexPath)
@@ -194,7 +193,7 @@ extension FavoriteAdsListView: UITableViewDelegate {
 
         let deleteAction = UIContextualAction(
             style: .normal,
-            title: deleteActionTitle,
+            title: viewModel.deleteAdActionTitle,
             handler: { [weak self] _, _, completionHandler in
                 guard let self = self else { return }
                 self.delegate?.favoriteAdsListView(self, didSelectDeleteItemAt: indexPath)

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -35,15 +35,15 @@ public class FavoriteAdsListView: UIView {
     public weak var delegate: FavoriteAdsListViewDelegate?
     public weak var dataSource: FavoriteAdsListViewDataSource?
 
-    public var title: String = "" {
+    public var title = "" {
         didSet { tableHeaderView.title = title }
     }
 
-    public var subtitle: String = "" {
+    public var subtitle = "" {
         didSet { tableHeaderView.subtitle = subtitle }
     }
 
-    public var searchBarPlaceholder: String = "" {
+    public var searchBarPlaceholder = "" {
         didSet { tableHeaderView.searchBarPlaceholder = searchBarPlaceholder }
     }
 
@@ -55,6 +55,9 @@ public class FavoriteAdsListView: UIView {
     public var sortingTitle: String = "" {
         didSet { tableHeaderView.sortingTitle = sortingTitle }
     }
+
+    public var commentActionTitle = ""
+    public var deleteActionTitle = ""
 
     // MARK: - Private properties
 
@@ -169,6 +172,35 @@ extension FavoriteAdsListView: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         guard dataSource?.favoriteAdsListView(self, titleForHeaderInSection: section) != nil else { return .leastNonzeroMagnitude }
         return 32
+    }
+
+    public func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let commentAction = UIContextualAction(
+            style: .normal,
+            title: commentActionTitle,
+            handler: { (action, view, completionHandler) in
+
+                completionHandler(true)
+            })
+
+        commentAction.image = UIImage(named: .favoritesNote)
+        commentAction.backgroundColor = .licorice
+
+        let deleteAction = UIContextualAction(
+            style: .normal,
+            title: deleteActionTitle,
+            handler: { (action, view, completionHandler) in
+
+                completionHandler(true)
+            })
+
+        deleteAction.image = UIImage(named: .favoritesDelete)
+        deleteAction.backgroundColor = .cherry
+
+        return UISwipeActionsConfiguration(actions: [deleteAction, commentAction])
     }
 }
 

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListViewModel.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright © FINN.no AS, Inc. All rights reserved.
+//
+
+public struct FavoriteAdsListViewModel {
+    public let searchBarPlaceholder: String
+    public let addCommentActionTitle: String
+    public let editCommentActionTitle: String
+    public let deleteAdActionTitle: String
+
+    public init(
+        searchBarPlaceholder: String,
+        addCommentActionTitle: String,
+        editCommentActionTitle: String,
+        deleteAdActionTitle: String
+    ) {
+        self.searchBarPlaceholder = searchBarPlaceholder
+        self.addCommentActionTitle = addCommentActionTitle
+        self.editCommentActionTitle = editCommentActionTitle
+        self.deleteAdActionTitle = deleteAdActionTitle
+    }
+}


### PR DESCRIPTION
# Why?

Because it should be possible to add comments and delete ads using swipe actions on table view cells.

# What?

- Add "comment" and "delete" swipe actions using iOS11 `UISwipeActionsConfiguration` API
- Originally the title for "comment" action should be "Skriv notat", but it breaks alignment, which ofc is not possible to fix via `UIContextualAction` APIs. I'll talk to designers how we can address this issue. For now I'm using "Notere" as a title.

# Show me

![Simulator Screen Shot - iPhone Xs - 2019-09-16 at 17 04 49](https://user-images.githubusercontent.com/10529867/64970186-960abb80-d8a5-11e9-97c1-de772488e3e4.png)
