### PR TITLE
New favorites: EmptyView constraints

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -248,7 +248,7 @@ public class FavoriteAdsListView: UIView {
         ]
 
         emptyViewConstraints = [
-            emptyView.topAnchor.constraint(equalTo: tableHeaderView.bottomAnchor, constant: -48)
+            emptyView.topAnchor.constraint(equalTo: tableHeaderView.bottomAnchor)
         ]
 
         NSLayoutConstraint.activate(tableViewConstraints + emptyViewConstraints)

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -262,6 +262,8 @@ public class FavoriteAdsListView: UIView {
         let shouldShowEmptyView = numberOfSections(in: tableView) == 0
         emptyView.isHidden = !shouldShowEmptyView
         tableHeaderView.isSortingViewHidden = shouldShowEmptyView
+        tableView.alwaysBounceVertical = !shouldShowEmptyView
+        setTableHeader()
     }
 }
 


### PR DESCRIPTION
# Why?
The constraints set for the emptyView in the list of ads was wrong, and overlayed the tableHeaderView.

After adding/removing the emptyView, we didn't reset the tableHeaderView.

# What?
- Fix constraint for emptyView.
- Reset tableHeaderView.
- Disable bouncing when emptyView is shown.

# Show me
| Before | After |
| --- | --- |
| ![favorites-emptyview-constant-before](https://user-images.githubusercontent.com/1901556/66033554-cf7b3200-e507-11e9-8f5a-55dcb756d448.gif) | ![favorites-emptyview-constant-after](https://user-images.githubusercontent.com/1901556/66033562-d2762280-e507-11e9-9b97-4bbdff311257.gif) |