### PR TITLE
IdentityView's profileImage now uses .scaleAspectFill

### DIFF
--- a/Sources/Components/Profile/IdentityView.swift
+++ b/Sources/Components/Profile/IdentityView.swift
@@ -68,6 +68,7 @@ public class IdentityView: UIView {
 
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
+        imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = IdentityView.profileImageSize / 2
         imageView.layer.masksToBounds = true
         return imageView


### PR DESCRIPTION
# Why?

Profile images fetched from the back-end are "acidentally" always square, meaning that we could get away with not explicitly setting the content mode of the profile-image view. When explicitly setting a non-square profile image _(through `IdentityViewModel.profileImage`)_, it'd end up looking horribly weird.