### PR TITLE
New favorites: show empty view after deleting rows and sections

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '12.3.0'
+  s.version      = '12.3.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -192,10 +192,12 @@ public class FavoriteAdsListView: UIView {
 
     public func deleteRow(at indexPath: IndexPath, with animation: UITableView.RowAnimation = .automatic) {
         tableView.deleteRows(at: [indexPath], with: animation)
+        showEmptyViewIfNeeded()
     }
 
     public func deleteSection(at index: Int, with animation: UITableView.RowAnimation = .automatic) {
         tableView.deleteSections(IndexSet(integer: index), with: animation)
+        showEmptyViewIfNeeded()
     }
 
     // MARK: - Images


### PR DESCRIPTION
# Why?

The empty view should be shown if the last row or section was deleted.

# What?

Show empty view if needed in `deleteRow` and `deleteSection` methods.

# Show me

No UI changes.