### PR TITLE
Motor MP: Identifiers for link buttons

### DIFF
--- a/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -42,8 +42,8 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
 }
 
 extension ObjectPagePriceDemoView: ObjectPagePriceViewDelegate {
-    func priceView(_ view: ObjectPagePriceView, didTapLinkWithUrl url: URL) {
-        print("🔥🔥🔥🔥 \(#function) - url: \(url)")
+    func priceView(_ view: ObjectPagePriceView, didTapLinkButtonWithIdentifier identifier: String?, url: URL) {
+        print("🔥🔥🔥🔥 \(#function) - buttonIdentifier: \(identifier) - url: \(url)")
     }
 }
 
@@ -54,15 +54,18 @@ extension ObjectPagePriceViewModel {
             totalPrice: "1 389 588 kr",
             links: [
                 LinkButtonViewModel(
+                    buttonIdentifier: "loan",
                     buttonTitle: "Lån fra 16 581 kr",
                     subtitle: "Eff.rente 3,89 %. 903 232 o/5 år. Kostnad: 91 628 kr. Totalt 994 860 kr.",
                     linkUrl: URL(string: "https://www.finn.no/")!
                 ),
                 LinkButtonViewModel(
+                    buttonIdentifier: "insurance",
                     buttonTitle: "Pris på forsikring",
                     linkUrl: URL(string: "https://www.finn.no/")!
                 ),
                 LinkButtonViewModel(
+                    buttonIdentifier: "used-car-guarantee",
                     buttonTitle: "Bruktbilgaranti 272 kr",
                     linkUrl: URL(string: "https://www.finn.no/")!
                 )

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '33.3.0'
+  s.version      = '33.3.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Components/ObjectPagePriceView/Models/LinkButtonViewModel.swift
+++ b/Sources/Components/ObjectPagePriceView/Models/LinkButtonViewModel.swift
@@ -3,11 +3,13 @@
 //
 
 public struct LinkButtonViewModel {
+    let buttonIdentifier: String?
     let buttonTitle: String
     let subtitle: String?
     let linkUrl: URL
 
-    public init(buttonTitle: String, subtitle: String? = nil, linkUrl: URL) {
+    public init(buttonIdentifier: String?, buttonTitle: String, subtitle: String? = nil, linkUrl: URL) {
+        self.buttonIdentifier = buttonIdentifier
         self.buttonTitle = buttonTitle
         self.subtitle = subtitle
         self.linkUrl = linkUrl

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -3,7 +3,7 @@
 //
 
 public protocol ObjectPagePriceViewDelegate: AnyObject {
-    func priceView(_ view: ObjectPagePriceView, didTapLinkWithUrl url: URL)
+    func priceView(_ view: ObjectPagePriceView, didTapLinkButtonWithIdentifier identifier: String?, url: URL)
 }
 
 public class ObjectPagePriceView: UIView {
@@ -73,7 +73,7 @@ public class ObjectPagePriceView: UIView {
 // MARK: - LinkButtonViewDelegate
 
 extension ObjectPagePriceView: LinkButtonViewDelegate {
-    func linkButtonWasTapped(withUrl url: URL) {
-        delegate?.priceView(self, didTapLinkWithUrl: url)
+    func linkButton(withIdentifier identifier: String?, wasTappedWithUrl url: URL) {
+        delegate?.priceView(self, didTapLinkButtonWithIdentifier: identifier, url: url)
     }
 }

--- a/Sources/Components/ObjectPagePriceView/Views/LinkButtonView.swift
+++ b/Sources/Components/ObjectPagePriceView/Views/LinkButtonView.swift
@@ -14,6 +14,7 @@ class LinkButtonView: UIView {
 
     // MARK: - Private properties
 
+    private let buttonIdentifier: String?
     private let linkUrl: URL
     private let linkButtonStyle = Button.Style.link.overrideStyle(normalFont: .body)
 
@@ -41,10 +42,11 @@ class LinkButtonView: UIView {
     // MARK: - Init
 
     convenience init(viewModel: LinkButtonViewModel) {
-        self.init(buttonTitle: viewModel.buttonTitle, subtitle: viewModel.subtitle, linkUrl: viewModel.linkUrl)
+        self.init(buttonIdentifier: viewModel.buttonIdentifier, buttonTitle: viewModel.buttonTitle, subtitle: viewModel.subtitle, linkUrl: viewModel.linkUrl)
     }
 
-    init(buttonTitle: String, subtitle: String?, linkUrl: URL) {
+    init(buttonIdentifier: String?, buttonTitle: String, subtitle: String?, linkUrl: URL) {
+        self.buttonIdentifier = buttonIdentifier
         self.linkUrl = linkUrl
         super.init(frame: .zero)
 

--- a/Sources/Components/ObjectPagePriceView/Views/LinkButtonView.swift
+++ b/Sources/Components/ObjectPagePriceView/Views/LinkButtonView.swift
@@ -3,7 +3,7 @@
 //
 
 protocol LinkButtonViewDelegate: AnyObject {
-    func linkButtonWasTapped(withUrl url: URL)
+    func linkButton(withIdentifier identifier: String?, wasTappedWithUrl url: URL)
 }
 
 class LinkButtonView: UIView {
@@ -68,6 +68,6 @@ class LinkButtonView: UIView {
     // MARK: - Private methods
 
     @objc private func handleTap() {
-        delegate?.linkButtonWasTapped(withUrl: linkUrl)
+        delegate?.linkButton(withIdentifier: buttonIdentifier, wasTappedWithUrl: linkUrl)
     }
 }


### PR DESCRIPTION
# Why?
In order to do the correct tracking when the user taps one of the buttons within `ObjectPagePriceView`, we need to identify what kind of button it is. We get this information from the proxy, but we'll do the tracking manually in the app.

# What?
- Bump FinniversKit to `33.3.1`.
- Added optional property `buttonIdentifier` to `LinkButtonViewModel`.
- Include this value when notifying the delegates.
- Update demo.

# Show me
_No UI._