### PR TITLE
Fix: Configure style for ObjectPagePriceView

### DIFF
--- a/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -119,8 +119,7 @@ extension ObjectPagePriceViewModel {
     static var withoutLinks: ObjectPagePriceViewModel = {
         ObjectPagePriceViewModel(
             title: "Totalpris",
-            totalPrice: "1 389 588 kr",
-            links: []
+            totalPrice: "1 389 588 kr"
         )
     }()
 
@@ -128,8 +127,7 @@ extension ObjectPagePriceViewModel {
         ObjectPagePriceViewModel(
             title: "Totalpris",
             totalPrice: "1 389 588 kr",
-            subtitle: "Inkludert alle klargjøringskostnader",
-            links: []
+            subtitle: "Inkludert alle klargjøringskostnader"
         )
     }()
 

--- a/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -25,6 +25,10 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
 
             TweakingOption(title: "With seconday price & links", action: { [weak self] in
                 self?.priceView.configure(with: .secondaryPrice)
+            }),
+
+            TweakingOption(title: "Main price only", action: { [weak self] in
+                self?.priceView.configure(with: .mainPriceOnly, style: .init(priceStyle: .title1))
             })
         ]
     }()
@@ -144,5 +148,9 @@ extension ObjectPagePriceViewModel {
                 )
             ]
         )
+    }()
+
+    static var mainPriceOnly: ObjectPagePriceViewModel = {
+        ObjectPagePriceViewModel(totalPrice: "1 389 588 kr")
     }()
 }

--- a/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
+++ b/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
@@ -7,7 +7,7 @@ public struct ObjectPagePriceViewModel {
     let secondaryPriceModel: Price?
     let links: [LinkButtonViewModel]
 
-    public init(title: String, totalPrice: String, subtitle: String? = nil, links: [LinkButtonViewModel]) {
+    public init(title: String? = nil, totalPrice: String, subtitle: String? = nil, links: [LinkButtonViewModel] = []) {
         let mainPriceModel = Price(title: title, totalPrice: totalPrice, subtitle: subtitle)
         self.init(mainPriceModel: mainPriceModel, links: links)
     }
@@ -19,11 +19,11 @@ public struct ObjectPagePriceViewModel {
     }
 
     public struct Price {
-        let title: String
+        let title: String?
         let totalPrice: String
         let subtitle: String?
 
-        public init(title: String, totalPrice: String, subtitle: String? = nil) {
+        public init(title: String?, totalPrice: String, subtitle: String? = nil) {
             self.title = title
             self.totalPrice = totalPrice
             self.subtitle = subtitle

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -109,6 +109,8 @@ private class PriceView: UIView {
 
     private func setup() {
         titleLabel.text = viewModel.title
+        titleLabel.isHidden = viewModel.title?.isEmpty ?? true
+
         totalPriceLabel.text = viewModel.totalPrice
 
         subtitleLabel.text = viewModel.subtitle

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -52,14 +52,14 @@ public class ObjectPagePriceView: UIView {
 
     // MARK: - Public methods
 
-    public func configure(with viewModel: ObjectPagePriceViewModel) {
+    public func configure(with viewModel: ObjectPagePriceViewModel, style: Style = .init()) {
         pricesStackView.removeArrangedSubviews()
 
-        let mainPriceView = PriceView(viewModel: viewModel.mainPriceModel, withAutoLayout: true)
+        let mainPriceView = PriceView(viewModel: viewModel.mainPriceModel, style: style, withAutoLayout: true)
         pricesStackView.addArrangedSubview(mainPriceView)
 
         if let secondaryPriceModel = viewModel.secondaryPriceModel {
-            let secondaryPriceView = PriceView(viewModel: secondaryPriceModel, withAutoLayout: true)
+            let secondaryPriceView = PriceView(viewModel: secondaryPriceModel, style: style, withAutoLayout: true)
             pricesStackView.addArrangedSubview(secondaryPriceView)
         }
 
@@ -83,9 +83,10 @@ private class PriceView: UIView {
     // MARK: - Private properties
 
     private let viewModel: ObjectPagePriceViewModel.Price
-    private lazy var titleLabel = Label(style: .body, withAutoLayout: true)
-    private lazy var totalPriceLabel = Label(style: .title3Strong, withAutoLayout: true)
-    private lazy var subtitleLabel = Label(style: .caption, withAutoLayout: true)
+    private let style: ObjectPagePriceView.Style
+    private lazy var titleLabel = Label(style: style.titleStyle, withAutoLayout: true)
+    private lazy var totalPriceLabel = Label(style: style.priceStyle, withAutoLayout: true)
+    private lazy var subtitleLabel = Label(style: style.subtitleStyle, withAutoLayout: true)
 
     private lazy var textStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [titleLabel, totalPriceLabel, subtitleLabel])
@@ -96,8 +97,9 @@ private class PriceView: UIView {
 
     // MARK: - Init
 
-    init(viewModel: ObjectPagePriceViewModel.Price, withAutoLayout: Bool) {
+    init(viewModel: ObjectPagePriceViewModel.Price, style: ObjectPagePriceView.Style, withAutoLayout: Bool) {
         self.viewModel = viewModel
+        self.style = style
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = !withAutoLayout
         setup()

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -120,3 +120,21 @@ private class PriceView: UIView {
         textStackView.fillInSuperview()
     }
 }
+
+public extension ObjectPagePriceView {
+    struct Style {
+        let titleStyle: Label.Style
+        let priceStyle: Label.Style
+        let subtitleStyle: Label.Style
+
+        public init(
+            titleStyle: Label.Style = .body,
+            priceStyle: Label.Style = .title3Strong,
+            subtitleStyle: Label.Style = .caption
+        ) {
+            self.titleStyle = titleStyle
+            self.priceStyle = priceStyle
+            self.subtitleStyle = subtitleStyle
+        }
+    }
+}


### PR DESCRIPTION
# Why?
I want to remove the price view currently existing in the app and replace it with this view.

The view in the app is currently being used for BAP, which has a larger font for the price as well as no `title`.

# What?
- Make `title` optional.
- Add struct to configure styles for the three labels within the view.

# Show me

| Most markets | BAP |
| --- | --- |
| ![Screenshot 2020-03-17 at 11 34 25](https://user-images.githubusercontent.com/1901556/76848202-916a9400-6843-11ea-8fe3-621d7c90f355.png) | ![Screenshot 2020-03-17 at 11 34 27](https://user-images.githubusercontent.com/1901556/76848210-9596b180-6843-11ea-8471-c80f609d7a84.png) |