### PR TITLE
Internal: set default value for `UserInterfaceStyleSupport` as `dynamic`

### DIFF
--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		9B2D17D223E02B2900EF3B50 /* KeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D17D123E02B2900EF3B50 /* KeyValuePair.swift */; };
 		9B2D17D623E02B6900EF3B50 /* KeyValueGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D17D523E02B6900EF3B50 /* KeyValueGridView.swift */; };
 		9B93F210230FC3CD009B2D4B /* NSDirectionalEdgeInsetsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B93F20F230FC3CD009B2D4B /* NSDirectionalEdgeInsetsExtensions.swift */; };
+		9B9663CB2460383900D34BA1 /* FinniversKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9663CA2460383900D34BA1 /* FinniversKitTests.swift */; };
 		9BA6C49A24336AEC009D417B /* CoronaHelpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA6C49824336AEC009D417B /* CoronaHelpViewModel.swift */; };
 		9BA6C49B24336AEC009D417B /* CoronaHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA6C49924336AEC009D417B /* CoronaHelpView.swift */; };
 		9BA8248623859B4400163F24 /* MapZoomRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8248523859B4400163F24 /* MapZoomRange.swift */; };
@@ -673,6 +674,7 @@
 		9B2D17D123E02B2900EF3B50 /* KeyValuePair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValuePair.swift; sourceTree = "<group>"; };
 		9B2D17D523E02B6900EF3B50 /* KeyValueGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueGridView.swift; sourceTree = "<group>"; };
 		9B93F20F230FC3CD009B2D4B /* NSDirectionalEdgeInsetsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSDirectionalEdgeInsetsExtensions.swift; sourceTree = "<group>"; };
+		9B9663CA2460383900D34BA1 /* FinniversKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinniversKitTests.swift; sourceTree = "<group>"; };
 		9BA6C49824336AEC009D417B /* CoronaHelpViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoronaHelpViewModel.swift; sourceTree = "<group>"; };
 		9BA6C49924336AEC009D417B /* CoronaHelpView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoronaHelpView.swift; sourceTree = "<group>"; };
 		9BA8248523859B4400163F24 /* MapZoomRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapZoomRange.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				CF3D5EFD215A759A006E4D08 /* EasterEggs */,
 				14F4F1BD1FD6CEA800E9CECA /* Info.plist */,
 				9F213D8A2542DC1D6D998B43 /* Util */,
+				9B9663CA2460383900D34BA1 /* FinniversKitTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -3203,6 +3206,7 @@
 				CF3D5F00215A75BF006E4D08 /* InstrumentTests.swift in Sources */,
 				CF376C1B231D458200ED2B24 /* ArrayStepTests.swift in Sources */,
 				CF376C1D231D459900ED2B24 /* StepTests.swift in Sources */,
+				9B9663CB2460383900D34BA1 /* FinniversKitTests.swift in Sources */,
 				9F213830B2F4E5DFE596431F /* KeyboardNotificationInfoTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FinniversKit/Sources/FinniversKit.swift
+++ b/FinniversKit/Sources/FinniversKit.swift
@@ -18,7 +18,13 @@ import Foundation
     }
 
     public static var isDynamicTypeEnabled: Bool = true
-    public static var userInterfaceStyleSupport: UserInterfaceStyleSupport = .forceLight
+    public static var userInterfaceStyleSupport: UserInterfaceStyleSupport = {
+        if #available(iOS 13.0, *) {
+            return .dynamic
+        } else {
+            return .forceLight
+        }
+    }()
 }
 
 @objc public extension Bundle {

--- a/FinniversKit/UnitTests/FinniversKitTests.swift
+++ b/FinniversKit/UnitTests/FinniversKitTests.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright © 2020 FINN AS. All rights reserved.
+//
+
+import XCTest
+import FinniversKit
+
+class FinniversKitTests: XCTestCase {
+    @available(iOS 13.0, *)
+    func testDefaultValueForInterfaceStyle() {
+        let defaultValue: FinniversKit.UserInterfaceStyleSupport = .dynamic
+        XCTAssertEqual(FinniversKit.userInterfaceStyleSupport, defaultValue)
+    }
+
+    func testOverridingValueForInterfaceStyle() {
+        FinniversKit.userInterfaceStyleSupport = .forceDark
+        XCTAssertEqual(
+            FinniversKit.userInterfaceStyleSupport,
+            FinniversKit.UserInterfaceStyleSupport.forceDark
+        )
+    }
+}


### PR DESCRIPTION
for iOS 13.

Now that we support iOS 13's dark mode, when including the library in a
new project we expect the dynamic colors to be on, which is something
that people can forget.

For older iOS versions, we still use `forceLight` as default value.

This changes the logic for the default value while still allowing
overrides.