### PR TITLE
Fullscreen presentation, instead of pageSheet

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -9,10 +9,7 @@ import FinniversKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    lazy var navigationController: NavigationController = {
-        let navigationController = NavigationController(rootViewController: DemoViewsTableViewController())
-        return navigationController
-    }()
+    lazy var navigationController = NavigationController(rootViewController: DemoViewsTableViewController())
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let userInterfaceStyle = UserInterfaceStyle(rawValue: UserDefaults.standard.integer(forKey: State.currentUserInterfaceStyleKey))

--- a/Demo/Demo/DemoViewsTableViewController.swift
+++ b/Demo/Demo/DemoViewsTableViewController.swift
@@ -144,6 +144,13 @@ class DemoViewsTableViewController: UITableViewController {
     private var sections: [String] {
         return Array(indexAndValues.keys.sorted(by: <))
     }
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool = true, completion: (() -> Void)? = nil) {
+        if viewControllerToPresent.modalPresentationStyle == .pageSheet {
+            viewControllerToPresent.modalPresentationStyle = .fullScreen
+        }
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
 }
 
 // MARK: - UITableViewDelegate


### PR DESCRIPTION
# Why?
The default `modalPresentationStyle` in iOS 13 is `.pageSheet`. This doesn't work very well with our demos in FinniversKit, as they're meant to be presented in full screen.

Other demo views, such as the bottomSheets have already set this value to something else and won't be affected by these changes.

# What?
- Set `modalPresentationStyle` to `.fullScreen`, if the current value is `.pageSheet`.
- Small refactoring in the Demo's `AppDelegate`.

# Show me
| Before | After |
| --- | --- |
| ![demo-presentation-fullscreen-before](https://user-images.githubusercontent.com/1901556/66750946-1ebd4d00-ee8e-11e9-87a0-04f1891b50de.gif) | ![demo-presentation-fullscreen-after](https://user-images.githubusercontent.com/1901556/66750953-211fa700-ee8e-11e9-840f-a2e1fff83fa6.gif) |