### PR TITLE
Bugfix: Constraint ambiguity when measuring UserAdTableViewCell height

### DIFF
--- a/Sources/Cells/UserAdTableViewCell/UserAdTableViewCell.swift
+++ b/Sources/Cells/UserAdTableViewCell/UserAdTableViewCell.swift
@@ -82,7 +82,7 @@ public class UserAdTableViewCell: UITableViewCell {
 
     private lazy var regularConstraints: [NSLayoutConstraint] = [
         contentStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: .mediumLargeSpacing),
-        contentStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -.mediumLargeSpacing),
+        contentStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -.mediumLargeSpacing, priority: .init(999)),
 
         adImageView.heightAnchor.constraint(equalToConstant: UserAdTableViewCell.defaultImageWidth),
         adImageView.widthAnchor.constraint(equalToConstant: UserAdTableViewCell.defaultImageWidth),


### PR DESCRIPTION
# Why?

I want the height calculation of the cell to not be ambiguous.

# What?

Lowered priority on the content stack's bottom anchor, so it ain't ambiguous with regards to the content view height constraint set by the table view on the previous layout.

# Show me
_No UI changes_
