### PR TITLE
Improvement: `SafetyElementView.ElementContentView` public + small fixes

### DIFF
--- a/Sources/Components/CollapsibleContentView/CollapsibleContentView.swift
+++ b/Sources/Components/CollapsibleContentView/CollapsibleContentView.swift
@@ -41,6 +41,7 @@ public class CollapsibleContentView: UIView {
         let stackView = UIStackView(withAutoLayout: true)
         stackView.axis = .horizontal
         stackView.layoutMargins = .init(vertical: .mediumSpacing, horizontal: 0)
+        stackView.distribution = .equalSpacing
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()

--- a/Sources/Components/CollapsibleContentView/CollapsibleContentView.swift
+++ b/Sources/Components/CollapsibleContentView/CollapsibleContentView.swift
@@ -45,7 +45,11 @@ public class CollapsibleContentView: UIView {
         return stackView
     }()
 
-    private lazy var titleLabel: Label = Label(style: .title3Strong, withAutoLayout: true)
+    private lazy var titleLabel: Label = {
+        let label = Label(style: .title3Strong, withAutoLayout: true)
+        label.numberOfLines = 0
+        return label
+    }()
 
     private lazy var collapseIndicatorImageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)

--- a/Sources/Components/SafetyElementsView/Common/ElementContentView.swift
+++ b/Sources/Components/SafetyElementsView/Common/ElementContentView.swift
@@ -2,13 +2,13 @@
 //  Copyright © 2020 FINN AS. All rights reserved.
 //
 
-protocol SafetyElementContentViewDelegate: AnyObject {
+public protocol SafetyElementContentViewDelegate: AnyObject {
     func safetyElementContentView(_ view: SafetyElementsView.ElementContentView, didClickOnLink identifier: String?, url: URL)
 }
 
-extension SafetyElementsView {
+public extension SafetyElementsView {
     class ElementContentView: UIView {
-        weak var delegate: SafetyElementContentViewDelegate?
+        public weak var delegate: SafetyElementContentViewDelegate?
 
         private var viewModel: SafetyElementViewModel?
 
@@ -32,16 +32,16 @@ extension SafetyElementsView {
         private lazy var topLinkButton: Button = makeExternalLinkButton(onTap: #selector(didTapOnTopLink))
         private lazy var bottomLinkButton: Button = makeExternalLinkButton(onTap: #selector(didTapOnBottomLink))
 
-        override init(frame: CGRect) {
+        public override init(frame: CGRect) {
             super.init(frame: frame)
             setup()
         }
 
-        required init?(coder aDecoder: NSCoder) { fatalError() }
+        public required init?(coder aDecoder: NSCoder) { fatalError() }
 
-        func configure(with viewModel: SafetyElementViewModel) {
             self.viewModel = viewModel
             contentLabel.text = viewModel.body
+        public func configure(with viewModel: SafetyElementViewModel) {
 
             if let topLink = viewModel.topLink {
                 topLinkButton.setTitle(topLink.buttonTitle, for: .normal)

--- a/Sources/Components/SafetyElementsView/Common/ElementContentView.swift
+++ b/Sources/Components/SafetyElementsView/Common/ElementContentView.swift
@@ -10,7 +10,8 @@ public extension SafetyElementsView {
     class ElementContentView: UIView {
         public weak var delegate: SafetyElementContentViewDelegate?
 
-        private var viewModel: SafetyElementViewModel?
+        private var topLink: LinkButtonViewModel?
+        private var bottomLink: LinkButtonViewModel?
 
         private lazy var contentStackView: UIStackView = {
             let stackView = UIStackView(withAutoLayout: true)
@@ -39,18 +40,27 @@ public extension SafetyElementsView {
 
         public required init?(coder aDecoder: NSCoder) { fatalError() }
 
-            self.viewModel = viewModel
-            contentLabel.text = viewModel.body
         public func configure(with viewModel: SafetyElementViewModel) {
+            configure(with: viewModel.body, topLink: viewModel.topLink, bottomLink: viewModel.bottomLink)
+        }
 
-            if let topLink = viewModel.topLink {
+        public func configure(
+            with content: String,
+            topLink: LinkButtonViewModel? = nil,
+            bottomLink: LinkButtonViewModel? = nil
+        ) {
+            self.topLink = topLink
+            self.bottomLink = bottomLink
+            contentLabel.text = content
+
+            if let topLink = topLink {
                 topLinkButton.setTitle(topLink.buttonTitle, for: .normal)
                 topLinkButton.isHidden = false
             } else {
                 topLinkButton.isHidden = true
             }
 
-            if let bottomLink = viewModel.bottomLink {
+            if let bottomLink = bottomLink {
                 bottomLinkButton.setTitle(bottomLink.buttonTitle, for: .normal)
                 bottomLinkButton.isHidden = false
             } else {
@@ -68,12 +78,12 @@ public extension SafetyElementsView {
         }
 
         @objc private func didTapOnBottomLink() {
-            guard let bottomLink = viewModel?.bottomLink else { return }
+            guard let bottomLink = bottomLink else { return }
             didTap(on: bottomLink)
         }
 
         @objc private func didTapOnTopLink() {
-            guard let topLink = viewModel?.topLink else { return }
+            guard let topLink = topLink else { return }
             didTap(on: topLink)
         }
 

--- a/Sources/Components/SafetyElementsView/SafetyElementsView.swift
+++ b/Sources/Components/SafetyElementsView/SafetyElementsView.swift
@@ -56,7 +56,7 @@ public class SafetyElementsView: UIView {
 }
 
 extension SafetyElementsView: SafetyElementContentViewDelegate {
-    func safetyElementContentView(_ view: ElementContentView, didClickOnLink identifier: String?, url: URL) {
+    public func safetyElementContentView(_ view: ElementContentView, didClickOnLink identifier: String?, url: URL) {
         delegate?.safetyElementsView(self, didClickOnLink: identifier, url: url)
     }
 }


### PR DESCRIPTION
# Why?

The "claim" safety element will be rendered with this component, so it needs to
be public now.

# What?

- Allow line breaks on the title of `CollapsibleContentView`
- Make `SafetyElementView.ElementContentView` public
- Add configuration method with data only for ``SafetyElementView.ElementContentView`

# Show me

No changes