### PR TITLE
Refactor:`Button.Style` as a `struct` instead of an `enum`

### DIFF
--- a/Sources/Components/Button/Button/Button+Style.swift
+++ b/Sources/Components/Button/Button/Button+Style.swift
@@ -11,7 +11,7 @@ public extension Button {
     }
 
     /// Convenience grouping of button state related properties
-    struct ButtonStateStyle {
+    struct StateStyle: Equatable {
         let textColor: UIColor?
         let backgroundColor: UIColor?
         let borderColor: UIColor?
@@ -67,9 +67,7 @@ public extension Button {
 
         init(
             borderWidth: CGFloat,
-            normalStyle: ButtonStateStyle,
-            highlightedStyle: ButtonStateStyle,
-            disabledStyle: ButtonStateStyle,
+            stateStyles: [UIControl.State: StateStyle],
             margins: UIEdgeInsets = UIEdgeInsets(
                 vertical: .mediumSpacing,
                 horizontal: .mediumLargeSpacing
@@ -78,17 +76,18 @@ public extension Button {
             normalFont: UIFont = .bodyStrong
         ) {
             self.borderWidth = borderWidth
-            self.bodyColor = normalStyle.backgroundColor ?? .bgPrimary
-            self.borderColor = normalStyle.borderColor
-            self.textColor = normalStyle.textColor ?? .textAction
 
-            self.highlightedBodyColor = highlightedStyle.backgroundColor
-            self.highlightedBorderColor = highlightedStyle.borderColor
-            self.highlightedTextColor = highlightedStyle.textColor
+            self.bodyColor = stateStyles[.normal]?.backgroundColor ?? .bgPrimary
+            self.borderColor = stateStyles[.normal]?.borderColor
+            self.textColor = stateStyles[.normal]?.textColor ?? .textAction
 
-            self.disabledBodyColor = disabledStyle.backgroundColor
-            self.disabledBorderColor = disabledStyle.borderColor
-            self.disabledTextColor = disabledStyle.textColor
+            self.highlightedBodyColor = stateStyles[.highlighted]?.backgroundColor
+            self.highlightedBorderColor = stateStyles[.highlighted]?.borderColor
+            self.highlightedTextColor = stateStyles[.highlighted]?.textColor
+
+            self.disabledBodyColor = stateStyles[.disabled]?.backgroundColor
+            self.disabledBorderColor = stateStyles[.disabled]?.borderColor
+            self.disabledTextColor = stateStyles[.disabled]?.textColor
 
             self.margins = margins
             self.smallFont = smallFont
@@ -173,118 +172,130 @@ public extension Button {
 public extension Button.Style {
     static let `default` = Button.Style(
         borderWidth: 2.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textAction,
-            backgroundColor: .bgPrimary,
-            borderColor: .accentSecondaryBlue
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: nil,
-            backgroundColor: .defaultButtonHighlightedBodyColor,
-            borderColor: .btnPrimary
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: .textDisabled,
-            backgroundColor: nil,
-            borderColor: .btnDisabled
-        )
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textAction,
+                backgroundColor: .bgPrimary,
+                borderColor: .accentSecondaryBlue
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: nil,
+                backgroundColor: .defaultButtonHighlightedBodyColor,
+                borderColor: .btnPrimary
+            ),
+            .disabled: Button.StateStyle(
+                textColor: .textDisabled,
+                backgroundColor: nil,
+                borderColor: .btnDisabled
+            )
+        ]
     )
 
     static let callToAction = Button.Style(
         borderWidth: 0.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textTertiary,
-            backgroundColor: .btnPrimary,
-            borderColor: nil
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: nil,
-            backgroundColor: .callToActionButtonHighlightedBodyColor,
-            borderColor: nil
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: nil,
-            backgroundColor: .btnDisabled,
-            borderColor: nil
-        )
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textTertiary,
+                backgroundColor: .btnPrimary,
+                borderColor: nil
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: nil,
+                backgroundColor: .callToActionButtonHighlightedBodyColor,
+                borderColor: nil
+            ),
+            .disabled: Button.StateStyle(
+                textColor: nil,
+                backgroundColor: .btnDisabled,
+                borderColor: nil
+            )
+        ]
     )
 
     static let destructive = Button.Style(
         borderWidth: 0.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textTertiary,
-            backgroundColor: .btnCritical,
-            borderColor: nil
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: nil,
-            backgroundColor: .destructiveButtonHighlightedBodyColor,
-            borderColor: nil
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: nil,
-            backgroundColor: .btnDisabled,
-            borderColor: nil
-        )
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textTertiary,
+                backgroundColor: .btnCritical,
+                borderColor: nil
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: nil,
+                backgroundColor: .destructiveButtonHighlightedBodyColor,
+                borderColor: nil
+            ),
+            .disabled: Button.StateStyle(
+                textColor: nil,
+                backgroundColor: .btnDisabled,
+                borderColor: nil
+            )
+        ]
     )
 
     static let flat = Button.Style(
         borderWidth: 0.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textAction,
-            backgroundColor: .clear,
-            borderColor: nil
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: .flatButtonHighlightedTextColor,
-            backgroundColor: nil,
-            borderColor: nil
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: .textDisabled,
-            backgroundColor: nil,
-            borderColor: nil
-        )
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textAction,
+                backgroundColor: .clear,
+                borderColor: nil
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: .flatButtonHighlightedTextColor,
+                backgroundColor: nil,
+                borderColor: nil
+            ),
+            .disabled: Button.StateStyle(
+                textColor: .textDisabled,
+                backgroundColor: nil,
+                borderColor: nil
+            )
+        ]
     )
 
     static let destructiveFlat = Button.Style(
         borderWidth: 0.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textCritical,
-            backgroundColor: .clear,
-            borderColor: nil
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: .destructiveFlatButtonHighlightedTextColor,
-            backgroundColor: nil,
-            borderColor: nil
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: .textDisabled,
-            backgroundColor: nil,
-            borderColor: nil
-        ),
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textCritical,
+                backgroundColor: .clear,
+                borderColor: nil
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: .destructiveFlatButtonHighlightedTextColor,
+                backgroundColor: nil,
+                borderColor: nil
+            ),
+            .disabled: Button.StateStyle(
+                textColor: .textDisabled,
+                backgroundColor: nil,
+                borderColor: nil
+            ),
+        ],
         smallFont: .detailStrong,
         normalFont: .detailStrong
     )
 
     static let link = Button.Style(
         borderWidth: 0.0,
-        normalStyle: Button.ButtonStateStyle(
-            textColor: .textAction,
-            backgroundColor: .clear,
-            borderColor: nil
-        ),
-        highlightedStyle: Button.ButtonStateStyle(
-            textColor: .linkButtonHighlightedTextColor,
-            backgroundColor: nil,
-            borderColor: nil
-        ),
-        disabledStyle: Button.ButtonStateStyle(
-            textColor: .textDisabled,
-            backgroundColor: nil,
-            borderColor: nil
-        ),
+        stateStyles: [
+            .normal: Button.StateStyle(
+                textColor: .textAction,
+                backgroundColor: .clear,
+                borderColor: nil
+            ),
+            .highlighted: Button.StateStyle(
+                textColor: .linkButtonHighlightedTextColor,
+                backgroundColor: nil,
+                borderColor: nil
+            ),
+            .disabled: Button.StateStyle(
+                textColor: .textDisabled,
+                backgroundColor: nil,
+                borderColor: nil
+            ),
+        ],
         margins: UIEdgeInsets(
             vertical: .smallSpacing,
             horizontal: 0
@@ -293,3 +304,5 @@ public extension Button.Style {
         normalFont: .caption
     )
 }
+
+extension UIControl.State: Hashable {}

--- a/Sources/Components/Button/Button/Button+Style.swift
+++ b/Sources/Components/Button/Button/Button+Style.swift
@@ -79,6 +79,41 @@ public extension Button {
                 return borderColor?.cgColor
             }
         }
+
+        /// Given an existing style, this helps to create a new one overriding some of the values of the original style
+        /// This method is intended for styles for concrete cases rather than default styles like `callToAction`
+        func overrideStyle(
+            bodyColor: UIColor? = nil,
+            borderWidth: CGFloat? = nil,
+            borderColor: UIColor? = nil,
+            textColor: UIColor? = nil,
+            highlightedBodyColor: UIColor? = nil,
+            highlightedBorderColor: UIColor? = nil,
+            highlightedTextColor: UIColor? = nil,
+            disabledBodyColor: UIColor? = nil,
+            disabledBorderColor: UIColor? = nil,
+            disabledTextColor: UIColor? = nil,
+            margins: UIEdgeInsets? = nil,
+            smallFont: UIFont? = nil,
+            normalFont: UIFont? = nil
+        ) -> Style {
+            Style(
+                bodyColor: bodyColor ?? self.bodyColor,
+                borderWidth: borderWidth ?? self.borderWidth,
+                borderColor: borderColor ?? self.borderColor,
+                textColor: textColor ?? self.textColor,
+                highlightedBodyColor: highlightedBodyColor ?? self.highlightedBodyColor,
+                highlightedBorderColor: highlightedBorderColor ?? self.highlightedBorderColor,
+                highlightedTextColor: highlightedTextColor ?? self.highlightedTextColor,
+                disabledBodyColor: disabledBodyColor ?? self.disabledBodyColor,
+                disabledBorderColor: disabledBorderColor ?? self.disabledBorderColor,
+                disabledTextColor: disabledTextColor ?? self.disabledTextColor,
+                margins: margins ?? self.margins,
+                smallFont: smallFont ?? self.smallFont,
+                normalFont: normalFont ?? self.normalFont
+            )
+        }
+
         // MARK: - Size dependant methods
 
         func paddings(forSize size: Size) -> UIEdgeInsets {

--- a/Sources/Components/Button/Button/Button+Style.swift
+++ b/Sources/Components/Button/Button/Button+Style.swift
@@ -10,6 +10,13 @@ public extension Button {
         case small
     }
 
+    /// Convenience grouping of button state related properties
+    struct ButtonStateStyle {
+        let textColor: UIColor?
+        let backgroundColor: UIColor?
+        let borderColor: UIColor?
+    }
+
     struct Style: Equatable {
         let bodyColor: UIColor
         let borderWidth: CGFloat
@@ -53,6 +60,36 @@ public extension Button {
             self.disabledBodyColor = disabledBodyColor
             self.disabledBorderColor = disabledBorderColor
             self.disabledTextColor = disabledTextColor
+            self.margins = margins
+            self.smallFont = smallFont
+            self.normalFont = normalFont
+        }
+
+        init(
+            borderWidth: CGFloat,
+            normalStyle: ButtonStateStyle,
+            highlightedStyle: ButtonStateStyle,
+            disabledStyle: ButtonStateStyle,
+            margins: UIEdgeInsets = UIEdgeInsets(
+                vertical: .mediumSpacing,
+                horizontal: .mediumLargeSpacing
+            ),
+            smallFont: UIFont = .detailStrong,
+            normalFont: UIFont = .bodyStrong
+        ) {
+            self.borderWidth = borderWidth
+            self.bodyColor = normalStyle.backgroundColor ?? .bgPrimary
+            self.borderColor = normalStyle.borderColor
+            self.textColor = normalStyle.textColor ?? .textAction
+
+            self.highlightedBodyColor = highlightedStyle.backgroundColor
+            self.highlightedBorderColor = highlightedStyle.borderColor
+            self.highlightedTextColor = highlightedStyle.textColor
+
+            self.disabledBodyColor = disabledStyle.backgroundColor
+            self.disabledBorderColor = disabledStyle.borderColor
+            self.disabledTextColor = disabledStyle.textColor
+
             self.margins = margins
             self.smallFont = smallFont
             self.normalFont = normalFont

--- a/Sources/Components/Button/Button/Button+Style.swift
+++ b/Sources/Components/Button/Button/Button+Style.swift
@@ -172,87 +172,119 @@ public extension Button {
 // MARK: - Styles
 public extension Button.Style {
     static let `default` = Button.Style(
-        bodyColor: .bgPrimary,
         borderWidth: 2.0,
-        borderColor: .accentSecondaryBlue,
-        textColor: .textAction,
-        highlightedBodyColor: .defaultButtonHighlightedBodyColor,
-        highlightedBorderColor: .btnPrimary,
-        highlightedTextColor: nil,
-        disabledBodyColor: nil,
-        disabledBorderColor: .btnDisabled,
-        disabledTextColor: .textDisabled
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textAction,
+            backgroundColor: .bgPrimary,
+            borderColor: .accentSecondaryBlue
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: nil,
+            backgroundColor: .defaultButtonHighlightedBodyColor,
+            borderColor: .btnPrimary
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: .textDisabled,
+            backgroundColor: nil,
+            borderColor: .btnDisabled
+        )
     )
 
     static let callToAction = Button.Style(
-        bodyColor: .btnPrimary,
         borderWidth: 0.0,
-        borderColor: nil,
-        textColor: .textTertiary,
-        highlightedBodyColor: .callToActionButtonHighlightedBodyColor,
-        highlightedBorderColor: nil,
-        highlightedTextColor: nil,
-        disabledBodyColor: .btnDisabled,
-        disabledBorderColor: nil,
-        disabledTextColor: nil
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textTertiary,
+            backgroundColor: .btnPrimary,
+            borderColor: nil
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: nil,
+            backgroundColor: .callToActionButtonHighlightedBodyColor,
+            borderColor: nil
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: nil,
+            backgroundColor: .btnDisabled,
+            borderColor: nil
+        )
     )
 
     static let destructive = Button.Style(
-        bodyColor: .btnCritical,
         borderWidth: 0.0,
-        borderColor: nil,
-        textColor: .textTertiary,
-        highlightedBodyColor: .destructiveButtonHighlightedBodyColor,
-        highlightedBorderColor: nil,
-        highlightedTextColor: nil,
-        disabledBodyColor: .btnDisabled,
-        disabledBorderColor: nil,
-        disabledTextColor: nil
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textTertiary,
+            backgroundColor: .btnCritical,
+            borderColor: nil
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: nil,
+            backgroundColor: .destructiveButtonHighlightedBodyColor,
+            borderColor: nil
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: nil,
+            backgroundColor: .btnDisabled,
+            borderColor: nil
+        )
     )
 
     static let flat = Button.Style(
-        bodyColor: .clear,
         borderWidth: 0.0,
-        borderColor: nil,
-        textColor: .textAction,
-        highlightedBodyColor: nil,
-        highlightedBorderColor: nil,
-        highlightedTextColor: .flatButtonHighlightedTextColor,
-        disabledBodyColor: nil,
-        disabledBorderColor: nil,
-        disabledTextColor: .textDisabled,
-        margins: UIEdgeInsets(
-            vertical: .mediumSpacing,
-            horizontal: .mediumLargeSpacing
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textAction,
+            backgroundColor: .clear,
+            borderColor: nil
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: .flatButtonHighlightedTextColor,
+            backgroundColor: nil,
+            borderColor: nil
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: .textDisabled,
+            backgroundColor: nil,
+            borderColor: nil
         )
     )
 
     static let destructiveFlat = Button.Style(
-        bodyColor: .clear,
         borderWidth: 0.0,
-        borderColor: nil,
-        textColor: .textCritical,
-        highlightedBodyColor: nil,
-        highlightedBorderColor: nil,
-        highlightedTextColor: .destructiveFlatButtonHighlightedTextColor,
-        disabledBodyColor: nil,
-        disabledBorderColor: nil,
-        disabledTextColor: .textDisabled,
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textCritical,
+            backgroundColor: .clear,
+            borderColor: nil
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: .destructiveFlatButtonHighlightedTextColor,
+            backgroundColor: nil,
+            borderColor: nil
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: .textDisabled,
+            backgroundColor: nil,
+            borderColor: nil
+        ),
         smallFont: .detailStrong,
         normalFont: .detailStrong
     )
 
     static let link = Button.Style(
-        bodyColor: .clear,
         borderWidth: 0.0,
-        borderColor: nil,
-        textColor: .textAction,
-        highlightedBodyColor: nil,
-        highlightedBorderColor: nil,
-        highlightedTextColor: .linkButtonHighlightedTextColor,
-        disabledBodyColor: nil,
-        disabledBorderColor: nil,
-        disabledTextColor: .textDisabled,
+        normalStyle: Button.ButtonStateStyle(
+            textColor: .textAction,
+            backgroundColor: .clear,
+            borderColor: nil
+        ),
+        highlightedStyle: Button.ButtonStateStyle(
+            textColor: .linkButtonHighlightedTextColor,
+            backgroundColor: nil,
+            borderColor: nil
+        ),
+        disabledStyle: Button.ButtonStateStyle(
+            textColor: .textDisabled,
+            backgroundColor: nil,
+            borderColor: nil
+        ),
         margins: UIEdgeInsets(
             vertical: .smallSpacing,
             horizontal: 0

--- a/Sources/Components/Button/Button/Button+Style.swift
+++ b/Sources/Components/Button/Button/Button+Style.swift
@@ -10,123 +10,55 @@ public extension Button {
         case small
     }
 
-    enum Style {
-        case `default`
-        case callToAction
-        case destructive
-        case flat
-        case destructiveFlat
-        case link
+    struct Style: Equatable {
+        let bodyColor: UIColor
+        let borderWidth: CGFloat
+        let borderColor: UIColor?
+        let textColor: UIColor
+        let highlightedBodyColor: UIColor?
+        let highlightedBorderColor: UIColor?
+        let highlightedTextColor: UIColor?
+        let disabledBodyColor: UIColor?
+        let disabledBorderColor: UIColor?
+        let disabledTextColor: UIColor?
+        let margins: UIEdgeInsets
+        let smallFont: UIFont
+        let normalFont: UIFont
 
-        var bodyColor: UIColor {
-            switch self {
-            case .default: return .bgPrimary
-            case .link, .flat, .destructiveFlat: return .clear
-            case .callToAction: return .btnPrimary
-            case .destructive: return .btnCritical
-            }
+        init(
+            bodyColor: UIColor,
+            borderWidth: CGFloat,
+            borderColor: UIColor?,
+            textColor: UIColor,
+            highlightedBodyColor: UIColor?,
+            highlightedBorderColor: UIColor?,
+            highlightedTextColor: UIColor?,
+            disabledBodyColor: UIColor?,
+            disabledBorderColor: UIColor?,
+            disabledTextColor: UIColor?,
+            margins: UIEdgeInsets = UIEdgeInsets(
+                vertical: .mediumSpacing,
+                horizontal: .mediumLargeSpacing
+            ),
+            smallFont: UIFont = .detailStrong,
+            normalFont: UIFont = .bodyStrong
+        ) {
+            self.bodyColor = bodyColor
+            self.borderWidth = borderWidth
+            self.borderColor = borderColor
+            self.textColor = textColor
+            self.highlightedBodyColor = highlightedBodyColor
+            self.highlightedBorderColor = highlightedBorderColor
+            self.highlightedTextColor = highlightedTextColor
+            self.disabledBodyColor = disabledBodyColor
+            self.disabledBorderColor = disabledBorderColor
+            self.disabledTextColor = disabledTextColor
+            self.margins = margins
+            self.smallFont = smallFont
+            self.normalFont = normalFont
         }
 
-        var borderWidth: CGFloat {
-            switch self {
-            case .default: return 2.0
-            default: return 0.0
-            }
-        }
-
-        var borderColor: UIColor? {
-            switch self {
-            case .default: return .accentSecondaryBlue
-            default: return nil
-            }
-        }
-
-        var textColor: UIColor {
-            switch self {
-            case .default, .link, .flat: return .textAction
-            case .destructiveFlat: return .textCritical
-            default: return .textTertiary
-            }
-        }
-
-        var highlightedBodyColor: UIColor? {
-            switch self {
-            case .callToAction: return .callToActionButtonHighlightedBodyColor
-            case .destructive: return .destructiveButtonHighlightedBodyColor
-            case .default: return .defaultButtonHighlightedBodyColor
-            default: return nil
-            }
-        }
-
-        var highlightedBorderColor: UIColor? {
-            switch self {
-            case .default: return .btnPrimary //DARK
-            default: return nil
-            }
-        }
-
-        var highlightedTextColor: UIColor? {
-            switch self {
-            case .link: return .linkButtonHighlightedTextColor
-            case .flat: return .flatButtonHighlightedTextColor
-            case .destructiveFlat: return .destructiveFlatButtonHighlightedTextColor
-            default: return nil
-            }
-        }
-
-        var disabledBodyColor: UIColor? {
-            switch self {
-            case .default, .link, .flat, .destructiveFlat: return nil
-            default: return .btnDisabled
-            }
-        }
-
-        var disabledBorderColor: UIColor? {
-            switch self {
-            case .default: return .btnDisabled
-            default: return nil
-            }
-        }
-
-        var disabledTextColor: UIColor? {
-            switch self {
-            case .callToAction, .destructive: return nil
-            default: return .textDisabled
-            }
-        }
-
-        var margins: UIEdgeInsets {
-            switch self {
-            case .link: return UIEdgeInsets(top: .smallSpacing, left: 0, bottom: .smallSpacing, right: 0)
-            default: return UIEdgeInsets(top: .mediumSpacing, left: .mediumLargeSpacing, bottom: .mediumSpacing, right: .mediumLargeSpacing)
-            }
-        }
-
-        func font(forSize size: Size) -> UIFont {
-            switch (self, size) {
-            case (.link, .normal):
-                return .caption
-            case (.link, .small):
-                return .detail
-            case (.destructiveFlat, .normal):
-                return .detailStrong
-            case (_, .normal):
-                return .bodyStrong
-            case (_, .small):
-                return .detailStrong
-            }
-        }
-
-        func paddings(forSize size: Size) -> UIEdgeInsets {
-            switch size {
-            case .normal:
-                return UIEdgeInsets(top: .smallSpacing, left: 0, bottom: .smallSpacing, right: 0)
-            case .small:
-                return .zero
-            }
-        }
-
-        func backgroundColor(forState state: State) -> UIColor? {
+        func backgroundColor(forState state: UIControl.State) -> UIColor? {
             switch state {
             case .highlighted:
                 return highlightedBodyColor
@@ -137,7 +69,7 @@ public extension Button {
             }
         }
 
-        func borderColor(forState state: State) -> CGColor? {
+        func borderColor(forState state: UIControl.State) -> CGColor? {
             switch state {
             case .highlighted:
                 return highlightedBorderColor?.cgColor
@@ -147,5 +79,113 @@ public extension Button {
                 return borderColor?.cgColor
             }
         }
+        // MARK: - Size dependant methods
+
+        func paddings(forSize size: Size) -> UIEdgeInsets {
+            switch size {
+            case .normal: return UIEdgeInsets(vertical: .smallSpacing, horizontal: 0)
+            case .small: return .zero
+            }
+        }
+
+        func font(forSize size: Size) -> UIFont {
+            switch size {
+            case .normal: return normalFont
+            case .small: return smallFont
+            }
+        }
     }
+}
+
+// MARK: - Styles
+public extension Button.Style {
+    static let `default` = Button.Style(
+        bodyColor: .bgPrimary,
+        borderWidth: 2.0,
+        borderColor: .accentSecondaryBlue,
+        textColor: .textAction,
+        highlightedBodyColor: .defaultButtonHighlightedBodyColor,
+        highlightedBorderColor: .btnPrimary,
+        highlightedTextColor: nil,
+        disabledBodyColor: nil,
+        disabledBorderColor: .btnDisabled,
+        disabledTextColor: .textDisabled
+    )
+
+    static let callToAction = Button.Style(
+        bodyColor: .btnPrimary,
+        borderWidth: 0.0,
+        borderColor: nil,
+        textColor: .textTertiary,
+        highlightedBodyColor: .callToActionButtonHighlightedBodyColor,
+        highlightedBorderColor: nil,
+        highlightedTextColor: nil,
+        disabledBodyColor: .btnDisabled,
+        disabledBorderColor: nil,
+        disabledTextColor: nil
+    )
+
+    static let destructive = Button.Style(
+        bodyColor: .btnCritical,
+        borderWidth: 0.0,
+        borderColor: nil,
+        textColor: .textTertiary,
+        highlightedBodyColor: .destructiveButtonHighlightedBodyColor,
+        highlightedBorderColor: nil,
+        highlightedTextColor: nil,
+        disabledBodyColor: .btnDisabled,
+        disabledBorderColor: nil,
+        disabledTextColor: nil
+    )
+
+    static let flat = Button.Style(
+        bodyColor: .clear,
+        borderWidth: 0.0,
+        borderColor: nil,
+        textColor: .textAction,
+        highlightedBodyColor: nil,
+        highlightedBorderColor: nil,
+        highlightedTextColor: .flatButtonHighlightedTextColor,
+        disabledBodyColor: nil,
+        disabledBorderColor: nil,
+        disabledTextColor: .textDisabled,
+        margins: UIEdgeInsets(
+            vertical: .mediumSpacing,
+            horizontal: .mediumLargeSpacing
+        )
+    )
+
+    static let destructiveFlat = Button.Style(
+        bodyColor: .clear,
+        borderWidth: 0.0,
+        borderColor: nil,
+        textColor: .textCritical,
+        highlightedBodyColor: nil,
+        highlightedBorderColor: nil,
+        highlightedTextColor: .destructiveFlatButtonHighlightedTextColor,
+        disabledBodyColor: nil,
+        disabledBorderColor: nil,
+        disabledTextColor: .textDisabled,
+        smallFont: .detailStrong,
+        normalFont: .detailStrong
+    )
+
+    static let link = Button.Style(
+        bodyColor: .clear,
+        borderWidth: 0.0,
+        borderColor: nil,
+        textColor: .textAction,
+        highlightedBodyColor: nil,
+        highlightedBorderColor: nil,
+        highlightedTextColor: .linkButtonHighlightedTextColor,
+        disabledBodyColor: nil,
+        disabledBorderColor: nil,
+        disabledTextColor: .textDisabled,
+        margins: UIEdgeInsets(
+            vertical: .smallSpacing,
+            horizontal: 0
+        ),
+        smallFont: .detail,
+        normalFont: .caption
+    )
 }

--- a/Sources/Components/Button/Button/Button.swift
+++ b/Sources/Components/Button/Button/Button.swift
@@ -21,7 +21,7 @@ public class Button: UIButton {
         didSet { setup() }
     }
 
-    // MARK: - Setup
+    // MARK: - Initializers
 
     public init(style: Style, size: Size = .normal, withAutoLayout: Bool = false) {
         self.style = style
@@ -35,48 +35,7 @@ public class Button: UIButton {
         self.init(style: .default)
     }
 
-    private func setup() {
-        isAccessibilityElement = true
-
-        titleEdgeInsets = style.paddings(forSize: size)
-        contentEdgeInsets = style.margins
-        titleLabel?.font = style.font(forSize: size)
-        titleLabel?.adjustsFontForContentSizeCategory = true
-        layer.cornerRadius = cornerRadius
-        layer.borderWidth = style.borderWidth
-        layer.borderColor = style.borderColor?.cgColor
-        backgroundColor = style.bodyColor
-
-        // Calling super because the method is effectively disabled for this class
-        super.setTitleColor(style.textColor, for: .normal)
-        super.setTitleColor(style.highlightedTextColor, for: .highlighted)
-        super.setTitleColor(style.disabledTextColor, for: .disabled)
-    }
-
-    // MARK: - Superclass Overrides
-
-    public override func setTitle(_ title: String?, for state: UIControl.State) {
-        guard let title = title else {
-            return
-        }
-
-        titleHeight = title.height(withConstrainedWidth: bounds.width, font: style.font(forSize: size))
-        titleWidth = title.width(withConstrainedHeight: bounds.height, font: style.font(forSize: size))
-
-        if style == .link {
-            setAsLink(title: title)
-        } else {
-            super.setTitle(title, for: state)
-        }
-
-        if state == .normal {
-            accessibilityLabel = title
-        }
-    }
-
-    public override func setTitleColor(_ color: UIColor?, for state: UIControl.State) {
-        assertionFailure("The title color cannot be changed outside the class")
-    }
+    // MARK: - Overrides
 
     public override var isHighlighted: Bool {
         didSet {
@@ -105,21 +64,69 @@ public class Button: UIButton {
         return buttonSize
     }
 
+    public override func setTitle(_ title: String?, for state: UIControl.State) {
+        guard let title = title else {
+            return
+        }
+
+        titleHeight = title.height(withConstrainedWidth: bounds.width, font: style.font(forSize: size))
+        titleWidth = title.width(withConstrainedHeight: bounds.height, font: style.font(forSize: size))
+
+        if style == .link {
+            setAsLink(title: title)
+        } else {
+            super.setTitle(title, for: state)
+        }
+
+        if state == .normal {
+            accessibilityLabel = title
+        }
+    }
+
+    public override func setTitleColor(_ color: UIColor?, for state: UIControl.State) {
+        assertionFailure("The title color cannot be changed outside the class")
+    }
+
     // MARK: - Private methods
+
+    private func setup() {
+        isAccessibilityElement = true
+
+        titleEdgeInsets = style.paddings(forSize: size)
+        contentEdgeInsets = style.margins
+        titleLabel?.font = style.font(forSize: size)
+        titleLabel?.adjustsFontForContentSizeCategory = true
+        layer.cornerRadius = cornerRadius
+        layer.borderWidth = style.borderWidth
+        layer.borderColor = style.borderColor?.cgColor
+        backgroundColor = style.bodyColor
+
+        // Calling super because the method is effectively disabled for this class
+        super.setTitleColor(style.textColor, for: .normal)
+        super.setTitleColor(style.highlightedTextColor, for: .highlighted)
+        super.setTitleColor(style.disabledTextColor, for: .disabled)
+    }
 
     private func setAsLink(title: String) {
         let textRange = NSRange(location: 0, length: title.count)
         let attributedTitle = NSMutableAttributedString(string: title)
 
-        attributedTitle.addAttribute(NSAttributedString.Key.foregroundColor, value: style.textColor, range: textRange)
+        attributedTitle.addAttribute(.foregroundColor, value: style.textColor, range: textRange)
         let underlinedAttributedTitle = NSMutableAttributedString(string: title)
+
         let disabledAttributedTitle = NSMutableAttributedString(string: title)
-        disabledAttributedTitle.addAttribute(NSAttributedString.Key.foregroundColor, value: style.disabledTextColor ?? UIColor.textTertiary, range: textRange)
+        disabledAttributedTitle.addAttribute(
+            .foregroundColor,
+            value: style.disabledTextColor ?? UIColor.textTertiary,
+            range: textRange
+        )
+
         let underlineAttributes: [NSAttributedString.Key: Any] = [
-            NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-            NSAttributedString.Key.foregroundColor: style.highlightedTextColor ?? style.textColor
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .foregroundColor: style.highlightedTextColor ?? style.textColor
         ]
         underlinedAttributedTitle.addAttributes(underlineAttributes, range: textRange)
+
         super.setAttributedTitle(attributedTitle, for: .normal)
         super.setAttributedTitle(underlinedAttributedTitle, for: .highlighted)
         super.setAttributedTitle(disabledAttributedTitle, for: .disabled)


### PR DESCRIPTION
# Why?

In several occassions, by design specs, we need button that look like the FINN
buttons, but they have some small modifications. Currently it's not possible to
extend/modify button styles because of their `enum` representation, neither is
possible to create new styles for concret usages outside of the `Style` enum.

# What?

- Re-write `Button.Style` as a `struct` instead of an `enum`
- Add `overrideStyle` method to `Button.Style`

This PR doesn't change the public API for `Button` and `Button.Style`. At the
same time, this will allow to remove unnecessary subclasses of button in order
to create custom buttons for a given use case.

Also, thanks to the snapshot test, we can make sure that the button styles were
not changed with the refactoring 🎉 

## Example

<img width="652" alt="Screenshot 2019-12-05 at 11 15 58" src="https://user-images.githubusercontent.com/167989/70226179-a7e75680-1750-11ea-9ade-09239e4bd9cd.png">

To create the call to action-like button in the screenshot, we can just do:

```swift
extension Button.Style {
    static func applyButton(with accentColor: UIColor) -> Button.Style {
        Button.Style.callToAction.overrideStyle(
            bodyColor: accentColor,
            highlightedBodyColor: accentColor.withAlphaComponent(0.8)
        )
    }
}
```

And then we have a "generic" call to action button with different colors