### PR TITLE
Fix: Label copyable issue

### DIFF
--- a/Sources/Components/Label/Label.swift
+++ b/Sources/Components/Label/Label.swift
@@ -8,7 +8,7 @@ public class Label: UILabel {
 
     // MARK: - Public properties
 
-    public var isTextCopyable = false
+    public private(set) var isTextCopyable = false
 
     // MARK: - Setup
 
@@ -30,7 +30,6 @@ public class Label: UILabel {
     }
 
     private func setup() {
-        isUserInteractionEnabled = true
         addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:))))
 
         isAccessibilityElement = true
@@ -39,6 +38,13 @@ public class Label: UILabel {
         font = style?.font
         textColor = .textPrimary
         adjustsFontForContentSizeCategory = true
+    }
+
+    // MARK: - Public methods
+
+    public func setTextCopyable(_ isTextCopyable: Bool) {
+        self.isTextCopyable = isTextCopyable
+        isUserInteractionEnabled = isTextCopyable
     }
 
     // MARK: - Dependency injection

--- a/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
+++ b/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
@@ -9,12 +9,12 @@ public class ObjectPageTitleView: UIView {
     // MARK: - Public properties
 
     public var isTitleTextCopyable: Bool {
-        set { titleLabel.isTextCopyable = newValue }
+        set { titleLabel.setTextCopyable(newValue) }
         get { titleLabel.isTextCopyable }
     }
 
     public var isSubtitleTextCopyable: Bool {
-        set { subtitleLabel.isTextCopyable = newValue }
+        set { subtitleLabel.setTextCopyable(newValue) }
         get { subtitleLabel.isTextCopyable }
     }
 


### PR DESCRIPTION
# Why?
The `Label` should not have `isUserInteractionEnabled` set to `true` by default. This caused some issues in the app where the label was present in a button.

# What?
- Add method to set text copyable. This also sets `isUserInteractionEnabled`.

# Show me
_No UI._