### PR TITLE
Fix: set content hugging high for arrow icon in CollpsibleContentView

### DIFF
--- a/Sources/Components/CollpsibleContentView/CollpsibleContentView.swift
+++ b/Sources/Components/CollpsibleContentView/CollpsibleContentView.swift
@@ -49,6 +49,7 @@ public class CollapsibleContentView: UIView {
         imageView.contentMode = .scaleAspectFit
         imageView.tintColor = .iconSecondary
         imageView.isUserInteractionEnabled = true
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return imageView
     }()
 


### PR DESCRIPTION
# Why?

otherwise since that view and a label are inside a stack view, it can
result in ambiuous layout

# Show me

_No UI changes_