### PR TITLE
Remove postfix "string" from url properties

### DIFF
--- a/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(
@@ -43,7 +43,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Forbered betaling",
                     style: "call_to_action",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(
@@ -50,7 +50,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Bekreft overlevering",
                     style: "call_to_action",
                     action: "url",
-                    urlString: "https://www.vegvesen.no/"),
+                    url: "https://www.vegvesen.no/"),
                 detail: "Hvis fristen går ut før dere har bekreftet, ta kontakt med Swiftcourt for å få pengene ut av hvelvet."),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .active,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Signer kontrakt",
                     style: "call_to_action",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .active,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Signer kontrakt",
                     style: "call_to_action",
-                    urlString: "https://www.google.com/search?q=contract+signed")),
+                    url: "https://www.google.com/search?q=contract+signed")),
 
             TransactionStepModel(
                 state: .notStarted,

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .active,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Inviter kjøper",
                     style: "call_to_action",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         steps: [
             TransactionStepModel(
@@ -20,7 +20,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .active,
@@ -29,7 +29,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Opprett digital kontrakt",
                     style: "call_to_action",
-                    urlString: "https://www.google.com/search?q=contract+signed")),
+                    url: "https://www.google.com/search?q=contract+signed")),
 
             TransactionStepModel(
                 state: .notStarted,

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(
@@ -50,7 +50,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Bekreft overlevering",
                     style: "call_to_action",
                     action: "url",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .completed,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "flat",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(
@@ -50,7 +50,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Bekreft overlevering",
                     style: "call_to_action",
                     action: "url",
-                    urlString: "https://www.vegvesen.no/"),
+                    url: "https://www.vegvesen.no/"),
                 detail: "Hvis fristen går ut før dere har bekreftet, ta kontakt med Swiftcourt for å få pengene ut av hvelvet."),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
@@ -10,7 +10,7 @@ extension TransactionDemoViewDefaultData {
             adId: "171529672",
             title: "BMW i3",
             registrationNumber: "CF40150",
-            imageUrlString: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+            imageUrl: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
 
         warning: TransactionWarningModel(
             title: "Du har opprettet flere kontrakter for denne bilen",
@@ -24,7 +24,7 @@ extension TransactionDemoViewDefaultData {
                     text: "Se annonsen",
                     style: "flat",
                     action: "see_ad",
-                    fallbackUrlString: "www.finn.no/171529672")),
+                    fallbackUrl: "www.finn.no/171529672")),
 
             TransactionStepModel(
                 state: .active,
@@ -33,7 +33,7 @@ extension TransactionDemoViewDefaultData {
                 primaryButton: TransactionStepPrimaryButtonModel(
                     text: "Gå til kontrakt",
                     style: "default",
-                    urlString: "https://www.google.com/search?q=contract+signed"
+                    url: "https://www.google.com/search?q=contract+signed"
                 )),
 
             TransactionStepModel(

--- a/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
+++ b/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
@@ -15,13 +15,13 @@ public struct TransactionHeaderModel: TransactionHeaderViewModel {
     public var adId: String
     public var title: String
     public var registrationNumber: String?
-    public var imageUrlString: String?
+    public var imageUrl: String?
 }
 
 public struct TransactionWarningModel: TransactionWarningViewModel {
     public var title: String
     public var message: String
-    public var imageUrlString: String?
+    public var imageUrl: String?
 }
 
 public struct TransactionStepModel: TransactionStepViewModel {
@@ -36,8 +36,8 @@ public struct TransactionStepPrimaryButtonModel: TransactionStepPrimaryButtonVie
     public var text: String
     public var style: String
     public var action: String?
-    public var urlString: String?
-    public var fallbackUrlString: String?
+    public var url: String?
+    public var fallbackUrl: String?
 }
 
 public struct TransactionDemoViewDefaultData {

--- a/Sources/Fullscreen/TransactionView/TransactionAlertView/TransactionAlertViewModel.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionAlertView/TransactionAlertViewModel.swift
@@ -7,5 +7,5 @@ import Foundation
 public protocol TransactionAlertViewModel {
     var title: String { get set }
     var message: String { get set }
-    var imageUrlString: String? { get set }
+    var imageUrl: String? { get set }
 }

--- a/Sources/Fullscreen/TransactionView/TransactionHeaderView/TransactionHeaderViewModel.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionHeaderView/TransactionHeaderViewModel.swift
@@ -8,5 +8,5 @@ public protocol TransactionHeaderViewModel {
     var adId: String { get set }
     var title: String { get set }
     var registrationNumber: String? { get set }
-    var imageUrlString: String? { get set }
+    var imageUrl: String? { get set }
 }

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -221,8 +221,8 @@ private extension TransactionStepView {
 private extension TransactionStepView {
     @objc func handlePrimaryButtonTap() {
         let action = PrimaryButton.Action(rawValue: primaryButtonModel?.action ?? "unknown")
-        let urlString = primaryButtonModel?.urlString
-        let fallbackUrlString = primaryButtonModel?.fallbackUrlString
+        let urlString = primaryButtonModel?.url
+        let fallbackUrlString = primaryButtonModel?.fallbackUrl
 
         delegate?.transactionStepViewDidTapPrimaryButton(self, inTransactionStep: step, withAction: action,
                                                          withUrl: urlString, withFallbackUrl: fallbackUrlString)

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepViewModel.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepViewModel.swift
@@ -16,6 +16,6 @@ public protocol TransactionStepPrimaryButtonViewModel {
     var action: String? { get set }
     var text: String { get }
     var style: String { get set }
-    var urlString: String? { get set }
-    var fallbackUrlString: String? { get set }
+    var url: String? { get set }
+    var fallbackUrl: String? { get set }
 }

--- a/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -197,9 +197,12 @@ private extension TransactionView {
 
 extension TransactionView: TransactionStepViewDelegate {
     public func transactionStepViewDidTapPrimaryButton(_ view: TransactionStepView, inTransactionStep step: Int,
-                                                       withAction action: TransactionStepView.PrimaryButton.Action, withUrl urlString: String?,
-                                                       withFallbackUrl fallbackUrlString: String?) {
-        delegate?.transactionViewDidSelectPrimaryButton(self, inTransactionStep: step, withAction: action, withUrl: urlString, withFallbackUrl: fallbackUrlString)
+                                                       withAction action: TransactionStepView.PrimaryButton.Action, withUrl url: String?,
+                                                       withFallbackUrl fallbackUrl: String?) {
+
+        delegate?.transactionViewDidSelectPrimaryButton(self, inTransactionStep: step,
+                                                        withAction: action, withUrl: url,
+                                                        withFallbackUrl: fallbackUrl)
     }
 }
 

--- a/Sources/Fullscreen/TransactionView/TransactionWarningView/TransactionWarningView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionWarningView/TransactionWarningView.swift
@@ -43,7 +43,7 @@ public class TransactionWarningView: UIView {
     }
 
     public func loadImage() {
-        guard let imagePath = model.imageUrlString else {
+        guard let imagePath = model.imageUrl else {
             imageView.image = fallbackImage
             return
         }

--- a/Sources/Fullscreen/TransactionView/TransactionWarningView/TransactionWarningViewModel.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionWarningView/TransactionWarningViewModel.swift
@@ -7,5 +7,5 @@ import Foundation
 public protocol TransactionWarningViewModel {
     var title: String { get set }
     var message: String { get set }
-    var imageUrlString: String? { get set }
+    var imageUrl: String? { get set }
 }


### PR DESCRIPTION
# Why?

- It felt like repeating something twice
- Yes, I have OCD.

# What?

- Remove the "string" postfix from the properties in the `TransactionView` protocols
