### PR TITLE
Bottom sheet: check if modal presentation style is not custom

### DIFF
--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -118,7 +118,6 @@ public class BottomSheet: UIViewController {
     let notchHeight: CGFloat = 20
     var isDefaultPresentationStyle: Bool { modalPresentationStyle == .custom }
 
-
     // MARK: - Private properties
 
     private let transitionDelegate: BottomSheetTransitioningDelegate

--- a/Sources/Components/BottomSheet/Controller/BottomSheet.swift
+++ b/Sources/Components/BottomSheet/Controller/BottomSheet.swift
@@ -77,7 +77,7 @@ public class BottomSheet: UIViewController {
         get { transitionDelegate.presentationController?.state ?? .dismissed }
         set {
             transitionDelegate.presentationController?.state = newValue
-            if isPopover {
+            if !isDefaultPresentationStyle && newValue == .dismissed {
                 delegate?.bottomSheet(self, didDismissBy: .none)
                 dismiss(animated: true, completion: nil)
             }
@@ -116,7 +116,8 @@ public class BottomSheet: UIViewController {
     }
 
     let notchHeight: CGFloat = 20
-    var isPopover: Bool { modalPresentationStyle == .popover }
+    var isDefaultPresentationStyle: Bool { modalPresentationStyle == .custom }
+
 
     // MARK: - Private properties
 

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionSheet.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionSheet.swift
@@ -51,7 +51,7 @@ public final class FavoriteFolderActionSheet: BottomSheet {
         super.viewDidLoad()
         viewController?.delegate = self
 
-        let animationOffsetMultiplier: CGFloat = isPopover ? -2 : (isShared ? 1 : 2)
+        let animationOffsetMultiplier: CGFloat = !isDefaultPresentationStyle ? -2 : (isShared ? 1 : 2)
         let maxTransitionOffset = Height.transitionOffset(for: viewModel)
 
         positionObservationToken = view.layer.observe(\.position, options: [.new, .old]) { [weak self] _, change in


### PR DESCRIPTION
# Why?

Sometimes it makes sense to present bottom sheet controller not only as popover, but for example, as a form sheet.

# What?

Dismiss the bottom sheet when state is set to `.dismissed` and modal presentation style is not custom.

# Show me

No UI changes.
