### PR TITLE
Motor MP: IconCollectionView tintColor

### DIFF
--- a/Demo/Components/IconCollection/IconCollectionViewDemo.swift
+++ b/Demo/Components/IconCollection/IconCollectionViewDemo.swift
@@ -70,6 +70,7 @@ public class IconCollectionDemoView: UIView, Tweakable {
             collectionView.backgroundColor = .bgSecondary
             collectionView.layer.cornerRadius = 8
             collectionView.clipsToBounds = true
+            collectionView.tintColor = .textPrimary
 
         case .vertical:
             collectionView.configure(with: .verticalModels)
@@ -87,10 +88,10 @@ public class IconCollectionDemoView: UIView, Tweakable {
 private extension Array where Element == IconCollectionViewModel {
     static var horizontalModels: [IconCollectionViewModel] {
         [
-            IconCollectionViewModel(title: "Modellår", text: "2006", image: UIImage(named: .iconRealestateBedrooms)),
-            IconCollectionViewModel(title: "Kilometer", text: "309 000", image: UIImage(named: .iconRealestateApartments)),
-            IconCollectionViewModel(title: "Girkasse", text: "Manuell", image: UIImage(named: .iconRealestatePrice)),
-            IconCollectionViewModel(title: "Drivstoff", text: "Diesel", image: UIImage(named: .iconRealestateOwner))
+            IconCollectionViewModel(title: "Modellår", text: "2006", image: UIImage(named: .iconRealestateBedrooms).withRenderingMode(.alwaysTemplate)),
+            IconCollectionViewModel(title: "Kilometer", text: "309 000", image: UIImage(named: .iconRealestateApartments).withRenderingMode(.alwaysTemplate)),
+            IconCollectionViewModel(title: "Girkasse", text: "Manuell", image: UIImage(named: .iconRealestatePrice).withRenderingMode(.alwaysTemplate)),
+            IconCollectionViewModel(title: "Drivstoff", text: "Diesel", image: UIImage(named: .iconRealestateOwner).withRenderingMode(.alwaysTemplate))
         ]
     }
 

--- a/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/Sources/Components/IconCollection/IconCollectionView.swift
@@ -116,10 +116,12 @@ extension IconCollectionView: UICollectionViewDataSource {
         switch alignment {
         case .horizontal:
             let cell = collectionView.dequeue(HorizontalIconCollectionViewCell.self, for: indexPath)
+            cell.tintColor = tintColor
             cell.configure(with: viewModels[indexPath.item])
             return cell
         case .vertical:
             let cell = collectionView.dequeue(VerticalIconCollectionViewCell.self, for: indexPath)
+            cell.tintColor = tintColor
             cell.configure(with: viewModels[indexPath.item])
             return cell
         }


### PR DESCRIPTION
# Why?
We had no way to configure the tintColor for the cells within this view.

# What?
- Set the `IconCollectionView`'s tintColor as each cell's tintColor 

# Show me
| Before | After |
| --- | --- |
| <img width="545" alt="Screenshot 2020-01-28 at 14 30 47" src="https://user-images.githubusercontent.com/1901556/73268197-cd399380-41da-11ea-87b5-5d91f4d40876.png"> | <img width="545" alt="Screenshot 2020-01-28 at 14 30 22" src="https://user-images.githubusercontent.com/1901556/73268199-ce6ac080-41da-11ea-8262-175e780b25dd.png"> |