### PR TITLE
Fix: Price view accessibility

### DIFF
--- a/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -67,6 +67,7 @@ extension ObjectPagePriceViewModel {
         ObjectPagePriceViewModel(
             title: "Totalpris",
             totalPrice: "1 389 588 kr",
+            accessibilityLabel: "Totalpris: \(NumberFormatter.spokenFormatter.string(from: 1389588) ?? String(1389588)) kroner",
             links: [
                 LinkButtonViewModel(
                     buttonIdentifier: "loan",
@@ -152,5 +153,14 @@ extension ObjectPagePriceViewModel {
 
     static var mainPriceOnly: ObjectPagePriceViewModel = {
         ObjectPagePriceViewModel(totalPrice: "1 389 588 kr")
+    }()
+}
+
+private extension NumberFormatter {
+    static var spokenFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .spellOut
+        formatter.locale = Locale(identifier: "nb_NO")
+        return formatter
     }()
 }

--- a/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
+++ b/Sources/Components/ObjectPagePriceView/Models/ObjectPagePriceViewModel.swift
@@ -7,8 +7,8 @@ public struct ObjectPagePriceViewModel {
     let secondaryPriceModel: Price?
     let links: [LinkButtonViewModel]
 
-    public init(title: String? = nil, totalPrice: String, subtitle: String? = nil, links: [LinkButtonViewModel] = []) {
-        let mainPriceModel = Price(title: title, totalPrice: totalPrice, subtitle: subtitle)
+    public init(title: String? = nil, totalPrice: String, subtitle: String? = nil, accessibilityLabel: String? = nil, links: [LinkButtonViewModel] = []) {
+        let mainPriceModel = Price(title: title, totalPrice: totalPrice, subtitle: subtitle, accessibilityLabel: accessibilityLabel)
         self.init(mainPriceModel: mainPriceModel, links: links)
     }
 
@@ -22,11 +22,13 @@ public struct ObjectPagePriceViewModel {
         let title: String?
         let totalPrice: String
         let subtitle: String?
+        let accessibilityLabel: String?
 
-        public init(title: String?, totalPrice: String, subtitle: String? = nil) {
+        public init(title: String?, totalPrice: String, subtitle: String? = nil, accessibilityLabel: String? = nil) {
             self.title = title
             self.totalPrice = totalPrice
             self.subtitle = subtitle
+            self.accessibilityLabel = accessibilityLabel
         }
     }
 }

--- a/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -110,6 +110,9 @@ private class PriceView: UIView {
     // MARK: - Setup
 
     private func setup() {
+        isAccessibilityElement = true
+        accessibilityLabel = viewModel.accessibilityLabel
+
         titleLabel.text = viewModel.title
         titleLabel.isHidden = viewModel.title?.isEmpty ?? true
 


### PR DESCRIPTION
# Why?
`ObjectPagePriceView` needs to have a value for `accessibilityLabel` in order to have the same features as the view it's replacing in the app. 

Each price within the view will have its own label.

# What?
- Add property `accessibilityLabel` to `ObjectPagePriceViewModel.Price`.
- Update demo.

# Show me
![Screenshot 2020-03-18 at 09 42 39](https://user-images.githubusercontent.com/1901556/76942000-49a84300-68fd-11ea-9472-f3623fd970e8.png)
