### PR TITLE
Dark mode fix in primings

### DIFF
--- a/FinniversKit/Sources/Components/Priming/Subviews/PrimingTableViewCell.swift
+++ b/FinniversKit/Sources/Components/Priming/Subviews/PrimingTableViewCell.swift
@@ -47,6 +47,8 @@ final class PrimingTableViewCell: UITableViewCell {
     }
 
     private func setup() {
+        backgroundColor = .bgPrimary
+
         contentView.addSubview(iconImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(detailLabel)


### PR DESCRIPTION
# Why?

You can barely see the difference, but I noticed `PrimingTableViewCell` background color was a little different from the bottom sheet background. 

# What?

Use `.bgPrimary` on the cell, which is the background color used in the bottom sheet. 

# Show me

| Before | After |
| --- | --- |
| ![IMG_1748](https://user-images.githubusercontent.com/17450858/81046799-6d2d4a00-8eb9-11ea-9951-b5109e0936d7.PNG) | ![IMG_1749](https://user-images.githubusercontent.com/17450858/81046797-6999c300-8eb9-11ea-8840-af20c38f7524.PNG) |

