### PR TITLE
New favorites: reload data on changing "isReadOnly" if header is set up

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -38,7 +38,11 @@ public class FavoriteAdsListView: UIView {
     public weak var dataSource: FavoriteAdsListViewDataSource?
 
     public var isReadOnly: Bool {
-        didSet { reloadData() }
+        didSet {
+            if didSetTableHeader {
+                reloadData()
+            }
+        }
     }
 
     public var isSearchBarHidden: Bool {


### PR DESCRIPTION
# Why?

Calling `reloadData` before we setup table view header constraints apparently leads to incorrect header height.

# What?

Call `reloadData` only if table view header is setup.

# Show me

No UI changes.