### PR TITLE
New favorites: add read-only mode in the list of ads

### DIFF
--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
@@ -20,7 +20,7 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
     private lazy var navigationTitleView = PercentageDrivenTitleView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 44)))
 
     private lazy var favoritesListView: FavoriteAdsListView = {
-        let view = FavoriteAdsListView(viewModel: .default)
+        let view = FavoriteAdsListView(viewModel: .default, isReadOnly: true)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.dataSource = self
         view.delegate = self
@@ -33,14 +33,30 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
     lazy var tweakingOptions: [TweakingOption] = {
         [
             TweakingOption(title: "Selection mode", description: nil) { [weak self] in
+                if self?.favoritesListView.isReadOnly == true {
+                    self?.favoritesListView.isReadOnly = false
+                }
+
                 self?.favoritesListView.setEditing(false)
             },
             TweakingOption(title: "Edit mode, none selected", description: nil) { [weak self] in
+                if self?.favoritesListView.isReadOnly == true {
+                    self?.favoritesListView.isReadOnly = false
+                }
+
                 self?.favoritesListView.setEditing(true)
                 self?.favoritesListView.selectAllRows(false, animated: false)
             },
             TweakingOption(title: "Edit mode, all selected", description: nil) { [weak self] in
+                if self?.favoritesListView.isReadOnly == true {
+                    self?.favoritesListView.isReadOnly = false
+                }
+
                 self?.favoritesListView.setEditing(true)
+                self?.favoritesListView.selectAllRows(true, animated: false)
+            },
+            TweakingOption(title: "Read only", description: nil) { [weak self] in
+                self?.favoritesListView.isReadOnly = true
                 self?.favoritesListView.selectAllRows(true, animated: false)
             }
         ]

--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
@@ -47,8 +47,8 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
                 self?.favoritesListView.selectAllRows(true, animated: false)
             },
             TweakingOption(title: "Read only", description: nil) { [weak self] in
-                self?.favoritesListView.setEditing(false)
                 self?.setReadOnly(true)
+                self?.favoritesListView.setEditing(false)
             }
         ]
     }()

--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
@@ -20,7 +20,7 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
     private lazy var navigationTitleView = PercentageDrivenTitleView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 44)))
 
     private lazy var favoritesListView: FavoriteAdsListView = {
-        let view = FavoriteAdsListView(viewModel: .default, isReadOnly: true)
+        let view = FavoriteAdsListView(viewModel: .default)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.dataSource = self
         view.delegate = self
@@ -33,31 +33,22 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
     lazy var tweakingOptions: [TweakingOption] = {
         [
             TweakingOption(title: "Selection mode", description: nil) { [weak self] in
-                if self?.favoritesListView.isReadOnly == true {
-                    self?.favoritesListView.isReadOnly = false
-                }
-
+                self?.setReadOnly(false)
                 self?.favoritesListView.setEditing(false)
             },
             TweakingOption(title: "Edit mode, none selected", description: nil) { [weak self] in
-                if self?.favoritesListView.isReadOnly == true {
-                    self?.favoritesListView.isReadOnly = false
-                }
-
+                self?.setReadOnly(false)
                 self?.favoritesListView.setEditing(true)
                 self?.favoritesListView.selectAllRows(false, animated: false)
             },
             TweakingOption(title: "Edit mode, all selected", description: nil) { [weak self] in
-                if self?.favoritesListView.isReadOnly == true {
-                    self?.favoritesListView.isReadOnly = false
-                }
-
+                self?.setReadOnly(false)
                 self?.favoritesListView.setEditing(true)
                 self?.favoritesListView.selectAllRows(true, animated: false)
             },
             TweakingOption(title: "Read only", description: nil) { [weak self] in
-                self?.favoritesListView.isReadOnly = true
-                self?.favoritesListView.selectAllRows(true, animated: false)
+                self?.favoritesListView.setEditing(false)
+                self?.setReadOnly(true)
             }
         ]
     }()
@@ -77,6 +68,15 @@ class FavoriteAdsListDemoViewController: DemoViewController<UIView>, Tweakable {
 
         navigationTitleView.title = folderTitle
         navigationItem.titleView = navigationTitleView
+    }
+
+    private func setReadOnly(_ isReadOnly: Bool) {
+        guard favoritesListView.isReadOnly != isReadOnly else {
+            return
+        }
+
+        favoritesListView.isReadOnly = isReadOnly
+        favoritesListView.isSearchBarHidden = isReadOnly
     }
 }
 

--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
@@ -22,9 +22,10 @@ public class FavoriteAdTableViewCell: UITableViewCell {
 
     public var loadingColor: UIColor?
 
-    var isMoreButtonHidden: Bool {
-        get { return adView.isMoreButtonHidden }
-        set { adView.isMoreButtonHidden = newValue }
+    var isMoreButtonHidden = false {
+        didSet {
+            adView.isMoreButtonHidden = isMoreButtonHidden
+        }
     }
 
     // MARK: - Private properties
@@ -65,7 +66,7 @@ public class FavoriteAdTableViewCell: UITableViewCell {
         super.didTransition(to: state)
         let isEditing = state.contains(.showingEditControl)
 
-        adView.isMoreButtonHidden = isEditing
+        adView.isMoreButtonHidden = isEditing || isMoreButtonHidden
     }
 
     // MARK: - Public methods

--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdTableViewCell.swift
@@ -22,6 +22,11 @@ public class FavoriteAdTableViewCell: UITableViewCell {
 
     public var loadingColor: UIColor?
 
+    var isMoreButtonHidden: Bool {
+        get { return adView.isMoreButtonHidden }
+        set { adView.isMoreButtonHidden = newValue }
+    }
+
     // MARK: - Private properties
 
     private lazy var adView: FavoriteAdView = {

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -41,6 +41,14 @@ public class FavoriteAdsListView: UIView {
         didSet { reloadData() }
     }
 
+    public var isSearchBarHidden: Bool {
+        get { return tableHeaderView.isSearchBarHidden }
+        set {
+            tableHeaderView.isSearchBarHidden = newValue
+            setTableHeader()
+        }
+    }
+
     public var title = "" {
         didSet { tableHeaderView.title = title }
     }

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -36,6 +36,7 @@ public class FavoriteAdsListView: UIView {
 
     public weak var delegate: FavoriteAdsListViewDelegate?
     public weak var dataSource: FavoriteAdsListViewDataSource?
+    public var isReadOnly = false
 
     public var title = "" {
         didSet { tableHeaderView.title = title }
@@ -280,6 +281,10 @@ extension FavoriteAdsListView: UITableViewDelegate {
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
+        guard !isReadOnly else {
+            return nil
+        }
+
         let comment = dataSource?.favoriteAdsListView(self, viewModelFor: indexPath).comment
 
         let commentAction = UIContextualAction(

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -36,7 +36,10 @@ public class FavoriteAdsListView: UIView {
 
     public weak var delegate: FavoriteAdsListViewDelegate?
     public weak var dataSource: FavoriteAdsListViewDataSource?
-    public var isReadOnly = false
+
+    public var isReadOnly: Bool {
+        didSet { reloadData() }
+    }
 
     public var title = "" {
         didSet { tableHeaderView.title = title }
@@ -94,8 +97,9 @@ public class FavoriteAdsListView: UIView {
 
     // MARK: - Init
 
-    public init(viewModel: FavoriteAdsListViewModel) {
+    public init(viewModel: FavoriteAdsListViewModel, isReadOnly: Bool = false) {
         self.viewModel = viewModel
+        self.isReadOnly = isReadOnly
         super.init(frame: .zero)
         setup()
     }
@@ -277,6 +281,10 @@ extension FavoriteAdsListView: UITableViewDelegate {
         return 32
     }
 
+    public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return !isReadOnly
+    }
+
     public func tableView(
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
@@ -351,10 +359,12 @@ extension FavoriteAdsListView: UITableViewDataSource {
         // Show a pretty color while we load the image
         let colors: [UIColor] = [.toothPaste, .mint, .banana, .salmon]
         cell.loadingColor = colors[indexPath.row % colors.count]
+        cell.isMoreButtonHidden = isReadOnly
 
         if let viewModel = dataSource?.favoriteAdsListView(self, viewModelFor: indexPath) {
             cell.configure(with: viewModel)
         }
+
         return cell
     }
 }

--- a/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
@@ -17,6 +17,12 @@ class FavoriteAdsListTableHeader: UIView {
         didSet { searchBar.delegate = searchBarDelegate }
     }
 
+    var isSearchBarHidden = false {
+        didSet {
+            searchBar.isHidden = isSearchBarHidden
+        }
+    }
+
     var searchBarPlaceholder: String = "" {
         didSet { searchBar.placeholder = searchBarPlaceholder }
     }
@@ -96,28 +102,22 @@ class FavoriteAdsListTableHeader: UIView {
     private func setup() {
         addGestureRecognizer(tapRecognizer)
 
-        addSubview(titleLabel)
-        addSubview(subtitleLabel)
-        addSubview(searchBar)
-        addSubview(sortingView)
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel, searchBar, sortingView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.setCustomSpacing(.smallSpacing, after: titleLabel)
+        stackView.setCustomSpacing(24, after: subtitleLabel)
+        stackView.setCustomSpacing(37, after: searchBar)
+
+        addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: .mediumLargeSpacing),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: .mediumLargeSpacing),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
 
-            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: .smallSpacing),
-            subtitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
-            subtitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
-
-            searchBar.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 24),
-            searchBar.heightAnchor.constraint(equalToConstant: 36),
-            searchBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
-            searchBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.mediumLargeSpacing),
-
-            sortingView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: 37),
-            sortingView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .mediumLargeSpacing),
-            sortingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.mediumSpacing),
+            searchBar.heightAnchor.constraint(equalToConstant: 36)
         ])
     }
 

--- a/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsSortingView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsSortingView.swift
@@ -51,7 +51,6 @@ class FavoriteAdsSortingView: UIView {
             sortingLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             arrowImage.leadingAnchor.constraint(equalTo: sortingLabel.trailingAnchor, constant: 1),
-            arrowImage.trailingAnchor.constraint(equalTo: trailingAnchor),
             arrowImage.heightAnchor.constraint(equalToConstant: 12),
             arrowImage.widthAnchor.constraint(equalToConstant: 12),
             arrowImage.centerYAnchor.constraint(equalTo: centerYAnchor)


### PR DESCRIPTION
# Why?

There are cases when we want to hide editing actions and search

# What?

- Add `isReadOnly` property in `FavoriteAdsListView` to toggle "read only mode"
- Add `isSearchBarHidden` property to toggle search bar visibility
- Update demo with new tweaking option

# Show me

![read-only](https://user-images.githubusercontent.com/10529867/65767356-f6afb900-e12d-11e9-803c-4b8ed4b45942.gif)
