### PR TITLE
New favorites: Reset commentView background color

### DIFF
--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCommentView.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCommentView.swift
@@ -5,6 +5,13 @@
 import UIKit
 
 final class FavoriteAdCommentView: UIView {
+
+    // MARK: - Public properties
+
+    static let defaultBackgroundColor = UIColor.banana
+
+    // MARK: - Private properties
+
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.image = UIImage(named: .favoritesComment).withRenderingMode(.alwaysTemplate)
@@ -43,7 +50,7 @@ final class FavoriteAdCommentView: UIView {
         isAccessibilityElement = true
 
         clipsToBounds = true
-        backgroundColor = .banana
+        backgroundColor = FavoriteAdCommentView.defaultBackgroundColor
 
         layer.cornerRadius = 4
         layer.borderColor = UIColor.highlight?.cgColor

--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdView.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdView.swift
@@ -172,6 +172,7 @@ final class FavoriteAdView: UIView {
 
     func resetBackgroundColors() {
         remoteImageView.backgroundColor = remoteImageView.image == nil ? loadingColor : .clear
+        commentView.backgroundColor = FavoriteAdCommentView.defaultBackgroundColor
 
         if let ribbonStyle = viewModel?.ribbonStyle {
             statusRibbon.style = ribbonStyle


### PR DESCRIPTION
# Why?
The background color of the comment within an ad cell isn't reset once the cell is selected.

# What?
- Reset the color on selection.

# Show me

| Before | After |
| --- | --- |
| <img width="545" alt="Screenshot 2019-09-20 at 09 22 28" src="https://user-images.githubusercontent.com/1901556/65307570-56cfb980-db88-11e9-9834-9d5c7e7523ea.png"> | <img width="545" alt="Screenshot 2019-09-20 at 09 21 29" src="https://user-images.githubusercontent.com/1901556/65307571-5800e680-db88-11e9-8276-b853c27ab8e6.png"> |