### PR TITLE
Add configurable extra insets making AddressView polygons fit

### DIFF
--- a/Demo/Fullscreen/AddressMapView/AddressMapDemoView.swift
+++ b/Demo/Fullscreen/AddressMapView/AddressMapDemoView.swift
@@ -33,6 +33,7 @@ class AddressMapDemoView: UIView, Tweakable {
             let areas = $0.areas
             options.append(TweakingOption(title: "Postalcode shape (\(postalCode))") {
                 self.addressMapView.configurePolygons(areas.compactMap({ $0?.coordinates }))
+                self.addressMapView.makePolygonOverlayVisible(additionalEdgeInsets: UIEdgeInsets.zero)
             })
         })
         return options
@@ -81,7 +82,7 @@ class AddressMapDemoView: UIView, Tweakable {
 extension AddressMapDemoView: AddressMapViewDelegate {
     func addressMapViewDidSelectPinButton(_ view: AddressMapView) {
         print("addressViewDidSelectCenterMapButton")
-        view.makePolygonOverlayVisible()
+        view.makePolygonOverlayVisible(additionalEdgeInsets: UIEdgeInsets.zero)
     }
 
     func addressMapViewDidSelectViewModeButton(_ view: AddressMapView, sender: UIView) {

--- a/Sources/Fullscreen/AddressMapView/AddressMapView.swift
+++ b/Sources/Fullscreen/AddressMapView/AddressMapView.swift
@@ -85,7 +85,7 @@ public class AddressMapView: UIView {
         annotation = newAnnotation
     }
 
-    public func makePolygonOverlayVisible() {
+    public func makePolygonOverlayVisible(additionalEdgeInsets: UIEdgeInsets = .zero) {
         guard let firstPolygon = polygons.first else {
             return
         }
@@ -93,8 +93,12 @@ public class AddressMapView: UIView {
         let mapRect = polygons.dropFirst().reduce(firstPolygon.boundingMapRect, { (mapRect, polygon) -> MKMapRect in
             return polygon.boundingMapRect.union(mapRect)
         })
-        let bottomInset = traitCollection.horizontalSizeClass == .regular ? 16 : 16 + .mediumLargeSpacing
-        let edgePadding = UIEdgeInsets(top: 16, left: 16, bottom: bottomInset, right: 16)
+        let edgePadding = UIEdgeInsets(
+            top: 16 + additionalEdgeInsets.top,
+            left: 16 + additionalEdgeInsets.left,
+            bottom: 16 + additionalEdgeInsets.bottom,
+            right: 16 + additionalEdgeInsets.right
+        )
 
         mapView.setVisibleMapRect(mapRect, edgePadding: edgePadding, animated: false)
     }
@@ -106,8 +110,6 @@ public class AddressMapView: UIView {
             mapView.addOverlay(newPolygon)
             polygons.append(newPolygon)
         }
-
-        makePolygonOverlayVisible()
     }
 
     public func changeMapType(_ mapType: MKMapType) {


### PR DESCRIPTION
# Why?
If you are perhaps showing a bottom sheet on top of the map the polygon might not show fully.

# What?
- Make the `makePolygonOverlayVisible(...)` call required to make polygons fully visible on map, i.e. it is no longer called automatically when configuring polygon overlay
- Add optional `additionalEdgeInsets` parameter to `makePolygonOverlayVisible`.

# Show me
This is not a visible change in FinniversKit