### PR TITLE
Updated dark mode color for `btnDisabled` and `textDisabled`

### DIFF
--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -35,7 +35,7 @@ import UIKit
     }
 
     public class var btnDisabled: UIColor {
-        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: UIColor(hex: "#2F333F"))
+        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: UIColor(hex: "#434359"))
     }
 
     public class var btnCritical: UIColor {
@@ -59,7 +59,7 @@ import UIKit
     }
 
     public class var textDisabled: UIColor {
-        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: UIColor(hex: "#2F333F"))
+        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: UIColor(hex: "#434359"))
     }
 
     public class var textCritical: UIColor {

--- a/Sources/Fullscreen/MessageForm/MessageFormToolbar.swift
+++ b/Sources/Fullscreen/MessageForm/MessageFormToolbar.swift
@@ -255,4 +255,3 @@ private extension String {
         return components.filter { !$0.isEmpty }.joined(separator: " ")
     }
 }
-


### PR DESCRIPTION
# Why?
Because the disabled dark colors were sometimes hard to see.

# What?
Updated dark mode color for `btnDisabled` and `textDisabled`.

# Show me

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone Xs - 2019-09-25 at 14 20 37](https://user-images.githubusercontent.com/3169203/65600073-ac003680-df9f-11e9-99db-7e700febfcca.png) | ![Simulator Screen Shot - iPhone Xs - 2019-09-25 at 14 14 26](https://user-images.githubusercontent.com/3169203/65599969-604d8d00-df9f-11e9-9a92-5fa6af4b4fdd.png) |
| ![Simulator Screen Shot - iPhone Xs - 2019-09-25 at 14 20 28](https://user-images.githubusercontent.com/3169203/65600084-b3bfdb00-df9f-11e9-8f5d-1702bd152266.png) | ![Simulator Screen Shot - iPhone Xs - 2019-09-25 at 14 14 39](https://user-images.githubusercontent.com/3169203/65599996-722f3000-df9f-11e9-962f-1ae97453ee07.png) |
