### PR TITLE
Bottom sheet: don't animate dim view alpha with spring animator

### DIFF
--- a/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
+++ b/Sources/Components/BottomSheet/Transition/BottomSheetPresentationController.swift
@@ -88,7 +88,6 @@ class BottomSheetPresentationController: UIPresentationController {
         // Setup animations
         springAnimator.addAnimation { [weak self] position in
             self?.constraint?.constant = position.y
-            self?.dimView.alpha = self?.alphaValue(for: position) ?? 0
         }
         // Animate dim view alpha in sync with transition animation
         interactionController.animate { [weak self] position in


### PR DESCRIPTION
# Why?

Because it caused blinking when changing the height of the bottom sheet.

# What?

Don't animate dim view alpha with spring animator. It doesn't seem to affect anything, because when going from compact to expanded state and back it used to animate alpha from 1.0 to 1.3, while the max alpha value is 1.0.

# Show me

| Before | After |
| --- | --- |
| ![bs_before](https://user-images.githubusercontent.com/10529867/65227490-ff1e4900-dac8-11e9-9a84-8479fe15961a.gif) | ![bs_after](https://user-images.githubusercontent.com/10529867/65227489-ff1e4900-dac8-11e9-9dcb-c18c5e6bc7d7.gif) |