### PR TITLE
Use semantic colors for backgrounds

### DIFF
--- a/Sources/Cells/RemoteImageTableViewCell/RemoteImageTableViewCell.swift
+++ b/Sources/Cells/RemoteImageTableViewCell/RemoteImageTableViewCell.swift
@@ -75,7 +75,7 @@ public class RemoteImageTableViewCell: BasicTableViewCell {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         contentView.addSubview(remoteImageView)
 
         stackViewLeadingAnchorConstraint.isActive = false

--- a/Sources/Components/Button/FloatingButton/FloatingButton.swift
+++ b/Sources/Components/Button/FloatingButton/FloatingButton.swift
@@ -9,7 +9,7 @@ public final class FloatingButton: UIButton {
 
     public override var isHighlighted: Bool {
         didSet {
-            backgroundColor = isHighlighted ? .ice : .milk
+            backgroundColor = isHighlighted ? .bgSecondary : .milk
         }
     }
 
@@ -31,7 +31,7 @@ public final class FloatingButton: UIButton {
 
     public override var isSelected: Bool {
         didSet {
-            backgroundColor = isSelected ? .ice : .milk
+            backgroundColor = isSelected ? .bgSecondary : .milk
         }
     }
 

--- a/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
+++ b/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
@@ -26,7 +26,7 @@ public final class ReviewButtonControl: UIControl {
         let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.backgroundColor = .clear
-        imageView.tintColor = .milk
+        imageView.tintColor = .bgPrimary
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFit
         return imageView
@@ -35,7 +35,7 @@ public final class ReviewButtonControl: UIControl {
     private lazy var titleLabel: Label = {
         let label = Label(style: .bodyStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .milk
+        label.textColor = .bgPrimary
         label.textAlignment = .center
         return label
     }()

--- a/Sources/Components/Feedback/FeedbackView.swift
+++ b/Sources/Components/Feedback/FeedbackView.swift
@@ -89,7 +89,7 @@ public class FeedbackView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
 
         layer.borderWidth = 1
         layer.borderColor = .sardine

--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -10,7 +10,7 @@ public final class IconCollectionView: UIView {
     private lazy var collectionView: UICollectionView = {
         let collectionView = CollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
         collectionView.register(IconCollectionViewCell.self)
-        collectionView.backgroundColor = .milk
+        collectionView.backgroundColor = .bgPrimary
         collectionView.allowsSelection = false
         collectionView.isScrollEnabled = false
         collectionView.bounces = false
@@ -47,7 +47,7 @@ public final class IconCollectionView: UIView {
     }
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         addSubview(collectionView)
         collectionView.fillInSuperview()
     }

--- a/Sources/Components/IconCollection/IconCollectionViewCell.swift
+++ b/Sources/Components/IconCollection/IconCollectionViewCell.swift
@@ -69,7 +69,7 @@ public class IconCollectionViewCell: UICollectionViewCell {
     }
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         isAccessibilityElement = true
 
         addSubview(iconImageView)

--- a/Sources/Components/Infobox/InfoboxView.swift
+++ b/Sources/Components/Infobox/InfoboxView.swift
@@ -68,13 +68,13 @@ public final class InfoboxView: UIView {
     // MARK: - Init
 
     public override init(frame: CGRect) {
-        style = .small(backgroundColor: .ice)
+        style = .small(backgroundColor: .bgSecondary)
         super.init(frame: frame)
         setup()
     }
 
     required init?(coder aDecoder: NSCoder) {
-        style = .small(backgroundColor: .ice)
+        style = .small(backgroundColor: .bgSecondary)
         super.init(coder: aDecoder)
         setup()
     }

--- a/Sources/Components/Klimabrolet/KlimabroletView.swift
+++ b/Sources/Components/Klimabrolet/KlimabroletView.swift
@@ -23,7 +23,7 @@ public class KlimabroletView: UIView {
 
     private lazy var closeButton: UIButton = {
         let button = UIButton(withAutoLayout: true)
-        button.tintColor = .milk
+        button.tintColor = .bgPrimary
         button.setImage(UIImage(named: .cross), for: .normal)
         button.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         button.contentEdgeInsets = UIEdgeInsets(all: 6)
@@ -84,7 +84,7 @@ public class KlimabroletView: UIView {
     // MARK: - Private methods
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         layer.cornerRadius = 20
         clipsToBounds = true
 

--- a/Sources/Components/Klimabrolet/Views/KlimabroletActionsView.swift
+++ b/Sources/Components/Klimabrolet/Views/KlimabroletActionsView.swift
@@ -50,7 +50,7 @@ class KlimabroletActionsView: UIView {
     // MARK: - Private methods
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(primaryButton)
         addSubview(secondaryButton)

--- a/Sources/Components/Klimabrolet/Views/KlimabroletContentView.swift
+++ b/Sources/Components/Klimabrolet/Views/KlimabroletContentView.swift
@@ -73,7 +73,7 @@ class KlimabroletContentView: UIView {
     // MARK: - Private methods
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(bannerImageView)
         addSubview(titleLabel)

--- a/Sources/Components/LoanCalculator/LoanCalculatorView.swift
+++ b/Sources/Components/LoanCalculator/LoanCalculatorView.swift
@@ -74,7 +74,7 @@ public class LoanCalculatorView: UIView {
 
     // MARK: - Private methods
     private func setup() {
-        backgroundColor = .marble
+        backgroundColor = .bgTertiary
         layer.cornerRadius = .mediumSpacing
         directionalLayoutMargins = .init(all: .mediumLargeSpacing * 1.5)
 

--- a/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
+++ b/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
@@ -112,7 +112,7 @@ final class NativeContentSettingsButton: UIButton {
 
 private extension UIColor {
     static var foregroundColor: UIColor? {
-        return .milk
+        return .bgPrimary
     }
 
     static var buttonBackgroundColor: UIColor? {

--- a/Sources/Components/Panel/Panel+Style.swift
+++ b/Sources/Components/Panel/Panel+Style.swift
@@ -14,7 +14,7 @@ extension Panel {
 
         var backgroundColor: UIColor {
             switch self {
-            case .plain: return .milk
+            case .plain: return .bgPrimary
             case .info: return .bgSecondary
             case .tips: return .toothPaste
             case .newFunctionality: return .mint

--- a/Sources/Components/Panel/Panel+Style.swift
+++ b/Sources/Components/Panel/Panel+Style.swift
@@ -15,7 +15,7 @@ extension Panel {
         var backgroundColor: UIColor {
             switch self {
             case .plain: return .milk
-            case .info: return .ice
+            case .info: return .bgSecondary
             case .tips: return .toothPaste
             case .newFunctionality: return .mint
             case .success: return .mint

--- a/Sources/Components/Phases/PhaseListView.swift
+++ b/Sources/Components/Phases/PhaseListView.swift
@@ -48,7 +48,7 @@ public final class PhaseListView: UIView {
     }
 
     private func setup() {
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
         layer.cornerRadius = .mediumSpacing
 
         addSubview(stackView)

--- a/Sources/Components/Profile/IdentityView.swift
+++ b/Sources/Components/Profile/IdentityView.swift
@@ -159,7 +159,7 @@ public class IdentityView: UIView {
 
     private func setupSubviews() {
         layer.cornerRadius = 8
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
 
         addSubview(stackView)
         addSubview(profileImageView)

--- a/Sources/Components/Profile/ReputationView.swift
+++ b/Sources/Components/Profile/ReputationView.swift
@@ -73,7 +73,7 @@ public class ReputationView: UIView {
     private lazy var scoreLabel: Label = {
         let label = Label(style: .bodyStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .milk
+        label.textColor = .bgPrimary
         return label
     }()
 

--- a/Sources/Components/Profile/ReputationView.swift
+++ b/Sources/Components/Profile/ReputationView.swift
@@ -172,7 +172,7 @@ public class ReputationView: UIView {
         setupGestureRecognizer()
 
         layer.cornerRadius = 8
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
         clipsToBounds = true
 
         addSubview(scoreBackgroundView)

--- a/Sources/Components/QuestionnaireView/QuestionnaireView.swift
+++ b/Sources/Components/QuestionnaireView/QuestionnaireView.swift
@@ -70,13 +70,13 @@ public class QuestionnaireView: UIView {
     // MARK: - Init
 
     public override init(frame: CGRect) {
-        style = .normal(backgroundColor: .ice, primaryButtonIcon: nil)
+        style = .normal(backgroundColor: .bgSecondary, primaryButtonIcon: nil)
         super.init(frame: frame)
         setup()
     }
 
     required init?(coder aDecoder: NSCoder) {
-        style = .normal(backgroundColor: .ice, primaryButtonIcon: nil)
+        style = .normal(backgroundColor: .bgSecondary, primaryButtonIcon: nil)
         super.init(coder: aDecoder)
         setup()
     }

--- a/Sources/Components/ReviewButtonView/ReviewButtonView.swift
+++ b/Sources/Components/ReviewButtonView/ReviewButtonView.swift
@@ -79,7 +79,7 @@ public final class ReviewButtonView: UIView {
 
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(hairlineSeperator)
         addSubview(reviewButtonControl)

--- a/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -15,7 +15,7 @@ public extension RibbonView {
 
         var color: UIColor {
             switch self {
-            case .default: return .ice
+            case .default: return .bgSecondary
             case .success: return .mint
             case .warning: return .banana
             case .error: return .salmon

--- a/Sources/Components/SaveSearchView/SaveSearchView.swift
+++ b/Sources/Components/SaveSearchView/SaveSearchView.swift
@@ -120,7 +120,7 @@ public class SaveSearchView: UIView {
     // MARK: - Private methods
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         scrollView.addSubview(contentView)
         addSubview(scrollView)

--- a/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
+++ b/Sources/Components/StatisticsView/StatisticsItemEmptyView.swift
@@ -18,7 +18,7 @@ public class StatisticsItemEmptyView: UIView {
         let view = UIImageView(image: UIImage(named: .statsEmpty))
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
-        view.tintColor = .ice
+        view.tintColor = .bgSecondary
         return view
     }()
 

--- a/Sources/Components/StepIndicator/StepDot.swift
+++ b/Sources/Components/StepIndicator/StepDot.swift
@@ -47,7 +47,7 @@ class StepDot: UIView {
 
         shapeLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: radius).cgPath
         shapeLayer.frame = frame
-        shapeLayer.fillColor = UIColor.milk.cgColor
+        shapeLayer.fillColor = UIColor.bgPrimary.cgColor
         return shapeLayer
     }()
 

--- a/Sources/Components/Toast/ToastButton.swift
+++ b/Sources/Components/Toast/ToastButton.swift
@@ -36,7 +36,7 @@ internal class ToastButton: UIButton {
         case .promoted:
             setTitleColor(.licorice, for: .normal)
             contentEdgeInsets = UIEdgeInsets(vertical: .mediumSpacing, horizontal: .mediumLargeSpacing)
-            layer.borderColor = .milk
+            layer.borderColor = .bgPrimary
             layer.borderWidth = 2
         }
 

--- a/Sources/Components/Toast/ToastView+Style.swift
+++ b/Sources/Components/Toast/ToastView+Style.swift
@@ -21,7 +21,7 @@ extension ToastView {
 
         var imageBackgroundColor: UIColor {
             switch self {
-            case .sucesssWithImage: return .milk
+            case .sucesssWithImage: return .bgPrimary
             default: return .clear
             }
         }

--- a/Sources/Components/VerificationView/VerificationView.swift
+++ b/Sources/Components/VerificationView/VerificationView.swift
@@ -66,7 +66,7 @@ public class VerificationView: UIView {
 
 private extension VerificationView {
     func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(verificationImageView)
         addSubview(titleLabel)

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -255,6 +255,14 @@ extension CGColor {
     public class var marble: CGColor {
         return UIColor.marble.cgColor
     }
+
+    public class var bgPrimary: CGColor {
+        return UIColor.bgPrimary.cgColor
+    }
+
+    public class var bgSecondary: CGColor {
+        return UIColor.bgSecondary.cgColor
+    }
 }
 
 // MARK: - Button

--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -66,7 +66,7 @@ public class AddressView: UIView {
 
     private lazy var centerMapButton: UIButton = {
         let button = UIButton(withAutoLayout: true)
-        button.backgroundColor = .milk
+        button.backgroundColor = .bgPrimary
         button.tintColor = .primaryBlue
 
         button.layer.cornerRadius = 23

--- a/Sources/Fullscreen/ConsentActionView/ConsentActionView.swift
+++ b/Sources/Fullscreen/ConsentActionView/ConsentActionView.swift
@@ -28,7 +28,7 @@ public class ConsentActionView: UIView {
 
     private var buttonBackgroundView: UIView = {
         let view = UIView(frame: .zero)
-        view.backgroundColor = .milk
+        view.backgroundColor = .bgPrimary
         view.layer.shadowOffset = .zero
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
+++ b/Sources/Fullscreen/ConsentToggleView/ConsentToggleView.swift
@@ -28,7 +28,7 @@ public class ConsentToggleView: UIView {
 
     private var backgroundView: UIView = {
         let view = UIView(frame: .zero)
-        view.backgroundColor = .ice
+        view.backgroundColor = .bgSecondary
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/Sources/Fullscreen/ContactForm/ContactFormView.swift
+++ b/Sources/Fullscreen/ContactForm/ContactFormView.swift
@@ -151,7 +151,7 @@ public final class ContactFormView: UIView {
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         addGestureRecognizer(tap)
 
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(scrollView)
         scrollView.addSubview(contentView)

--- a/Sources/Fullscreen/EasterEggs/DrumMachine/InstrumentSelectorView.swift
+++ b/Sources/Fullscreen/EasterEggs/DrumMachine/InstrumentSelectorView.swift
@@ -17,7 +17,7 @@ final class InstrumentSelectorView: UIView {
         let label = UILabel()
         label.font = .title2
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .milk
+        label.textColor = .bgPrimary
         return label
     }()
 

--- a/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -292,7 +292,7 @@ public class EmptyView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         for shape in allShapes {
             addSubview(shape)

--- a/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListEmptyView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListEmptyView.swift
@@ -50,7 +50,7 @@ public class FavoriteAdsListEmptyView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         stackView.addArrangedSubview(iconImageView)
         stackView.addArrangedSubview(titleLabel)

--- a/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
@@ -84,7 +84,7 @@ class FavoriteAdsListTableHeader: UIView {
 
     private lazy var searchBar: UISearchBar = {
         let searchBar = UISearchBar(withAutoLayout: true)
-        searchBar.backgroundColor = .milk
+        searchBar.backgroundColor = .bgPrimary
         searchBar.searchBarStyle = .minimal
         return searchBar
     }()

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderActionButton.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderActionButton.swift
@@ -84,6 +84,6 @@ final class FavoriteFolderActionButton: UIButton {
     // MARK: - Private
 
     private func updateBackground() {
-        backgroundColor = (isHighlighted || isSelected) ? .defaultCellSelectedBackgroundColor : .milk
+        backgroundColor = (isHighlighted || isSelected) ? .defaultCellSelectedBackgroundColor : .bgPrimary
     }
 }

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderShareLinkView.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderShareLinkView.swift
@@ -64,7 +64,7 @@ final class FavoriteFolderShareLinkView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
 
         addSubview(iconImageView)
         addSubview(descriptionLabel)

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderShareToggleView.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/Views/FavoriteFolderShareToggleView.swift
@@ -70,7 +70,7 @@ final class FavoriteFolderShareToggleView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(iconImageView)
         addSubview(titleLabel)

--- a/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageRetryView.swift
@@ -68,7 +68,7 @@ final class FrontPageRetryView: UIView {
     }
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(label)
         addSubview(button)

--- a/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -163,7 +163,7 @@ public final class FrontPageView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(adsGridView)
 

--- a/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryOverlayView.swift
+++ b/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryOverlayView.swift
@@ -51,7 +51,7 @@ class FullscreenGalleryOverlayView: UIView {
         let label = Label(style: .bodyStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
-        label.textColor = .milk
+        label.textColor = .bgPrimary
         label.textAlignment = .center
         label.backgroundColor = UIColor.black.withAlphaComponent(0.4)
         label.shadowOffset = CGSize(width: 1.0, height: 1.0)

--- a/Sources/Fullscreen/LoadingView/LoadingView.swift
+++ b/Sources/Fullscreen/LoadingView/LoadingView.swift
@@ -157,8 +157,8 @@ private extension LoadingView {
                 layer.cornerRadius = 0
                 fillInSuperview()
             case .boxed:
-                successImageView.tintColor = .milk
-                messageLabel.textColor = .milk
+                successImageView.tintColor = .bgPrimary
+                messageLabel.textColor = .bgPrimary
                 backgroundColor = UIColor.black.withAlphaComponent(0.8)
                 layer.cornerRadius = 16
 

--- a/Sources/Fullscreen/LoginEntryView/LoginEntryView.swift
+++ b/Sources/Fullscreen/LoginEntryView/LoginEntryView.swift
@@ -54,7 +54,7 @@ public class LoginEntryView: UIView {
 
     private lazy var loginDialogue: LoginEntryDialogueView = {
         let view = LoginEntryDialogueView(withAutoLayout: true)
-        view.backgroundColor = .milk
+        view.backgroundColor = .bgPrimary
         view.dropShadow(color: .sardine, opacity: 0.3, offset: CGSize(width: 10, height: 0), radius: 24)
 
         return view

--- a/Sources/Fullscreen/LoginEntryView/LoginEntryView.swift
+++ b/Sources/Fullscreen/LoginEntryView/LoginEntryView.swift
@@ -37,7 +37,7 @@ public class LoginEntryView: UIView {
 
     private lazy var contentView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .marble
+        view.backgroundColor = .bgTertiary
         return view
     }()
 

--- a/Sources/Fullscreen/Receipt/ReceiptView.swift
+++ b/Sources/Fullscreen/Receipt/ReceiptView.swift
@@ -18,7 +18,7 @@ public class ReceiptView: UIView {
 
     private lazy var scrollView: UIScrollView = {
         let view = UIScrollView(withAutoLayout: true)
-        view.backgroundColor = .milk
+        view.backgroundColor = .bgPrimary
         view.showsVerticalScrollIndicator = false
         view.showsHorizontalScrollIndicator = false
         return view

--- a/Sources/Fullscreen/Review/Cell/ReviewProfileCell.swift
+++ b/Sources/Fullscreen/Review/Cell/ReviewProfileCell.swift
@@ -28,7 +28,7 @@ class ReviewProfileCell: UITableViewCell {
     lazy var hairlineView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .ice
+        view.backgroundColor = .bgSecondary
         return view
     }()
 

--- a/Sources/Fullscreen/SearchResultMapView/MapSettingsView.swift
+++ b/Sources/Fullscreen/SearchResultMapView/MapSettingsView.swift
@@ -60,7 +60,7 @@ public final class MapSettingsView: UIView {
         layer.shadowOpacity = 0.4
 
         layer.cornerRadius = .mediumSpacing
-        layer.backgroundColor = UIColor.milk.withAlphaComponent(0.8).cgColor
+        layer.backgroundColor = UIColor.bgPrimary.withAlphaComponent(0.8).cgColor
     }
 
     private func setup() {

--- a/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
+++ b/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
@@ -126,7 +126,7 @@ public final class SearchResultMapView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         addSubview(mapView)
         addSubview(mapSettingsButton)

--- a/Sources/Fullscreen/SplashView/SplashView.swift
+++ b/Sources/Fullscreen/SplashView/SplashView.swift
@@ -21,7 +21,7 @@ public final class SplashView: UIView {
         let view = UIView(withAutoLayout: true)
         view.clipsToBounds = true
         view.backgroundColor = .secondaryBlue
-        view.layer.borderColor = .milk
+        view.layer.borderColor = .bgPrimary
         view.layer.borderWidth = 3
         view.layer.cornerRadius = 4
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMaxXMaxYCorner]

--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -146,7 +146,7 @@ public class AdsGridViewCell: UICollectionViewCell {
         imageDescriptionView.addSubview(iconImageView)
         imageDescriptionView.addSubview(imageTextLabel)
 
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         NSLayoutConstraint.activate([
             imageBackgroundView.topAnchor.constraint(equalTo: topAnchor),

--- a/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
+++ b/Sources/Recycling/GridViews/Ads/GridView/AdsGridView.swift
@@ -34,7 +34,7 @@ public class AdsGridView: UIView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
         collectionView.dataSource = self
-        collectionView.backgroundColor = .milk
+        collectionView.backgroundColor = .bgPrimary
         return collectionView
     }()
 

--- a/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileViewCell.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileViewCell.swift
@@ -32,7 +32,7 @@ class NeighborhoodProfileViewCell: UICollectionViewCell {
 
     private func setup() {
         backgroundColor = .clear
-        contentView.backgroundColor = .milk
+        contentView.backgroundColor = .bgPrimary
 
         contentView.layer.cornerRadius = .mediumSpacing
         contentView.layer.borderWidth = 1

--- a/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
+++ b/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileView.swift
@@ -31,7 +31,7 @@ public final class NeighborhoodProfileView: UIView {
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.backgroundColor = .ice
+        collectionView.backgroundColor = .bgSecondary
         collectionView.contentInset = UIEdgeInsets(
             top: .mediumSpacing,
             left: .mediumLargeSpacing,
@@ -140,7 +140,7 @@ public final class NeighborhoodProfileView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .ice
+        backgroundColor = .bgSecondary
 
         addSubview(headerView)
         addSubview(collectionView)

--- a/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementButtonAndInformationCell.swift
+++ b/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementButtonAndInformationCell.swift
@@ -44,7 +44,7 @@ public class UserAdManagementButtonAndInformationCell: UITableViewCell {
     private lazy var button: UIButton = {
         let button = UIButton(frame: .zero)
         button.titleLabel?.font = .detailStrong
-        button.titleLabel?.textColor = .milk
+        button.titleLabel?.textColor = .bgPrimary
         button.translatesAutoresizingMaskIntoConstraints = false
         button.backgroundColor = .primaryBlue
         button.layer.cornerRadius = 8

--- a/Sources/Recycling/ListViews/FavoriteAdActions/FavoriteAdActionView.swift
+++ b/Sources/Recycling/ListViews/FavoriteAdActions/FavoriteAdActionView.swift
@@ -27,7 +27,7 @@ public final class FavoriteAdActionView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = FavoriteAdActionView.rowHeight
         tableView.estimatedRowHeight = FavoriteAdActionView.rowHeight
         tableView.tableFooterView = UIView()

--- a/Sources/Recycling/ListViews/FavoriteAdSorting/FavoriteAdSortingView.swift
+++ b/Sources/Recycling/ListViews/FavoriteAdSorting/FavoriteAdSortingView.swift
@@ -27,7 +27,7 @@ public final class FavoriteAdSortingView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = FavoriteAdSortingView.rowHeight
         tableView.estimatedRowHeight = FavoriteAdSortingView.rowHeight
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)

--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -62,7 +62,7 @@ public class FavoriteFoldersListView: UIView {
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = FavoriteFoldersListView.estimatedRowHeight
         tableView.estimatedRowHeight = FavoriteFoldersListView.estimatedRowHeight
         tableView.separatorInset = .leadingInset(frame.width)

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/AddFavoriteFolderButton.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/AddFavoriteFolderButton.swift
@@ -59,7 +59,7 @@ final class AddFavoriteFolderButton: UIButton {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         imageView?.backgroundColor = UIColor(r: 246, g: 248, b: 251)
         imageView?.layer.masksToBounds = true

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFolderSelectableViewCell.swift
@@ -17,7 +17,7 @@ public class FavoriteFolderSelectableViewCell: RemoteImageTableViewCell {
 
     private lazy var editModeView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .milk
+        view.backgroundColor = .bgPrimary
         view.isHidden = true
         return view
     }()

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersFooterView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersFooterView.swift
@@ -46,7 +46,7 @@ final class FavoriteFoldersFooterView: UIView {
     }
 
     private func setup() {
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         isAccessibilityElement = true
 
         layer.masksToBounds = false

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersSearchBar.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteFoldersSearchBar.swift
@@ -14,7 +14,7 @@ final class FavoriteFoldersSearchBar: BottomShadowView {
     private(set) lazy var searchBar: UISearchBar = {
         let searchBar = UISearchBar(withAutoLayout: true)
         searchBar.searchBarStyle = .minimal
-        searchBar.backgroundColor = .milk
+        searchBar.backgroundColor = .bgPrimary
         return searchBar
     }()
 
@@ -46,6 +46,7 @@ final class FavoriteFoldersSearchBar: BottomShadowView {
     // MARK: - Setup
 
     private func setup() {
+        backgroundColor = .bgPrimary
         addSubview(searchBar)
 
         NSLayoutConstraint.activate([

--- a/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteSearchEmptyView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/Subviews/FavoriteSearchEmptyView.swift
@@ -75,7 +75,7 @@ final class FavoriteSearchEmptyView: UIView {
         )
 
         clipsToBounds = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         stackView.addArrangedSubview(magnifyingGlassImageView)
         stackView.addArrangedSubview(bodyLabel)

--- a/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
+++ b/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
@@ -67,7 +67,7 @@ public class FavoritesListViewCell: UITableViewCell {
         addSubview(detailLabel)
         addSubview(titleLabel)
 
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         NSLayoutConstraint.activate([
             adImageView.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),

--- a/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
+++ b/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
@@ -28,7 +28,7 @@ public class FavoritesListView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = FavoritesListView.estimatedRowHeight
         tableView.estimatedRowHeight = FavoritesListView.estimatedRowHeight
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)

--- a/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
+++ b/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
@@ -76,7 +76,7 @@ public class NotificationsListViewCell: UITableViewCell {
         addSubview(titleLabel)
         addSubview(priceLabel)
 
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
 
         NSLayoutConstraint.activate([
             adImageView.topAnchor.constraint(equalTo: topAnchor, constant: .mediumSpacing),

--- a/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
+++ b/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
@@ -34,7 +34,7 @@ public class NotificationsListView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = NotificationsListView.estimatedRowHeight
         tableView.estimatedRowHeight = NotificationsListView.estimatedRowHeight
         tableView.estimatedSectionHeaderHeight = NotificationsListView.estimatedSectionHeaderHeight

--- a/Sources/Recycling/ListViews/SavedSearches/ListView/SavedSearchesListView.swift
+++ b/Sources/Recycling/ListViews/SavedSearches/ListView/SavedSearchesListView.swift
@@ -23,7 +23,7 @@ public class SavedSearchesListView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = SavedSearchesListView.estimatedRowHeight
         tableView.estimatedRowHeight = SavedSearchesListView.estimatedRowHeight
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)

--- a/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
+++ b/Sources/Recycling/ListViews/Settings/ListView/SettingsView.swift
@@ -20,7 +20,7 @@ public class SettingsView: UIView {
         let view = UITableView(frame: .zero, style: .grouped)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentInset = UIEdgeInsets(top: .mediumLargeSpacing, leading: 0, bottom: 0, trailing: 0)
-        view.backgroundColor = .marble
+        view.backgroundColor = .bgTertiary
         view.separatorStyle = .none
         view.dataSource = self
         view.delegate = self

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
@@ -72,7 +72,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
 
     private lazy var adWrapperView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .milk
+        view.backgroundColor = .bgPrimary
         view.layer.cornerRadius = UserAdsListEmphasizedActionCell.cornerRadius
         return view
     }()

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListEmphasizedActionCell.swift
@@ -114,14 +114,14 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
 
     private lazy var gradientWrapper: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .marble
+        view.backgroundColor = .bgTertiary
         return view
     }()
 
     private lazy var gradientLayer: CALayer = {
         let layer = CAGradientLayer()
         let color = UIColor.white.withAlphaComponent(0.75)
-        layer.colors = [UIColor.marble.cgColor, color.cgColor]
+        layer.colors = [UIColor.bgTertiary.cgColor, color.cgColor]
         layer.locations = [0.1, 1.0]
         return layer
     }()
@@ -133,7 +133,7 @@ public class UserAdsListEmphasizedActionCell: UITableViewCell {
 
     private func setupView() {
         isAccessibilityElement = true
-        contentView.backgroundColor = .marble
+        contentView.backgroundColor = .bgTertiary
         accessoryType = .none
         selectionStyle = .none
         separatorInset = UIEdgeInsets(top: 0, left: (UserAdsListEmphasizedActionCell.imageSize + .mediumSpacing), bottom: 0, right: 0)

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewCell.swift
@@ -91,7 +91,7 @@ public class UserAdsListViewCell: UITableViewCell {
 
     private func setupView() {
         isAccessibilityElement = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         accessoryType = .disclosureIndicator
         selectionStyle = .none
 

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewNewAdCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewNewAdCell.swift
@@ -38,7 +38,7 @@ public class UserAdsListViewNewAdCell: UITableViewCell {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         selectionStyle = .none
 
         addSubview(createNewAdButton)

--- a/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewSeeAllAdsCell.swift
+++ b/Sources/Recycling/ListViews/UserAds/Cell/UserAdsListViewSeeAllAdsCell.swift
@@ -36,7 +36,7 @@ public class UserAdsListViewSeeAllAdsCell: UITableViewCell {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .milk
+        backgroundColor = .bgPrimary
         selectionStyle = .none
         separatorInset = UIEdgeInsets(top: 0, left: frame.width, bottom: 0, right: 0)
 

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListHeaderView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListHeaderView.swift
@@ -52,7 +52,7 @@ public class UserAdsListHeaderView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
-        backgroundColor = .marble
+        backgroundColor = .bgTertiary
 
         addSubview(titleLabel)
         addSubview(moreButton)

--- a/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
+++ b/Sources/Recycling/ListViews/UserAds/ListView/UserAdsListView.swift
@@ -47,7 +47,7 @@ public class UserAdsListView: UIView {
         tableView.register(UserAdsListViewSeeAllAdsCell.self)
         tableView.register(UserAdsListEmphasizedActionCell.self)
         tableView.cellLayoutMarginsFollowReadableWidth = false
-        tableView.backgroundColor = .milk
+        tableView.backgroundColor = .bgPrimary
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 120
         tableView.estimatedSectionHeaderHeight = 48


### PR DESCRIPTION
# Why?

As an initial step to support dark mode in all FinniversKit

# What?

- Replace `.marble` usages for `.bgTertiary`
- Replace `.milk` for `.bgPrimary`
- Replace `.ice` for `.bgSecondary`

This according to the color palette present in trello.

There will be more refinements, per-view, but for now we do a common conversion to dark mode

# Show me

| Before | After |
| --- | --- |
| ![loan-calculator-1](https://user-images.githubusercontent.com/167989/66755279-f3d7f680-ee97-11e9-8009-536c30c71d54.png) | ![loan-calculator-2](https://user-images.githubusercontent.com/167989/66755038-81ffad00-ee97-11e9-88a8-f67a333096a4.png) |
| ![favorites1](https://user-images.githubusercontent.com/167989/66755183-cbe89300-ee97-11e9-8e47-fb413ff88ceb.png) | ![favorite-list-2](https://user-images.githubusercontent.com/167989/66755040-81ffad00-ee97-11e9-971c-583743335152.png) |
| ![feedback1](https://user-images.githubusercontent.com/167989/66755180-cbe89300-ee97-11e9-8cac-be71ce0dcf00.png) | ![feedback-2](https://user-images.githubusercontent.com/167989/66755041-82984380-ee97-11e9-96da-0c5710cc8d66.png) |
| ![grid1](https://user-images.githubusercontent.com/167989/66755182-cbe89300-ee97-11e9-8ba3-0bb20d1b5a16.png) | ![grid2](https://user-images.githubusercontent.com/167989/66755042-82984380-ee97-11e9-9627-541c93711b57.png) |
| ![loginentry](https://user-images.githubusercontent.com/167989/66755184-cc812980-ee97-11e9-911f-5a6a41789892.png) | ![loginentry-2](https://user-images.githubusercontent.com/167989/66755584-93958480-ee98-11e9-976d-cba6bbc98c7e.png) |

