### PR TITLE
Experiment: Add Xcode Previews to the `ChristmasWishListDemoView`

### DIFF
--- a/Demo/Components/ChristmasWishList/ChristmasWishListDemoView.swift
+++ b/Demo/Components/ChristmasWishList/ChristmasWishListDemoView.swift
@@ -76,6 +76,7 @@ struct ChristmasWishListDemoWrapperView: UIViewRepresentable {
 }
 
 @available(iOS 13.0, *)
+// swiftlint:disable:next type_name
 struct ChristmasWishListDemoView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Demo/Components/ChristmasWishList/ChristmasWishListDemoView.swift
+++ b/Demo/Components/ChristmasWishList/ChristmasWishListDemoView.swift
@@ -62,3 +62,46 @@ extension ChristmasWishListViewModel {
         )
     }
 }
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct ChristmasWishListDemoWrapperView: UIViewRepresentable {
+    func updateUIView(_ uiView: ChristmasWishListDemoView, context: Context) {
+    }
+
+    func makeUIView(context: Context) -> ChristmasWishListDemoView {
+        return ChristmasWishListDemoView()
+    }
+}
+
+@available(iOS 13.0, *)
+struct ChristmasWishListDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ChristmasWishListDemoWrapperView()
+
+            ChristmasWishListDemoWrapperView()
+                .environment(\.colorScheme, ColorScheme.dark)
+                .previewDisplayName("Dark")
+
+            ChristmasWishListDemoWrapperView()
+                .previewDevice(PreviewDevice.init(stringLiteral: "iPhone SE"))
+                .previewDisplayName("iPhone SE")
+
+            ChristmasWishListDemoWrapperView()
+                .previewDevice(PreviewDevice.init(stringLiteral: "iPhone 8"))
+                .previewDisplayName("iPhone 8")
+
+            ChristmasWishListDemoWrapperView()
+                .previewDevice(PreviewDevice.init(stringLiteral: "iPad Pro (11-inch)"))
+                .previewDisplayName("iPad Pro")
+
+            ChristmasWishListDemoWrapperView()
+                .previewDevice(PreviewDevice.init(stringLiteral: "iPad Pro (11-inch)"))
+                .environment(\.colorScheme, ColorScheme.dark)
+                .previewDisplayName("iPad Pro Dark")
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# Why?

As a test on how to use Xcode previews in catalina 😎 

# What?

- Add a wrapper for the ChristmasWishListDemoView for swiftUI
- Use swift UI to create a preview for ChristmasWishListDemoView in different settings

# Show me

<img width="1680" alt="Screenshot 2019-10-23 at 22 49 27" src="https://user-images.githubusercontent.com/167989/67433616-b8040600-f5e8-11e9-8991-0badf266da74.png">
<img width="1680" alt="Screenshot 2019-10-23 at 22 50 46" src="https://user-images.githubusercontent.com/167989/67433614-b76b6f80-f5e8-11e9-9865-1f484d639a3a.png">

Gif

http://www.giphy.com/gifs/YpTb00TZmzz2sGJf1o

# Notes

This should be safe to run even on Mojave, since we use Xcode 11 all the dependencies are there but the previous won't show

Since I opted for creating a preview over a demo view, it's easy to make a UIViewRepresentable for any demo view and make the previews with that UIViewRepresentable