### PR TITLE
New favorites: change swipe actions for favourite ads 

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -188,7 +188,6 @@ extension FavoriteAdsListView: UITableViewDelegate {
                 completionHandler(true)
             })
 
-        commentAction.image = UIImage(named: .favoritesNote)
         commentAction.backgroundColor = .licorice
 
         let deleteAction = UIContextualAction(
@@ -200,7 +199,6 @@ extension FavoriteAdsListView: UITableViewDelegate {
                 completionHandler(true)
             })
 
-        deleteAction.image = UIImage(named: .favoritesDelete)
         deleteAction.backgroundColor = .cherry
 
         return UISwipeActionsConfiguration(actions: [deleteAction, commentAction])

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -201,7 +201,10 @@ extension FavoriteAdsListView: UITableViewDelegate {
 
         deleteAction.backgroundColor = .cherry
 
-        return UISwipeActionsConfiguration(actions: [deleteAction, commentAction])
+        let configuration = UISwipeActionsConfiguration(actions: [deleteAction, commentAction])
+        configuration.performsFirstActionWithFullSwipe = false
+
+        return configuration
     }
 }
 


### PR DESCRIPTION
# Why?

To address UI/UX issues.

# What?

- Don't use icons for contextual actions. It fixes the problem with alignment we had before
- Disable full swipe because it was easy to trigger delete action by accident

# Show me

| Before | After |
| --- | --- |
| ![f_before](https://user-images.githubusercontent.com/10529867/65228297-7e604c80-daca-11e9-9f1b-df0e338b6f20.gif) | ![f_after](https://user-images.githubusercontent.com/10529867/65228296-7e604c80-daca-11e9-85f2-a5809234f056.gif) |