### PR TITLE
New favorites: add new appearance style to folder actions

### DIFF
--- a/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionViewController.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionViewController.swift
@@ -72,7 +72,7 @@ public final class FavoriteFolderActionViewController: UIViewController {
         let constant = isShared ? rowHeight : 0
 
         switch self.viewModel.appearance {
-        case .standard, .xmasFolder:
+        case .regular, .xmasFolder:
             return deleteButton.topAnchor.constraint(equalTo: shareToggleView.bottomAnchor, constant: constant)
         case .defaultFolder:
             return shareLinkView.topAnchor.constraint(equalTo: shareToggleView.topAnchor, constant: constant)
@@ -170,7 +170,7 @@ public final class FavoriteFolderActionViewController: UIViewController {
         ]
 
         switch viewModel.appearance {
-        case .standard:
+        case .regular:
             view.addSubview(changeNameButton)
             view.addSubview(deleteButton)
 
@@ -234,7 +234,7 @@ extension FavoriteFolderActionViewController: FavoriteFolderShareLinkViewDelegat
 private extension FavoriteFolderActionViewModel.Appearance {
     var actions: Set<FavoriteFolderAction> {
         switch self {
-        case .standard:
+        case .regular:
             return Set(FavoriteFolderAction.allCases)
         case .defaultFolder:
             return Set([.edit, .toggleSharing, .shareLink])

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionViewController.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/FavoriteFolderActionViewController.swift
@@ -72,9 +72,9 @@ public final class FavoriteFolderActionViewController: UIViewController {
         let constant = isShared ? rowHeight : 0
 
         switch self.viewModel.appearance {
-        case .full:
+        case .standard, .xmasFolder:
             return deleteButton.topAnchor.constraint(equalTo: shareToggleView.bottomAnchor, constant: constant)
-        case .minimal:
+        case .defaultFolder:
             return shareLinkView.topAnchor.constraint(equalTo: shareToggleView.topAnchor, constant: constant)
         }
     }()
@@ -163,8 +163,14 @@ public final class FavoriteFolderActionViewController: UIViewController {
             shareLinkView.heightAnchor.constraint(equalToConstant: rowHeight)
         ]
 
+        let deleteButtonConstraints = [
+            deleteButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            deleteButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            deleteButton.heightAnchor.constraint(equalToConstant: rowHeight)
+        ]
+
         switch viewModel.appearance {
-        case .full:
+        case .standard:
             view.addSubview(changeNameButton)
             view.addSubview(deleteButton)
 
@@ -175,16 +181,19 @@ public final class FavoriteFolderActionViewController: UIViewController {
                 changeNameButton.heightAnchor.constraint(equalToConstant: rowHeight),
 
                 shareToggleView.topAnchor.constraint(equalTo: changeNameButton.bottomAnchor),
-                shareLinkView.bottomAnchor.constraint(equalTo: deleteButton.topAnchor),
-
-                deleteButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                deleteButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                deleteButton.heightAnchor.constraint(equalToConstant: rowHeight)
-            ])
-        case .minimal:
+                shareLinkView.bottomAnchor.constraint(equalTo: deleteButton.topAnchor)
+            ] + deleteButtonConstraints)
+        case .defaultFolder:
             constraints.append(contentsOf: [
                 shareToggleView.topAnchor.constraint(equalTo: editButton.bottomAnchor)
             ])
+        case .xmasFolder:
+            view.addSubview(deleteButton)
+
+            constraints.append(contentsOf: [
+                shareToggleView.topAnchor.constraint(equalTo: editButton.bottomAnchor),
+                shareLinkView.bottomAnchor.constraint(equalTo: deleteButton.topAnchor)
+            ] + deleteButtonConstraints)
         }
 
         constraints.append(animatingConstraint)
@@ -194,7 +203,7 @@ public final class FavoriteFolderActionViewController: UIViewController {
     private func updateSeparators() {
         editButton.isSeparatorHidden = false
         changeNameButton.isSeparatorHidden = false
-        shareToggleView.isSeparatorHidden = viewModel.appearance == .minimal || isShared
+        shareToggleView.isSeparatorHidden = viewModel.appearance == .defaultFolder || isShared
     }
 
     // MARK: - Actions
@@ -225,10 +234,12 @@ extension FavoriteFolderActionViewController: FavoriteFolderShareLinkViewDelegat
 private extension FavoriteFolderActionViewModel.Appearance {
     var actions: Set<FavoriteFolderAction> {
         switch self {
-        case .full:
+        case .standard:
             return Set(FavoriteFolderAction.allCases)
-        case .minimal:
+        case .defaultFolder:
             return Set([.edit, .toggleSharing, .shareLink])
+        case .xmasFolder:
+            return Set([.edit, .toggleSharing, .shareLink, .delete])
         }
     }
 }

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/ViewModels/FavoriteFolderActionViewModel.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/ViewModels/FavoriteFolderActionViewModel.swift
@@ -6,8 +6,9 @@ import Foundation
 
 public struct FavoriteFolderActionViewModel {
     public enum Appearance {
-        case full
-        case minimal
+        case standard
+        case defaultFolder
+        case xmasFolder
     }
 
     public let appearance: Appearance
@@ -19,7 +20,7 @@ public struct FavoriteFolderActionViewModel {
     public let deleteText: String
 
     public init(
-        appearance: Appearance = .full,
+        appearance: Appearance = .xmasFolder,
         editText: String,
         renameText: String,
         shareToggleText: String,

--- a/Sources/Fullscreen/FavoriteFolderActionSheet/ViewModels/FavoriteFolderActionViewModel.swift
+++ b/Sources/Fullscreen/FavoriteFolderActionSheet/ViewModels/FavoriteFolderActionViewModel.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public struct FavoriteFolderActionViewModel {
     public enum Appearance {
-        case standard
+        case regular
         case defaultFolder
         case xmasFolder
     }
@@ -20,7 +20,7 @@ public struct FavoriteFolderActionViewModel {
     public let deleteText: String
 
     public init(
-        appearance: Appearance = .xmasFolder,
+        appearance: Appearance = .regular,
         editText: String,
         renameText: String,
         shareToggleText: String,


### PR DESCRIPTION
# Why?

It shouldn't be possible to rename Christmas folders, which means we should hide "rename" button in the list of folder actions.

# What?

- Add new favorite folder action appearance
- Rename cases in `FavoriteFolderActionViewModel.Appearance` enum

# Show me

| Regular | Default folder | Xmas folder |
| --- | --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 13 47 42](https://user-images.githubusercontent.com/10529867/67859733-9ccf5400-fb1c-11e9-8d46-ea5edd6626b7.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 13 48 51](https://user-images.githubusercontent.com/10529867/67859745-a2c53500-fb1c-11e9-8897-5902eabcf62d.png)| ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 13 49 29](https://user-images.githubusercontent.com/10529867/67859770-b1135100-fb1c-11e9-995d-777aca808535.png) |