### PR TITLE
New favorites: Comment view image constraint

### DIFF
--- a/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCommentView.swift
+++ b/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCommentView.swift
@@ -64,7 +64,7 @@ final class FavoriteAdCommentView: UIView {
         let margins = layoutMarginsGuide
 
         NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: margins.topAnchor),
+            imageView.topAnchor.constraint(equalTo: margins.topAnchor, constant: .verySmallSpacing),
             imageView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
             imageView.widthAnchor.constraint(equalToConstant: 15),
             imageView.heightAnchor.constraint(equalToConstant: 14),


### PR DESCRIPTION
# Why?
The speech bubble image's placement within the comment view was a bit off.

# What?
- Add `.verySmallSpacing` as constraint constant.

# Show me

| Before | After |
| --- | --- |
| <img width="545" alt="Screenshot 2019-11-04 at 14 32 22" src="https://user-images.githubusercontent.com/1901556/68125040-f8308600-ff10-11e9-9226-2f3b85606df0.png"> | <img width="545" alt="Screenshot 2019-11-04 at 14 31 59" src="https://user-images.githubusercontent.com/1901556/68125042-f961b300-ff10-11e9-965d-0e611e1d85ce.png"> |
| <img width="545" alt="Screenshot 2019-11-04 at 14 32 22 copy" src="https://user-images.githubusercontent.com/1901556/68125060-01215780-ff11-11e9-9e5e-140eff697e41.png"> | <img width="545" alt="Screenshot 2019-11-04 at 14 31 59 copy" src="https://user-images.githubusercontent.com/1901556/68125064-02528480-ff11-11e9-9f56-c4fc2fd8c7cb.png"> |