### PR TITLE
Fixed issue with constraints on TextView's placeholderLabel

### DIFF
--- a/Sources/Components/TextView/TextView.swift
+++ b/Sources/Components/TextView/TextView.swift
@@ -118,8 +118,7 @@ public class TextView: UIView {
             placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor, constant: textView.textContainerInset.left + 5),
             placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor, constant: textView.textContainerInset.top),
             placeholderLabel.widthAnchor.constraint(lessThanOrEqualTo: textView.widthAnchor,
-                                                    multiplier: 1.0,
-                                                    constant: textView.textContainerInset.left + textView.textContainerInset.right - 10),
+                                                    constant: -(textView.textContainerInset.left + textView.textContainerInset.right + 10)),
 
             textView.leadingAnchor.constraint(equalTo: leadingAnchor),
             textView.topAnchor.constraint(equalTo: topAnchor),


### PR DESCRIPTION
# Why?

The placeholder-label was anchored outside the `TextView`'s bounds.

# What?

Inverted the width-constraint's constant.

# Show me

### Before
<img width="2032" alt="Screen Shot 2019-11-04 at 10 54 38" src="https://user-images.githubusercontent.com/919713/68112925-d4f6de00-fef2-11e9-86ac-d5ffb9acb253.png">

### After
<img width="2032" alt="Screen Shot 2019-11-04 at 11 02 15" src="https://user-images.githubusercontent.com/919713/68112936-d6c0a180-fef2-11e9-8247-cc61b6035f3b.png">