### PR TITLE
New favorites: Fix blunder from previous PR

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -56,7 +56,9 @@ public class FavoriteAdsListView: UIView {
     public var title = "" {
         didSet {
             tableHeaderView.title = title
-            setTableHeader()
+            if !tableView.isEditing {
+                setTableHeader()
+            }
         }
     }
 
@@ -232,7 +234,6 @@ public class FavoriteAdsListView: UIView {
     // MARK: - Private
 
     private func setTableHeader() {
-        guard !tableView.isEditing else { return }
         tableView.tableHeaderView = tableHeaderView
 
         NSLayoutConstraint.deactivate(tableViewConstraints + emptyViewConstraints)


### PR DESCRIPTION
# Why?
I placed `tableView.isEditing` check in the wrong location in #631, and it messed up the tableHeaderView when entering/exiting edit mode.

It didn't have any effect in the demo, but it did in the app😄

# Show me
| Before | After |
| --- | --- |
| ![favoriteads-blunder-before](https://user-images.githubusercontent.com/1901556/65877680-8bafed80-e38c-11e9-869b-a5bef9f4605a.gif) | ![favoriteads-blunder-after](https://user-images.githubusercontent.com/1901556/65877684-8ce11a80-e38c-11e9-87da-c14cc51d9267.gif) |