### PR TITLE
New favorites: toggle selection for all ad cells

### DIFF
--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
@@ -32,9 +32,15 @@ class FavoriteAdsListDemoView: UIView, Tweakable {
                 self?.isEditing = false
                 self?.favoritesListView.setEditing(false)
             },
-            TweakingOption(title: "Edit mode", description: nil) { [weak self] in
+            TweakingOption(title: "Edit mode, none selected", description: nil) { [weak self] in
                 self?.isEditing = true
                 self?.favoritesListView.setEditing(true)
+                self?.favoritesListView.selectAllRows(false, animated: false)
+            },
+            TweakingOption(title: "Edit mode, all selected", description: nil) { [weak self] in
+                self?.isEditing = true
+                self?.favoritesListView.setEditing(true)
+                self?.favoritesListView.selectAllRows(true, animated: false)
             }
         ]
     }()

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -163,6 +163,20 @@ public class FavoriteAdsListView: UIView {
         tableView.setEditing(editing, animated: true)
     }
 
+    public func selectAllRows(_ selected: Bool, animated: Bool) {
+        for section in 0..<tableView.numberOfSections {
+            for row in 0..<tableView.numberOfRows(inSection: section) {
+                let indexPath = IndexPath(row: row, section: section)
+
+                if selected {
+                    tableView.selectRow(at: indexPath, animated: animated, scrollPosition: .none)
+                } else {
+                    tableView.deselectRow(at: indexPath, animated: animated)
+                }
+            }
+        }
+    }
+
     public func reloadRow(at indexPath: IndexPath, with animation: UITableView.RowAnimation = .automatic) {
         tableView.reloadRows(at: [indexPath], with: animation)
     }


### PR DESCRIPTION
# Why?
We need to be able to select/deselect all rows within the list of ads.

# Show me
![favorite-ads-edit-mode_selection](https://user-images.githubusercontent.com/1901556/65321789-67425d00-dba5-11e9-9b0b-8b8ffb18b0e1.gif)
