### PR TITLE
Early return if the cell has already been selected

### DIFF
--- a/Sources/Recycling/ListViews/PaymentOptions/ListView/PaymentOptionsListView.swift
+++ b/Sources/Recycling/ListViews/PaymentOptions/ListView/PaymentOptionsListView.swift
@@ -147,11 +147,13 @@ extension PaymentOptionsListView: UITableViewDataSource {
 extension PaymentOptionsListView: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         delegate?.paymentOptionsListView(self, didSelectRowAt: indexPath)
+        guard selectedIndexPath != indexPath else { return }
 
         guard selectedIndexPath != nil else {
             selectedIndexPath = indexPath
-            guard let cell = tableView.cellForRow(at: indexPath) as? PaymentOptionsListViewCell else { return }
-            cell.showSelectionCircle(true)
+            if let cell = tableView.cellForRow(at: indexPath) as? PaymentOptionsListViewCell {
+                cell.showSelectionCircle(true)
+            }
             return
         }
 


### PR DESCRIPTION
# Why?

- It reapplies the selection animation along with the view injection into collapse view.

# What?

- Guard that the selected cell hasn't already been selected