### PR TITLE
Favorites/expose remoteimagedatasource

### DIFF
--- a/Demo/Demo/DemoViews/FullscreenDemoViews.swift
+++ b/Demo/Demo/DemoViews/FullscreenDemoViews.swift
@@ -103,7 +103,7 @@ public enum FullscreenDemoViews: String, CaseIterable {
             let bottomSheet = FavoriteAdCommentSheet(
                 commentViewModel: .default,
                 adViewModel: FavoriteAdsFactory.create().last!,
-                adImage: FavoriteAdActionViewModel.createImage()
+                remoteImageViewDataSource: FavoriteAdCommentSheetDemoDelegate.shared
             )
             bottomSheet.commentDelegate = FavoriteAdCommentSheetDemoDelegate.shared
             return bottomSheet

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
@@ -15,11 +15,11 @@ public final class FavoriteAdCommentSheet: BottomSheet {
 
     // MARK: - Init
 
-    public required init(commentViewModel: FavoriteAdCommentViewModel, adViewModel: FavoriteAdViewModel, adImage: UIImage?) {
+    public required init(commentViewModel: FavoriteAdCommentViewModel, adViewModel: FavoriteAdViewModel, remoteImageViewDataSource: RemoteImageViewDataSource?) {
         viewController = FavoriteAdCommentViewController(
             commentViewModel: commentViewModel,
             adViewModel: adViewModel,
-            adImage: adImage
+            remoteImageViewDataSource: remoteImageViewDataSource
         )
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.isTranslucent = false

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
@@ -18,7 +18,6 @@ final class FavoriteAdCommentViewController: UIViewController {
     private weak var remoteImageViewDataSource: RemoteImageViewDataSource?
     private let commentViewModel: FavoriteAdCommentViewModel
     private let adViewModel: FavoriteAdViewModel
-    private let adImage: UIImage?
     private let notificationCenter: NotificationCenter
 
     private lazy var cancelButton = UIBarButtonItem(
@@ -55,7 +54,7 @@ final class FavoriteAdCommentViewController: UIViewController {
         view.isMoreButtonHidden = true
         view.isCommentViewHidden = true
         view.configure(with: adViewModel)
-        view.remoteImageViewDataSource = self
+        view.remoteImageViewDataSource = remoteImageViewDataSource
         view.setContentHuggingPriority(.defaultHigh, for: .vertical)
         return view
     }()
@@ -77,12 +76,12 @@ final class FavoriteAdCommentViewController: UIViewController {
     init(
         commentViewModel: FavoriteAdCommentViewModel,
         adViewModel: FavoriteAdViewModel,
-        adImage: UIImage?,
+        remoteImageViewDataSource: RemoteImageViewDataSource?,
         notificationCenter: NotificationCenter = .default
     ) {
         self.commentViewModel = commentViewModel
         self.adViewModel = adViewModel
-        self.adImage = adImage
+        self.remoteImageViewDataSource = remoteImageViewDataSource
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
     }
@@ -125,6 +124,7 @@ final class FavoriteAdCommentViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         _ = textView.resignFirstResponder()
+        adView.resetContent()
     }
 
     // MARK: - Setup
@@ -199,25 +199,6 @@ final class FavoriteAdCommentViewController: UIViewController {
     @objc private func handleSaveButtonTap() {
         delegate?.favoriteAdCommentViewController(self, didSelectSaveComment: textView.text)
     }
-}
-
-// MARK: - RemoteImageViewDataSource
-
-extension FavoriteAdCommentViewController: RemoteImageViewDataSource {
-    func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage? {
-        return adImage
-    }
-
-    func remoteImageView(
-        _ view: RemoteImageView,
-        loadImageWithPath imagePath: String,
-        imageWidth: CGFloat,
-        completion: @escaping ((UIImage?) -> Void)
-    ) {
-        completion(adImage)
-    }
-
-    func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat) {}
 }
 
 // MARK: - UIScrollViewDelegate


### PR DESCRIPTION
# Why?
There are cases in the app where we don't have the ad's image downloaded/cached before we want to present the comment sheet.

# What?
- Pass/use `RemoteImageViewDataSource` to deliver images.