### PR TITLE
New favorites: add search term to the empty view text

### DIFF
--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoView.swift
@@ -150,6 +150,6 @@ extension FavoriteAdsListViewModel {
         addCommentActionTitle: "Skriv\nnotat",
         editCommentActionTitle: "Rediger\nnotat",
         deleteAdActionTitle: "Slett",
-        emptyViewText: "Vi fant visst ingen favoritter for stoll"
+        emptyViewBodyPrefix: "Vi fant visst ingen favoritter for"
     )
 }

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '12.3.1'
+  s.version      = '12.4.0'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -107,7 +107,6 @@ public class FavoriteAdsListView: UIView {
 
         tableView.fillInSuperview()
         tableHeaderView.searchBarPlaceholder = viewModel.searchBarPlaceholder
-        emptyView.configure(withText: viewModel.emptyViewText, buttonTitle: nil)
 
         NSLayoutConstraint.activate([
             emptyView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -392,6 +391,9 @@ extension FavoriteAdsListView: UISearchBarDelegate {
     public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         let searchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         delegate?.favoriteAdsListView(self, didChangeSearchText: searchText)
+
+        let emptyViewText = "\(viewModel.emptyViewBodyPrefix) \"\(searchText)\""
+        emptyView.configure(withText: emptyViewText, buttonTitle: nil)
     }
 }
 

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListViewModel.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListViewModel.swift
@@ -7,19 +7,19 @@ public struct FavoriteAdsListViewModel {
     public let addCommentActionTitle: String
     public let editCommentActionTitle: String
     public let deleteAdActionTitle: String
-    public let emptyViewText: String
+    public let emptyViewBodyPrefix: String
 
     public init(
         searchBarPlaceholder: String,
         addCommentActionTitle: String,
         editCommentActionTitle: String,
         deleteAdActionTitle: String,
-        emptyViewText: String
+        emptyViewBodyPrefix: String
     ) {
         self.searchBarPlaceholder = searchBarPlaceholder
         self.addCommentActionTitle = addCommentActionTitle
         self.editCommentActionTitle = editCommentActionTitle
         self.deleteAdActionTitle = deleteAdActionTitle
-        self.emptyViewText = emptyViewText
+        self.emptyViewBodyPrefix = emptyViewBodyPrefix
     }
 }


### PR DESCRIPTION
# Why?

To improve text shown within the empty view.

# What?

- Rename property in `FavoriteAdsListViewModel`
- Add search term to the empty view text

# Show me

![fav_search2](https://user-images.githubusercontent.com/10529867/65688538-9eb07e00-e06b-11e9-9566-340e4c7851b8.gif)