### PR TITLE
Make `UIColor(r:g:b:a)` a non optional initializer

### DIFF
--- a/Sources/Components/Broadcast/StepIndicator.swift
+++ b/Sources/Components/Broadcast/StepIndicator.swift
@@ -23,7 +23,7 @@ public class StepIndicator: UIView {
     // MARK: - Internal properties
 
     static let animationDuration = 0.25
-    static let activeColor = UIColor(r: 82, g: 188, b: 245)!
+    static let activeColor = UIColor(r: 82, g: 188, b: 245)
     static let inactiveColor = UIColor.decorationSubtle
 
     // MARK: - Private properties

--- a/Sources/Components/EarthHour/Views/EarthHourHeaderView.swift
+++ b/Sources/Components/EarthHour/Views/EarthHourHeaderView.swift
@@ -22,7 +22,7 @@ final class EarthHourHeaderView: UIView {
 
     private lazy var bottomCurveLayer: CAShapeLayer = {
         let layer = CAShapeLayer()
-        layer.fillColor = fillColor?.cgColor
+        layer.fillColor = fillColor.cgColor
         return layer
     }()
 

--- a/Sources/Components/NativeAdvert/NativeContentAdvertView.swift
+++ b/Sources/Components/NativeAdvert/NativeContentAdvertView.swift
@@ -35,7 +35,7 @@ public final class NativeContentAdvertView: UIView {
 
     private lazy var bottomContainerView: UIView = {
         let view = UIView(withAutoLayout: true)
-        view.backgroundColor = UIColor(r: 248, g: 248, b: 248)!
+        view.backgroundColor = UIColor(r: 248, g: 248, b: 248)
         return view
     }()
 

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -431,8 +431,13 @@ extension CGColor {
 
 // MARK: - Public color creation methods
 public extension UIColor {
-    // swiftlint:disable:next identifier_name
-    convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) {
+    /// The UIColor initializer we need it's more natural to write integer values from 0 to 255 than decimas from 0 to 1
+    /// - Parameters:
+    ///   - r: red (0-255)
+    ///   - g: green (0-255)
+    ///   - b: blue (0-255)
+    ///   - a: alpla (0-1)
+    convenience init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) { // swiftlint:disable:this identifier_name
         self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: a)
     }
 

--- a/Sources/DNA/Color/Color.swift
+++ b/Sources/DNA/Color/Color.swift
@@ -114,31 +114,31 @@ import UIKit
 // MARK: - FINN UIColors
 @objc extension UIColor {
     public class var ice: UIColor {
-        return UIColor(r: 241, g: 249, b: 255)!
+        return UIColor(r: 241, g: 249, b: 255)
     }
 
     public class var milk: UIColor {
-        return UIColor(r: 255, g: 255, b: 255)!
+        return UIColor(r: 255, g: 255, b: 255)
     }
 
     public class var licorice: UIColor {
-        return UIColor(r: 71, g: 68, b: 69)!
+        return UIColor(r: 71, g: 68, b: 69)
     }
 
     public class var primaryBlue: UIColor {
-        return UIColor(r: 0, g: 99, b: 251)!
+        return UIColor(r: 0, g: 99, b: 251)
     }
 
     public class var secondaryBlue: UIColor {
-        return UIColor(r: 6, g: 190, b: 251)!
+        return UIColor(r: 6, g: 190, b: 251)
     }
 
     public class var stone: UIColor {
-        return UIColor(r: 118, g: 118, b: 118)!
+        return UIColor(r: 118, g: 118, b: 118)
     }
 
     public class var sardine: UIColor {
-        return UIColor(r: 195, g: 204, b: 217)!
+        return UIColor(r: 195, g: 204, b: 217)
     }
 
     public class var darkSardine: UIColor {
@@ -146,35 +146,35 @@ import UIKit
     }
 
     public class var salmon: UIColor {
-        return UIColor(r: 255, g: 239, b: 239)!
+        return UIColor(r: 255, g: 239, b: 239)
     }
 
     public class var mint: UIColor {
-        return UIColor(r: 204, g: 255, b: 236)!
+        return UIColor(r: 204, g: 255, b: 236)
     }
 
     public class var toothPaste: UIColor {
-        return UIColor(r: 182, g: 240, b: 255)!
+        return UIColor(r: 182, g: 240, b: 255)
     }
 
     public class var banana: UIColor {
-        return UIColor(r: 255, g: 245, b: 200)!
+        return UIColor(r: 255, g: 245, b: 200)
     }
 
     public class var cherry: UIColor {
-        return UIColor(r: 217, g: 39, b: 10)!
+        return UIColor(r: 217, g: 39, b: 10)
     }
 
     public class var watermelon: UIColor {
-        return UIColor(r: 255, g: 88, b: 68)!
+        return UIColor(r: 255, g: 88, b: 68)
     }
 
     public class var pea: UIColor {
-        return UIColor(r: 46, g: 230, b: 159)!
+        return UIColor(r: 46, g: 230, b: 159)
     }
 
     public class var marble: UIColor {
-        return UIColor(r: 246, g: 248, b: 251)!
+        return UIColor(r: 246, g: 248, b: 251)
     }
 
     public class var midnightBackground: UIColor {
@@ -371,7 +371,7 @@ extension CGColor {
     }
 
     public class var defaultButtonHighlightedBodyColor: UIColor {
-        return UIColor(r: 241, g: 249, b: 255)! //DARK btnTertiary?
+        return UIColor(r: 241, g: 249, b: 255) //DARK btnTertiary?
     }
 
     public class var linkButtonHighlightedTextColor: UIColor {
@@ -418,7 +418,7 @@ extension CGColor {
 
 @objc extension UIColor {
     public class var defaultCellSelectedBackgroundColor: UIColor {
-        let lightSelectedColor = UIColor(r: 230, g: 235, b: 242)!
+        let lightSelectedColor = UIColor(r: 230, g: 235, b: 242)
         return dynamicColorIfAvailable(defaultColor: lightSelectedColor, darkModeColor: lightSelectedColor.withAlphaComponent(0.4))
     }
 }

--- a/Sources/Fullscreen/EasterEggs/SnowGlobe/SnowGlobeView.swift
+++ b/Sources/Fullscreen/EasterEggs/SnowGlobe/SnowGlobeView.swift
@@ -17,7 +17,7 @@ public class SnowGlobeView: UIView {
 
     private lazy var gradientLayer: CALayer = {
         let layer = CAGradientLayer()
-        let color = UIColor(r: 0, g: 98, b: 255, a: 0.2) ?? UIColor.black.withAlphaComponent(0.2)
+        let color = UIColor(r: 0, g: 98, b: 255, a: 0.2)
         layer.colors = [UIColor.clear.cgColor, color.cgColor, color.cgColor, UIColor.clear.cgColor]
         layer.locations = [0.0, 0.1, 0.9, 1.0]
         return layer


### PR DESCRIPTION
# Why?

As I could tell there was no a real reason to be an optional, as the
traditional initalizer `UIColor(red:green:blue:alpha)` we expect the users will
use it with the correct values.

Then we can delete a bunch of force unwrapped values.

I considered adding an assertion before calling the designated initializer,
but it felt more an overhead than a real help in here.

I also adapted the currnent calls to this initializer.