### PR TITLE
Fix: Copyable Label

### DIFF
--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '36.1.0'
+  s.version      = '36.1.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Components/Label/Label.swift
+++ b/Sources/Components/Label/Label.swift
@@ -62,8 +62,8 @@ extension Label {
     @objc private func handleLongPress(_ recognizer: UIGestureRecognizer) {
         guard recognizer.state == .began else { return }
 
+        becomeFirstResponder()
         UIMenuController.shared.setTargetRect(bounds, in: self)
         UIMenuController.shared.setMenuVisible(true, animated:true)
-        becomeFirstResponder()
     }
 }


### PR DESCRIPTION
# Why?
Encountered an issue when trying to implement #815 in `ios-app` where the `UIMenuController` only would appear the second time you'd long press on the label.

Seems like we need to call `becomeFirstResponder()` before setting the target rect for `UIMenuController`.

# What?
- Re-arrange call to `becomeFirstResponder()`.
- Bump version to `36.1.1`.
  - This will include #816 as well.

# Show me
_No UI._