### PR TITLE
Fix: IconCollectionView vertical spacing

### DIFF
--- a/Demo/Components/IconCollection/IconCollectionViewDemo.swift
+++ b/Demo/Components/IconCollection/IconCollectionViewDemo.swift
@@ -88,7 +88,7 @@ private extension Array where Element == IconCollectionViewModel {
     static var horizontalModels: [IconCollectionViewModel] {
         [
             IconCollectionViewModel(title: "Modellår", text: "2006", image: UIImage(named: .iconRealestateBedrooms)),
-            IconCollectionViewModel(title: "Kilometerstand", text: "309 000 km", image: UIImage(named: .iconRealestateApartments)),
+            IconCollectionViewModel(title: "Kilometer", text: "309 000", image: UIImage(named: .iconRealestateApartments)),
             IconCollectionViewModel(title: "Girkasse", text: "Manuell", image: UIImage(named: .iconRealestatePrice)),
             IconCollectionViewModel(title: "Drivstoff", text: "Diesel", image: UIImage(named: .iconRealestateOwner))
         ]

--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -45,7 +45,7 @@ public final class IconCollectionView: UIView {
     private lazy var margins: UIEdgeInsets = {
         switch alignment {
         case .horizontal:
-            return UIEdgeInsets(vertical: .mediumSpacing, horizontal: .smallSpacing)
+            return UIEdgeInsets(vertical: .mediumLargeSpacing, horizontal: .smallSpacing)
         case .vertical:
             return .zero
         }


### PR DESCRIPTION
# Why?
After talking to Sanjin he decided to add more vertical spacing to the `IconCollectionView` for horizontal cells.

Some changes has also been made to the proxy response, and the demo has been updated to reflect this.

# Show me
| Before | After |
| --- | --- |
| <img width="504" alt="Screenshot 2020-01-23 at 12 43 11" src="https://user-images.githubusercontent.com/1901556/72982053-7f89e900-3dde-11ea-919f-73e7f33ae199.png"> | <img width="504" alt="Screenshot 2020-01-23 at 12 42 32" src="https://user-images.githubusercontent.com/1901556/72982057-80bb1600-3dde-11ea-84ef-ff0b18e1d8dc.png"> |