### PR TITLE
Revert "A-Case: Make StepIndicator work with vertical alignment"

### DIFF
--- a/Sources/Components/Broadcast/StepIndicator.swift
+++ b/Sources/Components/Broadcast/StepIndicator.swift
@@ -29,9 +29,7 @@ public class StepIndicator: UIView {
     // MARK: - Private properties
 
     private static let stepDotDiameter: CGFloat = 27.0
-
     private let numberOfSteps: Int
-    private let axis: NSLayoutConstraint.Axis
     private let stackView = UIStackView(withAutoLayout: true)
 
     private var stepDots = [StepDot]()
@@ -48,25 +46,21 @@ public class StepIndicator: UIView {
         fatalError("Not implemented: init(coder:)")
     }
 
-    public init(steps: Int, axis: NSLayoutConstraint.Axis = .horizontal) {
+    public init(steps: Int) {
         guard steps >= 2 else {
             fatalError("StepIndicator must have at least 2 steps")
         }
 
-        self.axis = axis
-        self.numberOfSteps = steps
-
+        numberOfSteps = steps
         super.init(frame: .zero)
-
-        setup(axis: axis)
+        setup()
     }
 
-    private func setup(axis: NSLayoutConstraint.Axis) {
+    private func setup() {
         addSubview(stackView)
         stackView.fillInSuperview()
-        stackView.distribution = axis == .horizontal ? .equalSpacing : .fillEqually
+        stackView.distribution = .equalSpacing
         stackView.alignment = .center
-        stackView.axis = axis
 
         for index in 0..<numberOfSteps {
             let stepDot = StepDot(step: index, diameter: StepIndicator.stepDotDiameter)
@@ -76,7 +70,7 @@ public class StepIndicator: UIView {
         }
 
         for index in 1..<numberOfSteps {
-            let connector = StepDotConnector(axis: axis)
+            let connector = StepDotConnector()
             addSubview(connector)
             connector.connect(from: stepDots[index - 1], to: stepDots[index])
 

--- a/Sources/Components/StepIndicator/StepDotConnector.swift
+++ b/Sources/Components/StepIndicator/StepDotConnector.swift
@@ -20,7 +20,6 @@ class StepDotConnector: UIView {
     // MARK: - Private properties
 
     private var connected = false
-    private var axis: NSLayoutConstraint.Axis
 
     // MARK: - Init
 
@@ -32,9 +31,7 @@ class StepDotConnector: UIView {
         fatalError("Not implemented: init(frame:)")
     }
 
-    init(axis: NSLayoutConstraint.Axis) {
-        self.axis = axis
-
+    init() {
         super.init(frame: .zero)
 
         backgroundColor = StepIndicator.inactiveColor
@@ -47,23 +44,13 @@ class StepDotConnector: UIView {
         guard !connected else { return }
 
         connected = true
-        switch axis {
-        case .horizontal:
-            NSLayoutConstraint.activate([
-                heightAnchor.constraint(equalToConstant: 4),
-                leadingAnchor.constraint(equalTo: from.centerXAnchor),
-                trailingAnchor.constraint(equalTo: to.centerXAnchor),
-                centerYAnchor.constraint(equalTo: from.centerYAnchor)
-            ])
-        case .vertical:
-            NSLayoutConstraint.activate([
-                widthAnchor.constraint(equalToConstant: 4),
-                heightAnchor.constraint(equalTo: to.heightAnchor),
-                bottomAnchor.constraint(equalTo: to.topAnchor),
-                centerXAnchor.constraint(equalTo: from.centerXAnchor),
-            ])
-        default:  return
-        }
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 4),
+            leadingAnchor.constraint(equalTo: from.centerXAnchor),
+            trailingAnchor.constraint(equalTo: to.centerXAnchor),
+            centerYAnchor.constraint(equalTo: from.centerYAnchor)
+        ])
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
Causes constraint ambiguity.  Decided it's better to use the `StepDotConnector` and `StepDot` to create a vertical arbitrary sized `StepView` instead.