### PR TITLE
TransactionProccess: Option to set custom background, new action and more demo data

### DIFF
--- a/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  Copyright © 2020 FINN AS. All rights reserved.
+//
+
+import Foundation.NSString
+
+extension TransactionDemoViewDefaultData {
+    static var AdExpiredDemoViewModel = TransactionModel(
+        title: "Salgsprosess",
+
+        header: TransactionHeaderModel(
+            adId: "171529672",
+            title: "BMW i3",
+            registrationNumber: "CF40150",
+            imagePath: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+
+        steps: [
+            TransactionStepModel(
+                state: .active,
+                title: "Annonsen er lagt ut",
+                primaryButton: TransactionStepActionButtonModel(
+                    text: "Se annonsen",
+                    style: "flat",
+                    action: "see_ad",
+                    fallbackUrl: "www.finn.no/171529672")),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Kontrakt",
+                body: NSAttributedString(string: "Begge har signert kontrakten."),
+                primaryButton: TransactionStepActionButtonModel(
+                    text: "Gå til kontrakt",
+                    style: "flat",
+                    url: "https://www.google.com/search?q=contract+signed"
+                )),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Betaling",
+                body: NSAttributedString(string: "Kjøper betalte 1. februar 2020."),
+                detail: "Utbetalingen starter først når begge har bekreftet at overleveringen har skjedd."),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Overlevering",
+                body: NSAttributedString(string: "Dere har bekreftet at overleveringen har skjedd.")),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Gratulerer med salget!",
+                body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."),
+                detail: "Det kan ta noen dager før pengene dukker opp på kontoen din.")
+    ])
+}

--- a/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
+++ b/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright © 2020 FINN AS. All rights reserved.
+//
+
+import Foundation.NSString
+
+extension TransactionDemoViewDefaultData {
+    static var PaymentCancelledDemoViewModel = TransactionModel(
+        title: "Salgsprosess",
+
+        header: TransactionHeaderModel(
+            adId: "171529672",
+            title: "BMW i3",
+            registrationNumber: "CF40150",
+            imagePath: "2020/2/vertical-0/26/2/171/529/672_525135443.jpg"),
+
+        alert: TransactionAlertModel(
+            title: "Du har opprettet flere kontrakter for denne bilen",
+            body: "En avtale er bindene når begge har signert. Prosessen under viser derfor prosessen for den første kontrakten begge signerte.",
+            imageIdentifier: "alert-multiple-contracts"
+        ),
+
+        steps: [
+            TransactionStepModel(
+                state: .completed,
+                title: "Annonsen er lagt ut",
+                primaryButton: TransactionStepActionButtonModel(
+                    text: "Se annonsen",
+                    style: "flat",
+                    action: "see_ad",
+                    fallbackUrl: "www.finn.no/171529672")),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Kontrakt",
+                body: NSAttributedString(string: "Begge har signert kontrakten."),
+                primaryButton: TransactionStepActionButtonModel(
+                    text: "Gå til kontrakt",
+                    style: "flat",
+                    url: "https://www.google.com/search?q=contract+signed"
+                )),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Betaling",
+                body: NSAttributedString(string: "Kjøper betalte 1. februar 2020."),
+                detail: "Utbetalingen starter først når begge har bekreftet at overleveringen har skjedd."),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Overlevering",
+                body: NSAttributedString(string: "Dere har bekreftet at overleveringen har skjedd.")),
+
+            TransactionStepModel(
+                state: .completed,
+                title: "Gratulerer med salget!",
+                body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."),
+                detail: "Det kan ta noen dager før pengene dukker opp på kontoen din.")
+    ])
+}

--- a/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
+++ b/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
@@ -26,6 +26,7 @@ public struct TransactionAlertModel: TransactionAlertViewModel {
 
 public struct TransactionStepModel: TransactionStepViewModel {
     public var state: TransactionStepViewState
+    public var customBackground: TransactionStepViewCustomBackground?
     public var title: String
     public var body: NSAttributedString?
     public var primaryButton: TransactionStepActionButtonViewModel?
@@ -46,7 +47,7 @@ public struct TransactionDemoViewDefaultData {
 
     // swiftlint:disable cyclomatic_complexity
     mutating func getState() -> TransactionViewModel {
-        if currentState == 10 {
+        if currentState == 12 {
             self.currentState = -1
         }
 
@@ -86,6 +87,12 @@ public struct TransactionDemoViewDefaultData {
         case 10:
             print("State: payment completed - both parties confirmed handover")
             return TransactionDemoViewDefaultData.BothPartiesConfirmedHandoverDemoViewModel
+        case 11:
+            print("State: ad expired - show Nettbil integration")
+            return TransactionDemoViewDefaultData.AdExpiredDemoViewModel
+        case 12:
+            print("State: payment cancelled")
+            return TransactionDemoViewDefaultData.PaymentCancelledDemoViewModel
         default:
             fatalError("No model exists for step \(currentState)")
         }

--- a/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit.xcodeproj/project.pbxproj
@@ -651,6 +651,8 @@
 		F2E48E0124095EF8009DEFBA /* SellerConfirmedHandoverDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E48E0024095EF8009DEFBA /* SellerConfirmedHandoverDemoViewModel.swift */; };
 		F2E48E0324095F5B009DEFBA /* BothPartiesConfirmedHandoverDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E48E0224095F5B009DEFBA /* BothPartiesConfirmedHandoverDemoViewModel.swift */; };
 		F2E48E0524095FB5009DEFBA /* AwaitingPaymentDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E48E0424095FB5009DEFBA /* AwaitingPaymentDemoViewModel.swift */; };
+		F2F16812242C89B40088D629 /* PaymentCancelledDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F16811242C89B40088D629 /* PaymentCancelledDemoViewModel.swift */; };
+		F2F16814242C8B770088D629 /* AdExpiredDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F16813242C8B770088D629 /* AdExpiredDemoViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1344,6 +1346,8 @@
 		F2E48E0024095EF8009DEFBA /* SellerConfirmedHandoverDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellerConfirmedHandoverDemoViewModel.swift; sourceTree = "<group>"; };
 		F2E48E0224095F5B009DEFBA /* BothPartiesConfirmedHandoverDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BothPartiesConfirmedHandoverDemoViewModel.swift; sourceTree = "<group>"; };
 		F2E48E0424095FB5009DEFBA /* AwaitingPaymentDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwaitingPaymentDemoViewModel.swift; sourceTree = "<group>"; };
+		F2F16811242C89B40088D629 /* PaymentCancelledDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCancelledDemoViewModel.swift; sourceTree = "<group>"; };
+		F2F16813242C8B770088D629 /* AdExpiredDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdExpiredDemoViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4756,6 +4760,8 @@
 				F2E48DFE24095EC0009DEFBA /* BuyerConfirmedHandoverDemoViewModel.swift */,
 				F2E48E0024095EF8009DEFBA /* SellerConfirmedHandoverDemoViewModel.swift */,
 				F2E48E0224095F5B009DEFBA /* BothPartiesConfirmedHandoverDemoViewModel.swift */,
+				F2F16813242C8B770088D629 /* AdExpiredDemoViewModel.swift */,
+				F2F16811242C89B40088D629 /* PaymentCancelledDemoViewModel.swift */,
 			);
 			path = DemoViewModels;
 			sourceTree = "<group>";
@@ -5042,6 +5048,7 @@
 				44AEFC2522E722FC00D3C307 /* BasicCellVariationsDemoView.swift in Sources */,
 				4940480523CDC57400ECBCFD /* ViewingsDemoView.swift in Sources */,
 				4441F9EF22CCF72F00DCFD2F /* AddressMapDemoView.swift in Sources */,
+				F2F16814242C8B770088D629 /* AdExpiredDemoViewModel.swift in Sources */,
 				9BB5438423D20107003FC9C3 /* ColumnListsDemoView.swift in Sources */,
 				9B7D5A2B22E1A5AF001E4005 /* KlimabroletDemoViewController.swift in Sources */,
 				F2E48DFF24095EC0009DEFBA /* BuyerConfirmedHandoverDemoViewModel.swift in Sources */,
@@ -5069,6 +5076,7 @@
 				CF9AC8BC21BECE13005A0D2F /* SnowGlobeDemoView.swift in Sources */,
 				CF3D5EFC215A7215006E4D08 /* DrumMachineDemoView.swift in Sources */,
 				44D9126B2077AD0200486848 /* PopupViewDemoView.swift in Sources */,
+				F2F16812242C89B40088D629 /* PaymentCancelledDemoViewModel.swift in Sources */,
 				44877453234616C30096B510 /* Device.swift in Sources */,
 				4447F7041FDB2B1F0033DBC1 /* ButtonDemoView.swift in Sources */,
 				14C6F7DA212324D600A7230C /* FavoritesListViewDemoViewHelpers.swift in Sources */,

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+ActionButton.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+ActionButton.swift
@@ -7,6 +7,7 @@ public extension TransactionStepView {
         case `default` = "default"
         case flat = "flat"
         case callToAction = "call_to_action"
+        case republishAd = "republish_ad"
         case unknown
 
         public init(rawValue: String) {
@@ -17,6 +18,8 @@ public extension TransactionStepView {
                 self = .flat
             case "call_to_action":
                 self = .callToAction
+            case "republish_ad":
+                self = .republishAd
             default:
                 self = .unknown
             }
@@ -26,7 +29,7 @@ public extension TransactionStepView {
             switch self {
             case .default:
                 return .default
-            case .callToAction:
+            case .callToAction, .republishAd:
                 return .callToAction
             case .flat:
                 return .flat
@@ -41,6 +44,7 @@ public extension TransactionStepView.ActionButton {
     enum Action: String {
         case url = "url"
         case seeAd = "see_ad"
+        case republishAd = "republish_ad"
         case unknown
 
         public init(rawValue: String) {
@@ -49,6 +53,8 @@ public extension TransactionStepView.ActionButton {
                 self = .url
             case "see_ad":
                 self = .seeAd
+            case "republish_ad":
+                self = .republishAd
             default:
                 self = .unknown
             }

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+ActionButton.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+ActionButton.swift
@@ -8,7 +8,6 @@ public extension TransactionStepView {
         case flat = "flat"
         case callToAction = "call_to_action"
         case republishAd = "republish_ad"
-        case unknown
 
         public init(rawValue: String) {
             switch rawValue {
@@ -21,7 +20,7 @@ public extension TransactionStepView {
             case "republish_ad":
                 self = .republishAd
             default:
-                self = .unknown
+                self = .default
             }
         }
 
@@ -33,8 +32,6 @@ public extension TransactionStepView {
                 return .callToAction
             case .flat:
                 return .flat
-            default:
-                return .default
             }
         }
     }

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -5,9 +5,13 @@
 import UIKit
 
 public protocol TransactionStepViewDelegate: AnyObject {
-    func transactionStepViewDidTapActionButton(_ view: TransactionStepView, inTransactionStep step: Int,
-                                               withAction action: TransactionStepView.ActionButton.Action, withUrl urlString: String?,
-                                               withFallbackUrl fallbackUrlString: String?)
+    func transactionStepViewDidTapActionButton(
+        _ view: TransactionStepView,
+        inTransactionStep step: Int,
+        withAction action: TransactionStepView.ActionButton.Action,
+        withUrl urlString: String?,
+        withFallbackUrl fallbackUrlString: String?
+    )
 }
 
 public enum TransactionStepViewState: String {
@@ -36,6 +40,20 @@ public enum TransactionStepViewState: String {
             return .active
         case .completed:
             return .completed
+        }
+    }
+}
+
+public enum TransactionStepViewCustomBackground: String {
+    case warning
+    case error
+
+    public var color: UIColor {
+        switch self {
+        case .error:
+            return .bgCritical
+        case .warning:
+            return .bgAlert
         }
     }
 }
@@ -119,7 +137,12 @@ public class TransactionStepView: UIView {
 
     // MARK: - Init
 
-    public init(step: Int, model: TransactionStepViewModel, withAutoLayout autoLayout: Bool = false) {
+    public init(
+        step: Int,
+        model: TransactionStepViewModel,
+        withCustomBackground backgroundStyle: TransactionStepViewCustomBackground? = nil,
+        withAutoLayout autoLayout: Bool = false
+    ) {
         self.step = step
         self.model = model
         self.primaryButtonModel = model.primaryButton ?? nil
@@ -142,6 +165,7 @@ public class TransactionStepView: UIView {
 
         verticalStackViewTopAnchor?.constant = .spacingM
         verticalStackViewLeadingAnchor?.constant = .spacingM
+        setup(withCustomBackground: backgroundStyle)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -152,8 +176,8 @@ public class TransactionStepView: UIView {
 // MARK: - Private
 
 private extension TransactionStepView {
-    private func setup() {
-        backgroundColor = style.backgroundColor
+    private func setup(withCustomBackground backgroundStyle: TransactionStepViewCustomBackground?) {
+        backgroundColor = backgroundStyle?.color ?? style.backgroundColor
         layer.cornerRadius = style.cornerRadius
 
         addSubview(verticalStackView)
@@ -264,7 +288,9 @@ private extension TransactionStepView {
 
         addSubview(imageView)
 
-        let buttonWidth = button.widthAnchor.constraint(greaterThanOrEqualToConstant: button.intrinsicContentSize.width + imageWidth + .spacingS)
+        let buttonWidth = button.widthAnchor.constraint(
+            greaterThanOrEqualToConstant: button.intrinsicContentSize.width + imageWidth + .spacingS
+        )
         buttonWidth.priority = .required
 
         NSLayoutConstraint.activate([
@@ -297,7 +323,12 @@ private extension TransactionStepView {
         let urlString = model?.url
         let fallbackUrlString = model?.fallbackUrl
 
-        delegate?.transactionStepViewDidTapActionButton(self, inTransactionStep: step, withAction: action,
-                                                         withUrl: urlString, withFallbackUrl: fallbackUrlString)
+        delegate?.transactionStepViewDidTapActionButton(
+            self,
+            inTransactionStep: step,
+            withAction: action,
+            withUrl: urlString,
+            withFallbackUrl: fallbackUrlString
+        )
     }
 }

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -152,19 +152,6 @@ public class TransactionStepView: UIView {
         super.init(frame: .zero)
 
         translatesAutoresizingMaskIntoConstraints = !autoLayout
-        setup()
-    }
-
-    public func hasCompletedLastStep(_ isCompleted: Bool) {
-        guard isCompleted == true else { return }
-
-        backgroundColor = activeStepColor
-        titleView.backgroundColor = activeStepColor
-        bodyView.backgroundColor = activeStepColor
-        detailView.backgroundColor = activeStepColor
-
-        verticalStackViewTopAnchor?.constant = .spacingM
-        verticalStackViewLeadingAnchor?.constant = .spacingM
         setup(withCustomBackground: backgroundStyle)
     }
 

--- a/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepViewModel.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepViewModel.swift
@@ -6,6 +6,7 @@ import Foundation
 
 public protocol TransactionStepViewModel {
     var state: TransactionStepViewState { get }
+    var customBackground: TransactionStepViewCustomBackground? { get }
     var title: String { get }
     var body: NSAttributedString? { get }
     var primaryButton: TransactionStepActionButtonViewModel? { get }

--- a/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -176,6 +176,12 @@ private extension TransactionView {
     func setupTransactionStepView(_ step: Int, _ model: TransactionStepViewModel) {
         let isLastStep = (step == numberOfSteps - 1)
         let transactionStepView = TransactionStepView(step: step, model: model, withAutoLayout: true)
+        let transactionStepView = TransactionStepView(
+            step: step,
+            model: model,
+            withCustomBackground: model.customBackground,
+            withAutoLayout: true
+        )
         transactionStepView.delegate = self
         verticalStackView.addArrangedSubview(transactionStepView)
 

--- a/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -174,8 +174,6 @@ private extension TransactionView {
     }
 
     func setupTransactionStepView(_ step: Int, _ model: TransactionStepViewModel) {
-        let isLastStep = (step == numberOfSteps - 1)
-        let transactionStepView = TransactionStepView(step: step, model: model, withAutoLayout: true)
         let transactionStepView = TransactionStepView(
             step: step,
             model: model,
@@ -184,10 +182,6 @@ private extension TransactionView {
         )
         transactionStepView.delegate = self
         verticalStackView.addArrangedSubview(transactionStepView)
-
-        if isLastStep && model.state == .completed {
-            transactionStepView.hasCompletedLastStep(true)
-        }
     }
 
     func setupTransactionStepDot(_ step: Int) {


### PR DESCRIPTION
# Why?

- Some added functionality that comes along with the bigger API changes. 

# What?

- Need to set a custom background if a step is invalid for some reason (e.g: Ad expiry)
- If an ad has expired we should navigate them to my ads
- Two additional states with demo data 
