### PR TITLE
New favorites: Scroll to top parameter

### DIFF
--- a/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
+++ b/Demo/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
@@ -150,7 +150,7 @@ class FavoriteAdsListDemoView: UIView, Tweakable {
         favoritesListView.setListIsEmpty(viewModels.isEmpty)
         favoritesListView.subtitle = "\(viewModels.count) favoritter"
         sectionDataSource.configureSection(forAds: viewModels, withSort: currentSorting, filterQuery: favoritesListView.searchBarText)
-        favoritesListView.reloadData()
+        favoritesListView.reloadData(scrollToTop: true)
     }
 }
 
@@ -179,14 +179,14 @@ extension FavoriteAdsListDemoView: FavoriteAdsListViewDelegate {
         }
         view.sortingTitle = currentSorting.rawValue
         sectionDataSource.configureSection(forAds: viewModels, withSort: currentSorting, filterQuery: favoritesListView.searchBarText)
-        view.reloadData()
+        view.reloadData(scrollToTop: true)
     }
 
     func favoriteAdsListViewDidFocusSearchBar(_ view: FavoriteAdsListView) {}
 
     func favoriteAdsListView(_ view: FavoriteAdsListView, didChangeSearchText searchText: String) {
         sectionDataSource.configureSection(forAds: viewModels, withSort: currentSorting, filterQuery: view.searchBarText)
-        view.reloadData()
+        view.reloadData(scrollToTop: true)
     }
 
     func favoriteAdsListView(_ view: FavoriteAdsListView, didUpdateTitleLabelVisibility isVisible: Bool) {}

--- a/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -44,7 +44,7 @@ public class FavoriteAdsListView: UIView {
     public var isReadOnly: Bool {
         didSet {
             if didSetTableHeader {
-                reloadData()
+                reloadData(scrollToTop: true)
                 setFooterVewHidden(isReadOnly || isFooterShareButtonHidden)
             }
         }
@@ -218,10 +218,12 @@ public class FavoriteAdsListView: UIView {
 
     // MARK: - Reload
 
-    public func reloadData() {
+    public func reloadData(scrollToTop: Bool) {
         showEmptySearchViewIfNeeded()
 
-        tableView.setContentOffset(.zero, animated: false)
+        if scrollToTop {
+            tableView.setContentOffset(.zero, animated: true)
+        }
         tableView.reloadData()
     }
 


### PR DESCRIPTION
# Why?
We need to more control over when the list of favorite ads scroll to the top. There was a Zendesk complaint about this, and we've seen it ourself as well.

# What?
- Add parameter `scrollToTop` to `FavoriteAdsListView.reloadData()`.

# Show me
_No UI._