### PR TITLE
Bump FinniversKit to 35.3.0

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '35.2.0'
+  s.version      = '35.3.0'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'


### PR DESCRIPTION
# Changes:

- #810: Internal: rename spacing constants to standarize with Android

☝️ is not a breaking change, but it does deprecate the old names for
spacing constants, that's why i bumped the minor number, although I am
not sure is the correct. (can be a patch bump)