### PR TITLE
Bootstrap: Color refactoring suggestion

### DIFF
--- a/Bootstrap/Bootstrap.swift
+++ b/Bootstrap/Bootstrap.swift
@@ -1,13 +1,5 @@
 import Foundation
 
 @objc public class Bootstrap: NSObject {
-    public enum UserInterfaceStyleSupport {
-        @available(iOS 13.0, *)
-        case dynamic
-        case forceLight
-        case forceDark
-    }
-
     public static var isDynamicTypeEnabled: Bool = true
-    public static var userInterfaceStyleSupport: UserInterfaceStyleSupport = .forceLight
 }

--- a/Bootstrap/Palette.swift
+++ b/Bootstrap/Palette.swift
@@ -1,264 +1,215 @@
-public class Palette: NSObject {
-    public static let shared = Palette()
-
-    public var bgPrimary: UIColor?
-    public var bgSecondary: UIColor?
-    public var bgTertiary: UIColor?
-    public var bgBottomSheet: UIColor?
-    public var bgAlert: UIColor?
-    public var bgSuccess: UIColor?
-    public var bgCritical: UIColor?
-    public var btnPrimary: UIColor?
-    public var btnDisabled: UIColor?
-    public var btnCritical: UIColor?
-    public var textPrimary: UIColor?
-    public var textSecondary: UIColor?
-    public var textTertiary: UIColor?
-    public var textAction: UIColor?
-    public var textDisabled: UIColor?
-    public var textCritical: UIColor?
-    public var accentSecondaryBlue: UIColor?
-    public var accentPea: UIColor?
-    public var accentToothpaste: UIColor?
-    public var textCTADisabled: UIColor?
-    public var textToast: UIColor?
-    public var tableViewSeparator: UIColor?
-    public var decorationSubtle: UIColor?
-    public var iconPrimary: UIColor?
-    public var iconSecondary: UIColor?
-    public var defaultCellSelectedBackgroundColor: UIColor?
-}
-
-// MARK: - Semantic colors, dark mode compatible
-@objc extension UIColor {
-    public class var bgPrimary: UIColor {
-        return Palette.shared.bgPrimary ?? dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: UIColor(hex: "#1B1B24"))
+public struct Palette {
+    public var bgPrimary: UIColor
+    public var bgSecondary: UIColor
+    public var bgTertiary: UIColor
+    public var bgBottomSheet: UIColor
+    public var bgAlert: UIColor
+    public var bgSuccess: UIColor
+    public var bgCritical: UIColor
+    public var btnPrimary: UIColor
+    public var btnDisabled: UIColor
+    public var btnCritical: UIColor
+    public var textPrimary: UIColor
+    public var textSecondary: UIColor
+    public var textTertiary: UIColor
+    public var textAction: UIColor
+    public var textDisabled: UIColor
+    public var textCritical: UIColor
+    public var accentSecondaryBlue: UIColor
+    public var accentPea: UIColor
+    public var accentToothpaste: UIColor
+    public var textCTADisabled: UIColor
+    public var textToast: UIColor
+    public var tableViewSeparator: UIColor
+    public var decorationSubtle: UIColor
+    public var iconPrimary: UIColor
+    public var iconSecondary: UIColor
+    public var defaultCellSelectedBackgroundColor: UIColor
+    public var dimmingColor: UIColor
+    
+    public static var current: Palette = .defaultPalette
+    static var defaultPalette: Palette {
+        Palette(bgPrimary: .white,
+                bgSecondary: .lightGray,
+                bgTertiary: .gray,
+                bgBottomSheet: .lightGray,
+                bgAlert: .systemYellow,
+                bgSuccess: .systemGreen,
+                bgCritical: .systemRed,
+                btnPrimary: .systemBlue,
+                btnDisabled: .systemTeal,
+                btnCritical: .systemRed,
+                textPrimary: .darkText,
+                textSecondary: UIColor.darkText.withAlphaComponent(0.8),
+                textTertiary: UIColor.darkText.withAlphaComponent(0.6),
+                textAction: .systemBlue,
+                textDisabled: .systemTeal,
+                textCritical: .systemRed,
+                accentSecondaryBlue: UIColor.systemBlue.withAlphaComponent(0.8),
+                accentPea: .systemGreen,
+                accentToothpaste: UIColor.systemBlue.withAlphaComponent(0.6),
+                textCTADisabled: UIColor.systemBlue.withAlphaComponent(0.6),
+                textToast: .darkText,
+                tableViewSeparator: .lightGray,
+                decorationSubtle: UIColor.lightGray.withAlphaComponent(0.6),
+                iconPrimary: .darkText,
+                iconSecondary: UIColor.darkText.withAlphaComponent(0.8),
+                defaultCellSelectedBackgroundColor: UIColor.lightGray.withAlphaComponent(0.6),
+                dimmingColor: UIColor.black.withAlphaComponent(0.4))
     }
-
-    public class var bgSecondary: UIColor {
-        return Palette.shared.bgSecondary ?? dynamicColorIfAvailable(defaultColor: .ice, darkModeColor: .darkIce)
-    }
-
-    public class var bgTertiary: UIColor {
-        return Palette.shared.bgTertiary ?? dynamicColorIfAvailable(defaultColor: .marble, darkModeColor: UIColor(hex: "#13131A"))
-    }
-
-    public class var bgBottomSheet: UIColor {
-        return Palette.shared.bgBottomSheet ?? dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: .darkIce)
-    }
-
-    public class var bgAlert: UIColor {
-        return Palette.shared.bgAlert ?? .banana
-    }
-
-    public class var bgSuccess: UIColor {
-        return Palette.shared.bgSuccess ?? .mint
-    }
-
-    public class var bgCritical: UIColor {
-        return Palette.shared.bgCritical ?? .salmon
-    }
-
-    public class var btnPrimary: UIColor {
-        return Palette.shared.btnPrimary ?? dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: UIColor(hex: "#006DFB"))
-    }
-
-    public class var btnDisabled: UIColor {
-        return Palette.shared.btnDisabled ?? dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
-    }
-
-    public class var btnCritical: UIColor {
-        return Palette.shared.btnCritical ?? .cherry
-    }
-
-    public class var textPrimary: UIColor {
-        return Palette.shared.textPrimary ?? dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
-    }
-
-    public class var textSecondary: UIColor {
-        return Palette.shared.textSecondary ?? dynamicColorIfAvailable(defaultColor: .stone, darkModeColor: UIColor(hex: "#828699"))
-    }
-
-    public class var textTertiary: UIColor {
-        return Palette.shared.textTertiary ?? .milk
-    }
-
-    public class var textAction: UIColor {
-        return Palette.shared.textAction ?? dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: UIColor(hex: "#3F8BFF"))
-    }
-
-    public class var textDisabled: UIColor {
-        return Palette.shared.textDisabled ?? dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
-    }
-
-    public class var textCritical: UIColor {
-        return Palette.shared.textCritical ?? dynamicColorIfAvailable(defaultColor: .cherry, darkModeColor: .watermelon)
-    }
-
-    public class var textCTADisabled: UIColor {
-        return Palette.shared.textCTADisabled ?? dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: UIColor(hex: "#828699"))
-    }
-
-    public class var textToast: UIColor {
-        return Palette.shared.textToast ?? .licorice
-    }
-
-    public class var tableViewSeparator: UIColor {
-        return Palette.shared.tableViewSeparator ?? dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
-    }
-
-    public class var decorationSubtle: UIColor {
-        return Palette.shared.decorationSubtle ?? .btnDisabled
-    }
-
-    public class var iconPrimary: UIColor {
-        return Palette.shared.iconPrimary ?? .textPrimary
-    }
-
-    public class var iconSecondary: UIColor {
-        return Palette.shared.iconSecondary ?? .textTertiary
-    }
-
-    public class var defaultCellSelectedBackgroundColor: UIColor {
-        let lightSelectedColor = UIColor(r: 230, g: 235, b: 242)!
-        return Palette.shared.defaultCellSelectedBackgroundColor ??  dynamicColorIfAvailable(defaultColor: lightSelectedColor, darkModeColor: lightSelectedColor.withAlphaComponent(0.4))
-    }
-
-    public class var dimmingColor: UIColor {
-        return UIColor.black.withAlphaComponent(0.4) //DARK
+    
+    public init(bgPrimary: UIColor,
+                bgSecondary: UIColor,
+                bgTertiary: UIColor,
+                bgBottomSheet: UIColor,
+                bgAlert: UIColor,
+                bgSuccess: UIColor,
+                bgCritical: UIColor,
+                btnPrimary: UIColor,
+                btnDisabled: UIColor,
+                btnCritical: UIColor,
+                textPrimary: UIColor,
+                textSecondary: UIColor,
+                textTertiary: UIColor,
+                textAction: UIColor,
+                textDisabled: UIColor,
+                textCritical: UIColor,
+                accentSecondaryBlue: UIColor,
+                accentPea: UIColor,
+                accentToothpaste: UIColor,
+                textCTADisabled: UIColor,
+                textToast: UIColor,
+                tableViewSeparator: UIColor,
+                decorationSubtle: UIColor,
+                iconPrimary: UIColor,
+                iconSecondary: UIColor,
+                defaultCellSelectedBackgroundColor: UIColor,
+                dimmingColor: UIColor) {
+        self.bgPrimary = bgPrimary
+        self.bgSecondary = bgSecondary
+        self.bgTertiary = bgTertiary
+        self.bgBottomSheet = bgBottomSheet
+        self.bgAlert = bgAlert
+        self.bgSuccess = bgSuccess
+        self.bgCritical = bgCritical
+        self.btnPrimary = btnPrimary
+        self.btnDisabled = btnDisabled
+        self.btnCritical = btnCritical
+        self.textPrimary = textPrimary
+        self.textSecondary = textSecondary
+        self.textTertiary = textTertiary
+        self.textAction = textAction
+        self.textDisabled = textDisabled
+        self.textCritical = textCritical
+        self.accentSecondaryBlue = accentSecondaryBlue
+        self.accentPea = accentPea
+        self.accentToothpaste = accentToothpaste
+        self.textCTADisabled = textCTADisabled
+        self.textToast = textToast
+        self.tableViewSeparator = tableViewSeparator
+        self.decorationSubtle = decorationSubtle
+        self.iconPrimary = iconPrimary
+        self.iconSecondary = iconSecondary
+        self.defaultCellSelectedBackgroundColor = defaultCellSelectedBackgroundColor
+        self.dimmingColor = dimmingColor
     }
 }
 
-// MARK: - FINN UIColors
-@objc extension UIColor {
-    class var ice: UIColor {
-        return UIColor(r: 241, g: 249, b: 255)!
-    }
-
-    class var milk: UIColor {
-        return UIColor(r: 255, g: 255, b: 255)!
-    }
-
-    class var licorice: UIColor {
-        return UIColor(r: 71, g: 68, b: 69)!
-    }
-
-    class var primaryBlue: UIColor {
-        return UIColor(r: 0, g: 99, b: 251)!
-    }
-
-    class var secondaryBlue: UIColor {
-        return UIColor(r: 6, g: 190, b: 251)!
-    }
-
-    class var stone: UIColor {
-        return UIColor(r: 118, g: 118, b: 118)!
-    }
-
-    class var sardine: UIColor {
-        return UIColor(r: 195, g: 204, b: 217)!
-    }
-
-    class var darkSardine: UIColor {
-        return UIColor(hex: "434359")
-    }
-
-    class var salmon: UIColor {
-        return UIColor(r: 255, g: 239, b: 239)!
-    }
-
-    class var mint: UIColor {
-        return UIColor(r: 204, g: 255, b: 236)!
-    }
-
-    class var toothPaste: UIColor {
-        return UIColor(r: 182, g: 240, b: 255)!
-    }
-
-    class var banana: UIColor {
-        return UIColor(r: 255, g: 245, b: 200)!
-    }
-
-    class var cherry: UIColor {
-        return UIColor(r: 217, g: 39, b: 10)!
-    }
-
-    class var watermelon: UIColor {
-        return UIColor(r: 255, g: 88, b: 68)!
-    }
-
-    class var pea: UIColor {
-        return UIColor(r: 46, g: 230, b: 159)!
-    }
-
-    class var marble: UIColor {
-        return UIColor(r: 246, g: 248, b: 251)!
-    }
-
-    class var midnightBackground: UIColor {
-        return UIColor(hex: "1D1D26")
-    }
-
-    class var midnightSectionHeader: UIColor {
-        return UIColor(hex: "585E8A")
-    }
-
-    class var midnightSectionSeparator: UIColor {
-        return UIColor(hex: "34343E")
-    }
-
-    class var darkIce: UIColor {
-        return UIColor(hex: "#262633")
-    }
-
-    // swiftlint:disable:next identifier_name
-    public convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) {
-        self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: a)
-    }
-
-    /// Base initializer, it creates an instance of `UIColor` using an HEX string.
-    ///
-    /// - Parameter hex: The base HEX string to create the color.
-    public convenience init(hex: String) {
-        let noHashString = hex.replacingOccurrences(of: "#", with: "")
-        let scanner = Scanner(string: noHashString)
-        scanner.charactersToBeSkipped = CharacterSet.symbols
-
-        var hexInt: UInt64 = 0
-        if scanner.scanHexInt64(&hexInt) {
-            let red = (hexInt >> 16) & 0xFF
-            let green = (hexInt >> 8) & 0xFF
-            let blue = (hexInt) & 0xFF
-
-            self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
-        } else {
-            self.init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-        }
-    }
-}
-
-// MARK: - Private helper for creating dynamic color
+// MARK: - Wrappers for Palette.current colors for easy usage
 extension UIColor {
-    public class func dynamicColorIfAvailable(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
-        switch Bootstrap.userInterfaceStyleSupport {
-        case .forceDark:
-            return darkModeColor
-        case .forceLight:
-            return defaultColor
-        case .dynamic:
-            if #available(iOS 13.0, *) {
-                #if swift(>=5.1)
-                return UIColor { traitCollection -> UIColor in
-                    switch traitCollection.userInterfaceStyle {
-                    case .dark:
-                        return darkModeColor
-                    default:
-                        return defaultColor
-                    }
-                }
-                #endif
-            }
-            return defaultColor
-        }
+    class var bgPrimary: UIColor {
+        return Palette.current.bgPrimary
+    }
+
+    class var bgSecondary: UIColor {
+        return Palette.current.bgSecondary
+    }
+
+    class var bgTertiary: UIColor {
+        return Palette.current.bgTertiary
+    }
+
+    class var bgBottomSheet: UIColor {
+        return Palette.current.bgBottomSheet
+    }
+
+    class var bgAlert: UIColor {
+        return Palette.current.bgAlert
+    }
+
+    class var bgSuccess: UIColor {
+        return Palette.current.bgSuccess
+    }
+
+    class var bgCritical: UIColor {
+        return Palette.current.bgCritical
+    }
+
+    class var btnPrimary: UIColor {
+        return Palette.current.btnPrimary
+    }
+
+    class var btnDisabled: UIColor {
+        return Palette.current.btnDisabled
+    }
+
+    class var btnCritical: UIColor {
+        return Palette.current.btnCritical
+    }
+
+    class var textPrimary: UIColor {
+        return Palette.current.textPrimary
+    }
+
+    class var textSecondary: UIColor {
+        return Palette.current.textSecondary
+    }
+
+    class var textTertiary: UIColor {
+        return Palette.current.textTertiary
+    }
+
+    class var textAction: UIColor {
+        return Palette.current.textAction
+    }
+
+    class var textDisabled: UIColor {
+        return Palette.current.textDisabled
+    }
+
+    class var textCritical: UIColor {
+        return Palette.current.textCritical
+    }
+
+    class var textCTADisabled: UIColor {
+        return Palette.current.textCTADisabled
+    }
+
+    class var textToast: UIColor {
+        return Palette.current.textToast
+    }
+
+    class var tableViewSeparator: UIColor {
+        return Palette.current.tableViewSeparator
+    }
+
+    class var decorationSubtle: UIColor {
+        return Palette.current.decorationSubtle
+    }
+
+    class var iconPrimary: UIColor {
+        return Palette.current.iconPrimary
+    }
+
+    class var iconSecondary: UIColor {
+        return Palette.current.iconSecondary
+    }
+
+    class var defaultCellSelectedBackgroundColor: UIColor {
+        return Palette.current.defaultCellSelectedBackgroundColor
+    }
+
+    class var dimmingColor: UIColor {
+        return Palette.current.dimmingColor
     }
 }

--- a/Bootstrap/SelectorTitleView/SelectorTitleView.swift
+++ b/Bootstrap/SelectorTitleView/SelectorTitleView.swift
@@ -98,7 +98,7 @@ public class SelectorTitleView: UIView {
 
         backgroundColor = .bgPrimary
 
-        updateButtonColor()
+        updateButtonColor(.btnPrimary, buttonDisabledColor: .btnDisabled)
         addSubview(button)
         button.fillInSuperview()
 
@@ -121,7 +121,7 @@ public class SelectorTitleView: UIView {
 
     // MARK: - Public
 
-    public func updateButtonColor(_ buttonColor: UIColor = .btnPrimary, buttonDisabledColor: UIColor = .btnDisabled) {
+    public func updateButtonColor(_ buttonColor: UIColor, buttonDisabledColor: UIColor) {
         button.setTitleColor(buttonColor, for: .normal)
         button.setTitleColor(buttonColor.withAlphaComponent(0.5), for: .highlighted)
         button.setTitleColor(buttonColor.withAlphaComponent(0.5), for: .selected)

--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -14,14 +14,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         registerFonts()
-        Palette.current = .finnPalette
 
         let userInterfaceStyle = UserInterfaceStyle(rawValue: UserDefaults.standard.integer(forKey: State.currentUserInterfaceStyleKey))
+        let userInterfaceStyleSupport: FinniversKit.UserInterfaceStyleSupport
         if let userInterfaceStyle = userInterfaceStyle {
-            FinniversKit.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
+            userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
         } else {
-            FinniversKit.userInterfaceStyleSupport = State.defaultUserInterfaceStyleSupport
+            userInterfaceStyleSupport = State.defaultUserInterfaceStyleSupport
         }
+
+        FinniversKit.setup(userInterfaceStyleSupport: userInterfaceStyleSupport)
+
         window = UIWindow(frame: UIScreen.main.bounds)
         if #available(iOS 13.0, *) {
             window?.setWindowUserInterfaceStyle(userInterfaceStyle)

--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -14,12 +14,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         registerFonts()
+        Palette.current = .finnPalette
 
         let userInterfaceStyle = UserInterfaceStyle(rawValue: UserDefaults.standard.integer(forKey: State.currentUserInterfaceStyleKey))
         if let userInterfaceStyle = userInterfaceStyle {
-            Bootstrap.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
+            FinniversKit.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
         } else {
-            Bootstrap.userInterfaceStyleSupport = State.defaultUserInterfaceStyleSupport
+            FinniversKit.userInterfaceStyleSupport = State.defaultUserInterfaceStyleSupport
         }
         window = UIWindow(frame: UIScreen.main.bounds)
         if #available(iOS 13.0, *) {

--- a/Demo/Demo/Helpers.swift
+++ b/Demo/Demo/Helpers.swift
@@ -20,7 +20,7 @@ struct State {
     private static let lastSelectedDeviceKey = "lastSelectedDeviceKey"
     static let currentUserInterfaceStyleKey = "currentUserInterfaceStyleKey"
 
-    static let defaultUserInterfaceStyleSupport: Bootstrap.UserInterfaceStyleSupport = {
+    static let defaultUserInterfaceStyleSupport: FinniversKit.UserInterfaceStyleSupport = {
         if #available(iOS 13.0, *) {
             return .dynamic
         }
@@ -102,10 +102,10 @@ struct State {
         }
         if let userInterfaceStyle = userInterfaceStyle {
             UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
-            Bootstrap.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
+            FinniversKit.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
         } else {
             UserDefaults.standard.removeObject(forKey: currentUserInterfaceStyleKey)
-            Bootstrap.userInterfaceStyleSupport = defaultUserInterfaceStyleSupport
+            FinniversKit.userInterfaceStyleSupport = defaultUserInterfaceStyleSupport
         }
         UserDefaults.standard.synchronize()
     }

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -466,7 +466,7 @@ extension UIColor {
 }
 
 extension Palette {
-    public static var finnPalette: Palette = Palette(
+    static var finnPalette: Palette = Palette(
         bgPrimary: .bgPrimary,
         bgSecondary: .bgSecondary,
         bgTertiary: .bgTertiary,

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -4,6 +4,105 @@
 
 import Bootstrap
 
+@objc extension UIColor {
+    public class var bgPrimary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: UIColor(hex: "#1B1B24"))
+    }
+
+    public class var bgSecondary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .ice, darkModeColor: .darkIce)
+    }
+
+    public class var bgTertiary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .marble, darkModeColor: UIColor(hex: "#13131A"))
+    }
+
+    public class var bgBottomSheet: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .milk, darkModeColor: .darkIce)
+    }
+
+    public class var bgAlert: UIColor {
+        return .banana
+    }
+
+    public class var bgSuccess: UIColor {
+        return .mint
+    }
+
+    public class var bgCritical: UIColor {
+        return .salmon
+    }
+
+    public class var btnPrimary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: UIColor(hex: "#006DFB"))
+    }
+
+    public class var btnDisabled: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
+    }
+
+    public class var btnCritical: UIColor {
+        return .cherry
+    }
+
+    public class var textPrimary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: .milk)
+    }
+
+    public class var textSecondary: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .stone, darkModeColor: UIColor(hex: "#828699"))
+    }
+
+    public class var textTertiary: UIColor {
+        return .milk
+    }
+
+    public class var textAction: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .primaryBlue, darkModeColor: UIColor(hex: "#3F8BFF"))
+    }
+
+    public class var textDisabled: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
+    }
+
+    public class var textCritical: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .cherry, darkModeColor: .watermelon)
+    }
+
+    public class var textCTADisabled: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .licorice, darkModeColor: UIColor(hex: "#828699"))
+    }
+
+    public class var textToast: UIColor {
+        return .licorice
+    }
+
+    public class var tableViewSeparator: UIColor {
+        return dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
+    }
+
+    public class var decorationSubtle: UIColor {
+        return .btnDisabled
+    }
+
+    public class var iconPrimary: UIColor {
+        return .textPrimary
+    }
+
+    public class var iconSecondary: UIColor {
+        return .textTertiary
+    }
+
+    public class var defaultCellSelectedBackgroundColor: UIColor {
+        let lightSelectedColor = UIColor(r: 230, g: 235, b: 242)!
+        return dynamicColorIfAvailable(defaultColor: lightSelectedColor, darkModeColor: lightSelectedColor.withAlphaComponent(0.4))
+    }
+
+    public class var dimmingColor: UIColor {
+        return UIColor.black.withAlphaComponent(0.4) //DARK
+    }
+}
+
 // MARK: - FINN UIColors
 @objc extension UIColor {
     public class var ice: UIColor {
@@ -311,4 +410,89 @@ extension CGColor {
     public class var defaultCellSelectedBackgroundColor: CGColor {
         return UIColor.defaultCellSelectedBackgroundColor.cgColor
     }
+}
+
+extension UIColor {
+    // swiftlint:disable:next identifier_name
+    public convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) {
+        self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: a)
+    }
+
+    /// Base initializer, it creates an instance of `UIColor` using an HEX string.
+    ///
+    /// - Parameter hex: The base HEX string to create the color.
+    public convenience init(hex: String) {
+        let noHashString = hex.replacingOccurrences(of: "#", with: "")
+        let scanner = Scanner(string: noHashString)
+        scanner.charactersToBeSkipped = CharacterSet.symbols
+
+        var hexInt: UInt64 = 0
+        if scanner.scanHexInt64(&hexInt) {
+            let red = (hexInt >> 16) & 0xFF
+            let green = (hexInt >> 8) & 0xFF
+            let blue = (hexInt) & 0xFF
+
+            self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
+        } else {
+            self.init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        }
+    }
+}
+
+// MARK: - Helper for creating dynamic color
+extension UIColor {
+    public class func dynamicColorIfAvailable(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
+        switch FinniversKit.userInterfaceStyleSupport {
+        case .forceDark:
+            return darkModeColor
+        case .forceLight:
+            return defaultColor
+        case .dynamic:
+            if #available(iOS 13.0, *) {
+                #if swift(>=5.1)
+                return UIColor { traitCollection -> UIColor in
+                    switch traitCollection.userInterfaceStyle {
+                    case .dark:
+                        return darkModeColor
+                    default:
+                        return defaultColor
+                    }
+                }
+                #endif
+            }
+            return defaultColor
+        }
+    }
+}
+
+extension Palette {
+    public static var finnPalette: Palette = Palette(
+        bgPrimary: .bgPrimary,
+        bgSecondary: .bgSecondary,
+        bgTertiary: .bgTertiary,
+        bgBottomSheet: .bgBottomSheet,
+        bgAlert: .bgAlert,
+        bgSuccess: .bgSuccess,
+        bgCritical: .bgCritical,
+        btnPrimary: .btnPrimary,
+        btnDisabled: .btnDisabled,
+        btnCritical: .btnCritical,
+        textPrimary: .textPrimary,
+        textSecondary: .textSecondary,
+        textTertiary: .textTertiary,
+        textAction: .textAction,
+        textDisabled: .textDisabled,
+        textCritical: .textCritical,
+        accentSecondaryBlue: .accentSecondaryBlue,
+        accentPea: .accentPea,
+        accentToothpaste: .accentToothpaste,
+        textCTADisabled: .textCTADisabled,
+        textToast: .textToast,
+        tableViewSeparator: .tableViewSeparator,
+        decorationSubtle: .decorationSubtle,
+        iconPrimary: .iconPrimary,
+        iconSecondary: .iconSecondary,
+        defaultCellSelectedBackgroundColor: .defaultCellSelectedBackgroundColor,
+        dimmingColor: .dimmingColor
+    )
 }

--- a/Sources/FinniversKit.swift
+++ b/Sources/FinniversKit.swift
@@ -16,6 +16,11 @@ import Foundation
 
     public static var userInterfaceStyleSupport: UserInterfaceStyleSupport = .forceLight
 
+    public static func setup(userInterfaceStyleSupport: UserInterfaceStyleSupport) {
+        self.userInterfaceStyleSupport = userInterfaceStyleSupport
+        Palette.current = .finnPalette
+    }
+
     static var bundle: Bundle {
         return Bundle(for: FinniversKit.self)
     }

--- a/Sources/FinniversKit.swift
+++ b/Sources/FinniversKit.swift
@@ -7,6 +7,15 @@ import Foundation
 
 /// Class for referencing the framework bundle
 @objc public class FinniversKit: NSObject {
+    public enum UserInterfaceStyleSupport {
+        @available(iOS 13.0, *)
+        case dynamic
+        case forceLight
+        case forceDark
+    }
+
+    public static var userInterfaceStyleSupport: UserInterfaceStyleSupport = .forceLight
+
     static var bundle: Bundle {
         return Bundle(for: FinniversKit.self)
     }


### PR DESCRIPTION
**Note: This is a PR for discussing changes to Bootstrap**

# Why?
There were some things with Bootstrap color handling that didn't feel quite right. This is a suggestion for change, open for discussion.

# What?
- Moved UserInterfaceStyleSupport back to FinniversKit, this should not be needed in Bootstrap since it gets all color set into Palette.
- Refactored Bootstrap.Palette to have default values for all colors. I did not spend a lot of time choosing the default colors. 😛 
- Made Bootstrap UIColor extension internal, is not so nice to pollute the "namespace" unless everything is at least prefixed (I think FinniversKit can do this since it is for FINN use and we want to always use those color names).
- Moved all the FINN colors to FinniversKit.
- FinniversKit defines a Palette object initialized with FINN colors.
- Added a setup method to FinniversKit class. This should handle all important setup values, for now only UserInterfaceStyleSupport but things like dynamic fonts should also be there. Setup method will then configure Bootstrap to fit FinniversKit.

# Show me
No visible changes.