### PR TITLE
New favorites: Present loading indicator on save for commentSheet

### DIFF
--- a/Demo/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheetDemoDelegate.swift
+++ b/Demo/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheetDemoDelegate.swift
@@ -17,7 +17,10 @@ extension FavoriteAdCommentSheetDemoDelegate: FavoriteAdCommentSheetDelegate {
 
     func favoriteAdCommentSheet(_ sheet: FavoriteAdCommentSheet, didSelectSaveComment comment: String?) {
         print(comment ?? "")
-        sheet.state = .dismissed
+        sheet.startLoading()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
+            sheet.state = .dismissed
+        })
     }
 }
 

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentSheet.swift
@@ -32,6 +32,16 @@ public final class FavoriteAdCommentSheet: BottomSheet {
     public required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
+
+    // MARK: - Public methods
+
+    public func startLoading() {
+        viewController.startLoading()
+    }
+
+    public func stopLoading() {
+        viewController.stopLoading()
+    }
 }
 
 // MARK: - FavoriteAdCommentViewControllerDelegate

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
@@ -199,6 +199,7 @@ final class FavoriteAdCommentViewController: UIViewController {
     }
 
     @objc private func handleSaveButtonTap() {
+        textView.endEditing(true)
         delegate?.favoriteAdCommentViewController(self, didSelectSaveComment: textView.text)
     }
 

--- a/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
+++ b/Sources/Fullscreen/FavoriteAdCommentSheet/FavoriteAdCommentViewController.swift
@@ -19,6 +19,8 @@ final class FavoriteAdCommentViewController: UIViewController {
     private let commentViewModel: FavoriteAdCommentViewModel
     private let adViewModel: FavoriteAdViewModel
     private let notificationCenter: NotificationCenter
+    private lazy var loadingView = LoadingIndicatorView(frame: CGRect(origin: .zero, size: CGSize(width: 24, height: 24)))
+    private lazy var loadingBarButton = UIBarButtonItem(customView: loadingView)
 
     private lazy var cancelButton = UIBarButtonItem(
         title: commentViewModel.cancelButtonText,
@@ -198,6 +200,20 @@ final class FavoriteAdCommentViewController: UIViewController {
 
     @objc private func handleSaveButtonTap() {
         delegate?.favoriteAdCommentViewController(self, didSelectSaveComment: textView.text)
+    }
+
+    // MARK: - Public methods
+
+    public func startLoading() {
+        loadingView.startAnimating()
+        navigationItem.setRightBarButton(loadingBarButton, animated: true)
+        cancelButton.isEnabled = false
+    }
+
+    public func stopLoading() {
+        loadingView.stopAnimating()
+        navigationItem.setRightBarButton(saveButton, animated: true)
+        cancelButton.isEnabled = true
     }
 }
 


### PR DESCRIPTION
# Why?
We want to present a loading indicator where the save button was on the comment sheet when the user taps to save the comment.

# What?
- Added `LoadingIndicatorView` within a `UIBarButtonItem`'s customView.

# Show me
![comment-sheet-loading-indicator](https://user-images.githubusercontent.com/1901556/65502424-0ecfd000-dec3-11e9-840f-a0141f56bf1e.gif)
