### PR TITLE
New favorites: animate Christmas button and callout only when needed

### DIFF
--- a/Demo/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListDemoView.swift
+++ b/Demo/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListDemoView.swift
@@ -37,7 +37,7 @@ final class FavoriteFoldersListDemoView: UIView, Tweakable {
                 self?.view.setEditing(true)
                 self?.view.hideXmasButton()
             },
-            TweakingOption(title: "Xmass overlay", description: nil) { [weak self] in
+            TweakingOption(title: "Xmas button", description: nil) { [weak self] in
                 let text = "Tips! Nå kan du endelig opprette og dele din egen juleønskeliste! Her er i såfall knappen for å gjøre det! God jul!"
                 self?.view.showXmasButton(withCalloutText: text)
             }

--- a/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -239,6 +239,10 @@ public class FavoriteFoldersListView: UIView {
     // MARK: - Xmas button
 
     public func showXmasButton(withCalloutText text: String?, delay: TimeInterval = 1) {
+        guard xmasButton.isHidden else {
+            return
+        }
+
         setXmasButtonHidden(false, delay: delay, completion: {
             if let text = text {
                 self.xmasCalloutView.isHidden = false
@@ -252,11 +256,15 @@ public class FavoriteFoldersListView: UIView {
     }
 
     public func hideXmasButton(delay: TimeInterval = 0) {
-        xmasCalloutView.hide()
+        if !xmasCalloutView.isHidden {
+            xmasCalloutView.hide()
+        }
 
-        setXmasButtonHidden(true, delay: delay, completion: {
-            self.xmasCalloutView.isHidden = true
-        })
+        if !xmasButton.isHidden {
+            setXmasButtonHidden(true, delay: delay, completion: {
+                self.xmasCalloutView.isHidden = true
+            })
+        }
     }
 
     private func setXmasButtonHidden(_ hidden: Bool, delay: TimeInterval = 0, completion: @escaping () -> Void) {


### PR DESCRIPTION
# Why?

There is no need to animate xmas button and callout if they are already visible/hidden.

# What?

Check if xmas button and callout are already visible/hidden before performing animations.

# Show me

No UI changes.