### PR TITLE
New favorites: improve draggable empty view

### DIFF
--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -84,7 +84,6 @@ public class FavoriteAdsListView: UIView {
     private var didSetTableHeader = false
     private var sendScrollUpdates: Bool = true
     private var tableViewConstraints = [NSLayoutConstraint]()
-    private var emptyViewConstraints = [NSLayoutConstraint]()
 
     private lazy var tableView: UITableView = {
         let tableView = TableView(withAutoLayout: true)
@@ -109,9 +108,8 @@ public class FavoriteAdsListView: UIView {
     }()
 
     private lazy var emptyView: FavoriteEmptyView = {
-        let emptyView = FavoriteEmptyView(withAutoLayout: true)
+        let emptyView = FavoriteEmptyView()
         emptyView.isHidden = true
-        emptyView.isUserInteractionEnabled = false
         return emptyView
     }()
 
@@ -130,16 +128,10 @@ public class FavoriteAdsListView: UIView {
 
     private func setup() {
         addSubview(tableView)
-        addSubview(emptyView)
+        tableView.addSubview(emptyView)
 
         tableView.fillInSuperview()
         tableHeaderView.searchBarPlaceholder = viewModel.searchBarPlaceholder
-
-        NSLayoutConstraint.activate([
-            emptyView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            emptyView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            emptyView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
     }
 
     // MARK: - Overrides
@@ -150,6 +142,8 @@ public class FavoriteAdsListView: UIView {
         if !didSetTableHeader {
             setTableHeader()
             didSetTableHeader = true
+        } else {
+            layoutEmptyView()
         }
     }
 
@@ -174,12 +168,6 @@ public class FavoriteAdsListView: UIView {
             sendScrollUpdates = true
             setTableHeader()
             tableView.contentOffset.y += tableHeaderHeight
-        } else {
-            emptyView.removeConstraints(emptyViewConstraints)
-            NSLayoutConstraint.deactivate(emptyViewConstraints)
-
-            emptyViewConstraints = [emptyView.topAnchor.constraint(equalTo: topAnchor)]
-            NSLayoutConstraint.activate(emptyViewConstraints)
         }
 
         UIView.animate(withDuration: 0.3, animations: { [weak self] in
@@ -239,9 +227,8 @@ public class FavoriteAdsListView: UIView {
     private func setTableHeader() {
         tableView.tableHeaderView = tableHeaderView
 
-        NSLayoutConstraint.deactivate(tableViewConstraints + emptyViewConstraints)
+        NSLayoutConstraint.deactivate(tableViewConstraints)
         tableHeaderView.removeConstraints(tableViewConstraints)
-        emptyView.removeConstraints(emptyViewConstraints)
 
         tableViewConstraints = [
             tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor),
@@ -249,15 +236,13 @@ public class FavoriteAdsListView: UIView {
             tableHeaderView.widthAnchor.constraint(equalTo: tableView.widthAnchor)
         ]
 
-        emptyViewConstraints = [
-            emptyView.topAnchor.constraint(equalTo: tableHeaderView.bottomAnchor)
-        ]
-
-        NSLayoutConstraint.activate(tableViewConstraints + emptyViewConstraints)
+        NSLayoutConstraint.activate(tableViewConstraints)
 
         tableView.tableHeaderView?.layoutIfNeeded()
         tableView.tableHeaderView = tableView.tableHeaderView
         tableView.sendSubviewToBack(tableHeaderView)
+
+        layoutEmptyView()
     }
 
     private func showEmptyViewIfNeeded() {
@@ -265,6 +250,12 @@ public class FavoriteAdsListView: UIView {
         emptyView.isHidden = !shouldShowEmptyView
         tableHeaderView.isSortingViewHidden = shouldShowEmptyView
         setTableHeader()
+    }
+
+    private func layoutEmptyView() {
+        emptyView.frame = tableView.bounds
+        emptyView.frame.origin.y = tableView.tableHeaderView?.frame.height ?? 0
+        emptyView.frame.size.height -= emptyView.frame.origin.y
     }
 }
 

--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -89,7 +89,7 @@ public class FavoriteFoldersListView: UIView {
     }()
 
     private lazy var emptyView: FavoriteEmptyView = {
-        let emptyView = FavoriteEmptyView(withAutoLayout: true)
+        let emptyView = FavoriteEmptyView()
         emptyView.delegate = self
         emptyView.isHidden = true
         return emptyView
@@ -221,7 +221,8 @@ public class FavoriteFoldersListView: UIView {
         addSubview(tableView)
         addSubview(searchBar)
         addSubview(footerView)
-        addSubview(emptyView)
+
+        tableView.addSubview(emptyView)
 
         NSLayoutConstraint.activate([
             searchBarTop,
@@ -237,12 +238,12 @@ public class FavoriteFoldersListView: UIView {
             footerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             footerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             footerView.heightAnchor.constraint(equalToConstant: footerHeight),
-
-            emptyView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
-            emptyView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            emptyView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            emptyView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        emptyView.frame = tableView.bounds
     }
 
     // MARK: - Private methods

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
@@ -109,18 +109,18 @@ final class FavoriteEmptyView: UIView {
     }
 
     @objc private func handleKeyboardNotification(_ notification: Notification) {
-        //swiftlint:disable notification_center_detachment
-        NotificationCenter.default.removeObserver(self)
-
         guard let keyboardInfo = KeyboardNotificationInfo(notification) else { return }
 
         let keyboardIntersection = keyboardInfo.keyboardFrameEndIntersectHeight(inView: wrapperView)
-        let wrapperBottomOffset = keyboardIntersection + windowSafeAreaInsets.bottom
 
-        wrapperViewBottomConstraint.constant = -wrapperBottomOffset
+        if keyboardIntersection > 0 {
+            let wrapperBottomOffset = keyboardIntersection + windowSafeAreaInsets.bottom
 
-        UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo) { [weak self] in
-            self?.layoutIfNeeded()
+            wrapperViewBottomConstraint.constant = -wrapperBottomOffset
+
+            UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo) { [weak self] in
+                self?.layoutIfNeeded()
+            }
         }
     }
 

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
@@ -84,12 +84,12 @@ final class FavoriteEmptyView: UIView {
         addSubview(wrapperView)
 
         NSLayoutConstraint.activate([
-            wrapperView.topAnchor.constraint(equalTo: topAnchor, constant: 44),
+            wrapperView.topAnchor.constraint(equalTo: topAnchor),
             wrapperView.leadingAnchor.constraint(equalTo: leadingAnchor),
             wrapperView.trailingAnchor.constraint(equalTo: trailingAnchor),
             wrapperViewBottomConstraint,
 
-            stackView.centerYAnchor.constraint(equalTo: wrapperView.centerYAnchor, constant: -.mediumSpacing),
+            stackView.centerYAnchor.constraint(equalTo: wrapperView.centerYAnchor),
             stackView.leadingAnchor.constraint(equalTo: wrapperView.leadingAnchor, constant: .veryLargeSpacing),
             stackView.trailingAnchor.constraint(equalTo: wrapperView.trailingAnchor, constant: -.veryLargeSpacing),
 

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
@@ -67,7 +67,6 @@ final class FavoriteEmptyView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardNotification), name: UIResponder.keyboardWillHideNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardNotification), name: UIResponder.keyboardWillShowNotification, object: nil)
 
         clipsToBounds = true
@@ -89,7 +88,7 @@ final class FavoriteEmptyView: UIView {
             wrapperView.trailingAnchor.constraint(equalTo: trailingAnchor),
             wrapperViewBottomConstraint,
 
-            stackView.centerYAnchor.constraint(equalTo: wrapperView.centerYAnchor),
+            stackView.centerYAnchor.constraint(equalTo: wrapperView.centerYAnchor, constant: -.mediumSpacing),
             stackView.leadingAnchor.constraint(equalTo: wrapperView.leadingAnchor, constant: .veryLargeSpacing),
             stackView.trailingAnchor.constraint(equalTo: wrapperView.trailingAnchor, constant: -.veryLargeSpacing),
 

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteEmptyView.swift
@@ -67,7 +67,12 @@ final class FavoriteEmptyView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardNotification), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleKeyboardNotification),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
 
         clipsToBounds = true
         backgroundColor = .milk
@@ -104,13 +109,17 @@ final class FavoriteEmptyView: UIView {
     }
 
     @objc private func handleKeyboardNotification(_ notification: Notification) {
+        //swiftlint:disable notification_center_detachment
+        NotificationCenter.default.removeObserver(self)
+
         guard let keyboardInfo = KeyboardNotificationInfo(notification) else { return }
 
         let keyboardIntersection = keyboardInfo.keyboardFrameEndIntersectHeight(inView: wrapperView)
         let wrapperBottomOffset = keyboardIntersection + windowSafeAreaInsets.bottom
 
+        wrapperViewBottomConstraint.constant = -wrapperBottomOffset
+
         UIView.animateAlongsideKeyboard(keyboardInfo: keyboardInfo) { [weak self] in
-            self?.wrapperViewBottomConstraint.constant = -wrapperBottomOffset
             self?.layoutIfNeeded()
         }
     }


### PR DESCRIPTION
# Why?

The movement of empty view and header view were out of sync while dragging.
 
# What?

- Add empty view as a subview to table view and layout it using frames (auto layout doesn't work in this case)
- Don't change empty view constraints when hiding the keyboard
- Animate bottom constraint only when keyboard intersection detected
- Make empty view draggable in the list of folders as well



# Show me


| Before | Folders | Ads |
| --- | --- | --- |
| ![](https://user-images.githubusercontent.com/1901556/66112996-2d714d80-e5cc-11e9-9dde-d97863f57470.gif) | ![folders](https://user-images.githubusercontent.com/10529867/66140491-83f97e80-e602-11e9-8a2f-dda23e634191.gif) | ![ads](https://user-images.githubusercontent.com/10529867/66140535-94a9f480-e602-11e9-82cf-422f13161535.gif) |