### PR TITLE
Component refinements for dark mode

### DIFF
--- a/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
+++ b/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
@@ -26,7 +26,7 @@ public final class ReviewButtonControl: UIControl {
         let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.backgroundColor = .clear
-        imageView.tintColor = .iconPrimary
+        imageView.tintColor = .iconSecondary
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFit
         return imageView

--- a/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
+++ b/Sources/Components/Control/ReviewButtonControl/ReviewButtonControl.swift
@@ -26,7 +26,7 @@ public final class ReviewButtonControl: UIControl {
         let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.backgroundColor = .clear
-        imageView.tintColor = .bgPrimary
+        imageView.tintColor = .iconPrimary
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFit
         return imageView
@@ -35,7 +35,7 @@ public final class ReviewButtonControl: UIControl {
     private lazy var titleLabel: Label = {
         let label = Label(style: .bodyStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .bgPrimary
+        label.textColor = .textTertiary
         label.textAlignment = .center
         return label
     }()

--- a/Sources/Components/NativeAdvert/NativeAdvertView.swift
+++ b/Sources/Components/NativeAdvert/NativeAdvertView.swift
@@ -44,6 +44,7 @@ public final class NativeAdvertView: UIView {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .iconPrimary
         return imageView
     }()
 
@@ -58,7 +59,7 @@ public final class NativeAdvertView: UIView {
     private lazy var sponsoredByLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.numberOfLines = 1
-        label.textColor = .textPrimary
+        label.textColor = .textToast
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         label.setContentHuggingPriority(.required, for: .horizontal)

--- a/Sources/Components/NativeAdvert/NativeContentAdvertView.swift
+++ b/Sources/Components/NativeAdvert/NativeContentAdvertView.swift
@@ -50,6 +50,7 @@ public final class NativeContentAdvertView: UIView {
         label.numberOfLines = 0
         label.minimumScaleFactor = 0.5
         label.adjustsFontSizeToFitWidth = true
+        label.textColor = .textToast
         return label
     }()
 

--- a/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
+++ b/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
@@ -36,14 +36,14 @@ final class NativeContentSettingsButton: UIButton {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.isUserInteractionEnabled = false
         imageView.image = UIImage(named: .settings).withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = .iconPrimary
+        imageView.tintColor = .iconSecondary
         return imageView
     }()
 
     private lazy var label: Label = {
         let label = Label(style: .detailStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .textPrimary
+        label.textColor = .textTertiary
         return label
     }()
 

--- a/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
+++ b/Sources/Components/NativeAdvert/NativeContentSettingsButton.swift
@@ -36,14 +36,14 @@ final class NativeContentSettingsButton: UIButton {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.isUserInteractionEnabled = false
         imageView.image = UIImage(named: .settings).withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = .foregroundColor
+        imageView.tintColor = .iconPrimary
         return imageView
     }()
 
     private lazy var label: Label = {
         let label = Label(style: .detailStrong)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .foregroundColor
+        label.textColor = .textPrimary
         return label
     }()
 

--- a/Sources/Components/Panel/Panel+Style.swift
+++ b/Sources/Components/Panel/Panel+Style.swift
@@ -33,6 +33,7 @@ extension Panel {
 
         var textColor: UIColor {
             switch self {
+            case .tips, .newFunctionality, .success, .warning, .error: return .textToast
             default: return .textPrimary
             }
         }

--- a/Sources/Components/ReviewButtonView/ReviewButtonView.swift
+++ b/Sources/Components/ReviewButtonView/ReviewButtonView.swift
@@ -25,7 +25,7 @@ public final class ReviewButtonView: UIView {
 
     private lazy var hairlineSeperator: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = .textDisabled
+        view.backgroundColor = .tableViewSeparator
         return view
     }()
 

--- a/Sources/Components/Toast/ToastButton.swift
+++ b/Sources/Components/Toast/ToastButton.swift
@@ -32,9 +32,9 @@ internal class ToastButton: UIButton {
 
         switch buttonStyle {
         case .normal:
-            setTitleColor(.btnPrimary, for: .normal)
+            setTitleColor(.textAction, for: .normal)
         case .promoted:
-            setTitleColor(.textPrimary, for: .normal)
+            setTitleColor(.textToast, for: .normal)
             contentEdgeInsets = UIEdgeInsets(vertical: .mediumSpacing, horizontal: .mediumLargeSpacing)
             layer.borderColor = .bgPrimary
             layer.borderWidth = 2

--- a/Sources/Components/Toast/ToastView.swift
+++ b/Sources/Components/Toast/ToastView.swift
@@ -32,6 +32,7 @@ public class ToastView: UIView {
         let label = Label(style: .body)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
+        label.textColor = .textToast
         return label
     }()
 

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -97,6 +97,10 @@ import UIKit
     public class var iconPrimary: UIColor {
         return .textPrimary
     }
+
+    public class var iconSecondary: UIColor {
+        return .textTertiary
+    }
 }
 
 // MARK: - FINN UIColors

--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -21,18 +21,8 @@ public class AddressView: UIView {
             control.selectedSegmentTintColor = .bgTertiary
             control.backgroundColor = .btnPrimary
             control.setTitleTextAttributes([.foregroundColor: UIColor.textTertiary], for: .normal)
-<<<<<<< HEAD
-<<<<<<< HEAD
+            control.setTitleTextAttributes([.foregroundColor: UIColor.textTertiary], for: .highlighted)
             control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .selected)
-            control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .highlighted)
-=======
-            control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .selected)
-            control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .highlighted)
->>>>>>> 004bfef4... Fix the style for the UISegmentedControls used
-=======
-            control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .selected)
-            control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .highlighted)
->>>>>>> b3b225b3... Update the selected segment text as textAction color
         } else {
             control.tintColor = .btnPrimary
         }

--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -22,12 +22,17 @@ public class AddressView: UIView {
             control.backgroundColor = .btnPrimary
             control.setTitleTextAttributes([.foregroundColor: UIColor.textTertiary], for: .normal)
 <<<<<<< HEAD
+<<<<<<< HEAD
             control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .selected)
             control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .highlighted)
 =======
             control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .selected)
             control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .highlighted)
 >>>>>>> 004bfef4... Fix the style for the UISegmentedControls used
+=======
+            control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .selected)
+            control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .highlighted)
+>>>>>>> b3b225b3... Update the selected segment text as textAction color
         } else {
             control.tintColor = .btnPrimary
         }

--- a/Sources/Fullscreen/AddressView/AddressView.swift
+++ b/Sources/Fullscreen/AddressView/AddressView.swift
@@ -21,8 +21,13 @@ public class AddressView: UIView {
             control.selectedSegmentTintColor = .bgTertiary
             control.backgroundColor = .btnPrimary
             control.setTitleTextAttributes([.foregroundColor: UIColor.textTertiary], for: .normal)
+<<<<<<< HEAD
             control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .selected)
             control.setTitleTextAttributes([.foregroundColor: UIColor.textAction], for: .highlighted)
+=======
+            control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .selected)
+            control.setTitleTextAttributes([.foregroundColor: UIColor.textPrimary], for: .highlighted)
+>>>>>>> 004bfef4... Fix the style for the UISegmentedControls used
         } else {
             control.tintColor = .btnPrimary
         }

--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -46,7 +46,7 @@ public class AdsGridViewCell: UICollectionViewCell {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .iconPrimary
+        imageView.tintColor = .iconSecondary
         return imageView
     }()
 

--- a/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
+++ b/Sources/Recycling/GridViews/Ads/Cell/AdsGridViewCell.swift
@@ -46,7 +46,7 @@ public class AdsGridViewCell: UICollectionViewCell {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .bgPrimary
+        imageView.tintColor = .iconPrimary
         return imageView
     }()
 


### PR DESCRIPTION
# Why?

because of dark mode 🕶 

# What?

- I went through all the components in dark mode and fixed the ones that needed it
  - toast
  - review button
  - panel
  - AdsGridViewCell
  - NativeAdvertView

With this both **DNA** and **Components** are fully dark mode compatible. Next I will move to: Cells, Recyclable and Fullscreen

# Show me

| Screen | Before | After |
| :---: | --- | --- |
| AdsGridViewCell | ![img](https://user-images.githubusercontent.com/167989/66924939-d63b9600-f02b-11e9-943d-312517b7314c.png) | ![img](https://user-images.githubusercontent.com/167989/66924938-d63b9600-f02b-11e9-9020-1784a0c515c5.png) |
| NativeAdvertView | ![img](https://user-images.githubusercontent.com/167989/66924941-d6d42c80-f02b-11e9-848b-213bf7007645.png) |  ![img](https://user-images.githubusercontent.com/167989/66924940-d63b9600-f02b-11e9-83b3-af7ca7c7db5c.png) |
| Panel | ![img](https://user-images.githubusercontent.com/167989/66924943-d6d42c80-f02b-11e9-8318-75a9bc4a4798.png) | ![img](https://user-images.githubusercontent.com/167989/66924942-d6d42c80-f02b-11e9-8678-028b45fe3e57.png) |
| review button | ![img](https://user-images.githubusercontent.com/167989/66924945-d6d42c80-f02b-11e9-86a9-1e656629d3c1.png) | ![img](https://user-images.githubusercontent.com/167989/66924944-d6d42c80-f02b-11e9-9561-9c8940feac9a.png) |
| toast | ![img](https://user-images.githubusercontent.com/167989/66924949-d76cc300-f02b-11e9-9059-2adadce55b0d.png) | ![img](https://user-images.githubusercontent.com/167989/66924948-d76cc300-f02b-11e9-9890-7ecf862049ef.png) |