### PR TITLE
Motor redesign: Multiple prices

### DIFF
--- a/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -22,6 +22,10 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
             TweakingOption(title: "With subtitle, without links", action: { [weak self] in
                 self?.priceView.configure(with: .subtitleWithoutLinks)
             }),
+
+            TweakingOption(title: "With seconday price & links", action: { [weak self] in
+                self?.priceView.configure(with: .secondaryPrice)
+            })
         ]
     }()
 
@@ -126,6 +130,21 @@ extension ObjectPagePriceViewModel {
             totalPrice: "1 389 588 kr",
             subtitle: "Inkludert alle klargjøringskostnader",
             links: []
+        )
+    }()
+
+    static var secondaryPrice: ObjectPagePriceViewModel = {
+        ObjectPagePriceViewModel(
+            mainPriceModel: Price(title: "Månedspris", totalPrice: "3950 kr"),
+            secondaryPriceModel: Price(title: "Innskudd", totalPrice: "120 000 kr"),
+            links: [
+                LinkButtonViewModel(
+                    buttonIdentifier: "insurance",
+                    buttonTitle: "Pris på forsikring",
+                    linkUrl: URL(string: "https://www.finn.no/")!,
+                    isExternal: false
+                )
+            ]
         )
     }()
 }

--- a/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
+++ b/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
@@ -3,15 +3,30 @@
 //
 
 public struct ObjectPagePriceViewModel {
-    let title: String
-    let totalPrice: String
-    let subtitle: String?
+    let mainPriceModel: Price
+    let secondaryPriceModel: Price?
     let links: [LinkButtonViewModel]
 
     public init(title: String, totalPrice: String, subtitle: String? = nil, links: [LinkButtonViewModel]) {
-        self.title = title
-        self.totalPrice = totalPrice
-        self.subtitle = subtitle
+        let mainPriceModel = Price(title: title, totalPrice: totalPrice, subtitle: subtitle)
+        self.init(mainPriceModel: mainPriceModel, links: links)
+    }
+
+    public init(mainPriceModel: Price, secondaryPriceModel: Price? = nil, links: [LinkButtonViewModel]) {
+        self.mainPriceModel = mainPriceModel
+        self.secondaryPriceModel = secondaryPriceModel
         self.links = links
+    }
+
+    public struct Price {
+        let title: String
+        let totalPrice: String
+        let subtitle: String?
+
+        public init(title: String, totalPrice: String, subtitle: String? = nil) {
+            self.title = title
+            self.totalPrice = totalPrice
+            self.subtitle = subtitle
+        }
     }
 }

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -14,21 +14,17 @@ public class ObjectPagePriceView: UIView {
 
     // MARK: - Private properties
 
-    private lazy var titleLabel = Label(style: .body, withAutoLayout: true)
-    private lazy var totalPriceLabel = Label(style: .title3Strong, withAutoLayout: true)
-    private lazy var subtitleLabel = Label(style: .caption, withAutoLayout: true)
-
-    private lazy var wrapperStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [textStackView, linkButtonListView])
-        stackView.axis = .vertical
-        stackView.spacing = .spacingM
+    private lazy var pricesStackView: UIStackView = {
+        let stackView = UIStackView(withAutoLayout: true)
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
         return stackView
     }()
 
-    private lazy var textStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, totalPriceLabel, subtitleLabel])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+    private lazy var wrapperStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [pricesStackView, linkButtonListView])
         stackView.axis = .vertical
+        stackView.spacing = .spacingM
         return stackView
     }()
 
@@ -57,11 +53,7 @@ public class ObjectPagePriceView: UIView {
     // MARK: - Public methods
 
     public func configure(with viewModel: ObjectPagePriceViewModel) {
-        titleLabel.text = viewModel.title
-        totalPriceLabel.text = viewModel.totalPrice
 
-        subtitleLabel.text = viewModel.subtitle
-        subtitleLabel.isHidden = viewModel.subtitle?.isEmpty ?? true
 
         linkButtonListView.configure(with: viewModel.links)
         linkButtonListView.isHidden = viewModel.links.isEmpty

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -53,7 +53,15 @@ public class ObjectPagePriceView: UIView {
     // MARK: - Public methods
 
     public func configure(with viewModel: ObjectPagePriceViewModel) {
+        pricesStackView.removeArrangedSubviews()
 
+        let mainPriceView = PriceView(viewModel: viewModel.mainPriceModel, withAutoLayout: true)
+        pricesStackView.addArrangedSubview(mainPriceView)
+
+        if let secondaryPriceModel = viewModel.secondaryPriceModel {
+            let secondaryPriceView = PriceView(viewModel: secondaryPriceModel, withAutoLayout: true)
+            pricesStackView.addArrangedSubview(secondaryPriceView)
+        }
 
         linkButtonListView.configure(with: viewModel.links)
         linkButtonListView.isHidden = viewModel.links.isEmpty

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -75,3 +75,46 @@ extension ObjectPagePriceView: LinkButtonListViewDelegate {
         delegate?.priceView(self, didTapLinkButtonWithIdentifier: identifier, url: url)
     }
 }
+
+// MARK: - Private class
+
+private class PriceView: UIView {
+
+    // MARK: - Private properties
+
+    private let viewModel: ObjectPagePriceViewModel.Price
+    private lazy var titleLabel = Label(style: .body, withAutoLayout: true)
+    private lazy var totalPriceLabel = Label(style: .title3Strong, withAutoLayout: true)
+    private lazy var subtitleLabel = Label(style: .caption, withAutoLayout: true)
+
+    private lazy var textStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, totalPriceLabel, subtitleLabel])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    // MARK: - Init
+
+    init(viewModel: ObjectPagePriceViewModel.Price, withAutoLayout: Bool) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = !withAutoLayout
+        setup()
+    }
+
+    public required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        titleLabel.text = viewModel.title
+        totalPriceLabel.text = viewModel.totalPrice
+
+        subtitleLabel.text = viewModel.subtitle
+        subtitleLabel.isHidden = viewModel.subtitle?.isEmpty ?? true
+
+        addSubview(textStackView)
+        textStackView.fillInSuperview()
+    }
+}


### PR DESCRIPTION
# Why?
For the redesign for `car-leasing`, we need to present two different prices to the user.

# What?
- Refactor `ObjectPagePriceViewModel` to accept a `mainPriceModel` and a `secondaryPriceModel`.
- Refactor labels and wrapper views into `PriceView`.
- Update demo.

# Show me

<img width="320" alt="Screenshot 2020-03-13 at 15 31 28" src="https://user-images.githubusercontent.com/1901556/76630234-f9696380-653f-11ea-96b6-17f9f3986dd3.png">
