### PR TITLE
Fix the way a bank logo is renderd in LoanCalculator

### DIFF
--- a/Sources/Components/LoanCalculator/LoanHeaderView.swift
+++ b/Sources/Components/LoanCalculator/LoanHeaderView.swift
@@ -62,7 +62,8 @@ class LoanHeaderView: UIView {
 
     private lazy var logoImageView: RemoteImageView = {
         let imageView = RemoteImageView(withAutoLayout: true)
-        imageView.contentMode = .scaleAspectFill
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
         imageView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         imageView.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return imageView


### PR DESCRIPTION
# Why?

I noticed some issues when displaying the nordea logo with the current
implementation to the loan calculator.

# Show me

| Before | After |
| --- | --- |
| ![Screenshot 2019-10-30 at 12 50 59](https://user-images.githubusercontent.com/167989/67856037-f8e1aa80-fb13-11e9-8adf-a2b12985cd87.png) | ![Screenshot 2019-10-30 at 12 50 19](https://user-images.githubusercontent.com/167989/67856038-f8e1aa80-fb13-11e9-98c6-66a9007e163d.png) |

