### PR TITLE
Motor MP: Ribbon for ObjectPageTitleView

### DIFF
--- a/Demo/Components/ObjectPageTitleView/ObjectPageTitleDemoView.swift
+++ b/Demo/Components/ObjectPageTitleView/ObjectPageTitleDemoView.swift
@@ -10,13 +10,19 @@ class ObjectPageTitleDemoView: UIView, Tweakable {
 
     lazy var tweakingOptions: [TweakingOption] = {
         [
-            TweakingOption(title: "Title and subtitle", description: "Default style") { [weak self] in
+            TweakingOption(title: "Title and subtitle") { [weak self] in
                 self?.configureTitleView(title: "Mercedes-Benz C-Klasse", subtitle: "C200 4MATIC aut Hengerfeste, Panoramasoltak, AMG, LED +")
             },
-            TweakingOption(title: "Only title", description: "Default style") { [weak self] in
+            TweakingOption(title: "Title and subtitle", description: "With ribbon") { [weak self] in
+                self?.configureTitleView(title: "Mercedes-Benz C-Klasse", subtitle: "C200 4MATIC aut Hengerfeste, Panoramasoltak, AMG, LED +", ribbonViewModel: .sold)
+            },
+            TweakingOption(title: "Only title") { [weak self] in
                 self?.configureTitleView(title: "Sofa med sjeselong - pris diskuterbar!")
             },
-            TweakingOption(title: "Only subtitle", description: "Default style") { [weak self] in
+            TweakingOption(title: "Only title", description: "With ribbon") { [weak self] in
+                self?.configureTitleView(title: "Sofa med sjeselong - pris diskuterbar!", ribbonViewModel: .sold)
+            },
+            TweakingOption(title: "Only subtitle") { [weak self] in
                 self?.configureTitleView(subtitle: "C200 4MATIC aut Hengerfeste, Panoramasoltak, AMG, LED +")
             },
         ]
@@ -46,8 +52,15 @@ class ObjectPageTitleDemoView: UIView, Tweakable {
 
     private func configureTitleView(
         title: String? = nil,
-        subtitle: String? = nil
+        subtitle: String? = nil,
+        ribbonViewModel: RibbonViewModel? = nil
     ) {
-        titleView.configure(withTitle: title, subtitle: subtitle)
+        titleView.configure(withTitle: title, subtitle: subtitle, ribbonViewModel: ribbonViewModel)
     }
+}
+
+// MARK: - Private extensions
+
+private extension RibbonViewModel {
+    static var sold = RibbonViewModel(style: .warning, title: "Solgt")
 }

--- a/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
+++ b/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
@@ -10,11 +10,14 @@ public class ObjectPageTitleView: UIView {
 
     private let titleStyle: Label.Style
     private let subtitleStyle: Label.Style
+    private lazy var ribbonView = RibbonView(withAutoLayout: true)
 
     private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        let stackView = UIStackView(arrangedSubviews: [ribbonView, titleLabel, subtitleLabel])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.setCustomSpacing(.mediumSpacing, after: ribbonView)
         return stackView
     }()
 
@@ -52,7 +55,12 @@ public class ObjectPageTitleView: UIView {
 
     // MARK: - Public methods
 
-    public func configure(withTitle title: String? = nil, subtitle: String? = nil) {
+    public func configure(withTitle title: String? = nil, subtitle: String? = nil, ribbonViewModel: RibbonViewModel? = nil) {
+        if let ribbonViewModel = ribbonViewModel {
+            ribbonView.configure(with: ribbonViewModel)
+        }
+        ribbonView.isHidden = ribbonViewModel == nil
+
         titleLabel.text = title
         titleLabel.isHidden = title?.isEmpty ?? true
 


### PR DESCRIPTION
# Why?
We need to add an optional `RibbonView` to `ObjectPageTitleView`.

# Show me

| Without ribbon | With ribbon |
| --- | --- |
|  <img width="545" alt="Screenshot 2020-02-19 at 13 03 11" src="https://user-images.githubusercontent.com/1901556/74834781-62cccc80-531c-11ea-8dd2-cd741911d75d.png"> | <img width="545" alt="Screenshot 2020-02-19 at 13 03 14" src="https://user-images.githubusercontent.com/1901556/74834785-64969000-531c-11ea-8ed0-2d2759032ee4.png"> |
| <img width="545" alt="Screenshot 2020-02-19 at 13 03 20" src="https://user-images.githubusercontent.com/1901556/74834787-66605380-531c-11ea-8cb8-62fca8f8a073.png"> | <img width="545" alt="Screenshot 2020-02-19 at 13 03 23" src="https://user-images.githubusercontent.com/1901556/74834790-66f8ea00-531c-11ea-986f-2cd89d563b3f.png"> |