### PR TITLE
TransactionProcess: Support for default case with fallback in CustomStyle

### DIFF
--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
@@ -36,6 +36,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt."),
@@ -58,6 +59,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -33,6 +34,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
@@ -55,6 +57,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -55,6 +56,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «<a href=\"/minekjoretoy\">Eide før</a>»."),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -43,6 +44,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Betaling",
                     body: NSAttributedString(string: "Før kjøper kan overføre pengene, må du forberede betalingen."),
@@ -59,6 +61,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -33,6 +34,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
@@ -51,6 +53,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Kjøper har bekreftet.</p><p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
@@ -68,6 +71,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før».")),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
@@ -33,6 +33,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Kjøper har blitt invitert."),
@@ -49,6 +50,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Velger dere å betale gjennom FINN, må overleveringen skje innen 7 dager etter kjøper har betalt.</p><p>Registrering av eierskiftet bør gjøres når dere møtes for overlevering.</p>"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -33,6 +34,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Kjøper har signert, nå mangler bare din signatur."),
@@ -43,12 +45,14 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Betaling",
                     body: NSAttributedString(string: "Dere kan betale trygt gjennom FINN ved å velge det i kontrakten."))),
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Velger dere å betale gjennom FINN, må overleveringen skje innen 7 dager etter kjøper har betalt.</p><p>Registrering av eierskiftet bør gjøres når dere møtes for overlevering.</p>"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
@@ -27,6 +27,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Du har opprettet kontrakt."),
@@ -49,6 +50,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
@@ -17,6 +17,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -27,6 +28,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt."),
@@ -49,6 +51,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -61,6 +62,7 @@ extension TransactionDemoViewDefaultData {
 
              TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før»."))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
@@ -43,6 +43,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Betaling",
                     body: NSAttributedString(string: "Kjøper betalte 1. februar 2020.")),
@@ -51,6 +52,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
@@ -68,6 +70,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før».")),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -51,6 +52,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Du har bekreftet overleveringen.<br/>Venter på kjøper.</p><p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
@@ -68,6 +70,7 @@ extension TransactionDemoViewDefaultData {
 
                 TransactionStepModel(
                     state: .notStarted,
+                    style: .default,
                     main: TransactionStepContentModel(
                         title: "Gratulerer med salget!",
                         body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «Eide før».")),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
@@ -23,6 +23,7 @@ extension TransactionDemoViewDefaultData {
         steps: [
             TransactionStepModel(
                 state: .completed,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
                     primaryButton: TransactionActionButtonModel(
@@ -33,6 +34,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .active,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Venter på at kjøper skal signere."),
@@ -49,6 +51,7 @@ extension TransactionDemoViewDefaultData {
 
             TransactionStepModel(
                 state: .notStarted,
+                style: .default,
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Velger dere å betale gjennom FINN, må overleveringen skje innen 7 dager etter kjøper har betalt.</p><p>Registrering av eierskiftet bør gjøres når dere møtes for overlevering.</p>"))),

--- a/FinnUI/Sources/Base Components/ButtonStyle+Previews.swift
+++ b/FinnUI/Sources/Base Components/ButtonStyle+Previews.swift
@@ -109,6 +109,7 @@ struct ButtonStyleUsageDemoView: View {
 }
 
 @available(iOS 13.0.0, *)
+// swiftlint:disable:next superfluous_disable_command type_name
 struct ButtonStyleUsageDemoView_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButton.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButton.swift
@@ -3,15 +3,13 @@
 //
 
 public enum TransactionActionButton: String {
-    case `default` = "DEFAULT"
     case flat = "FLAT"
     case callToAction = "CALL_TO_ACTION"
     case republishAd = "REPUBLISH_AD"
+    case `default` = "DEFAULT"
 
     public init(rawValue: String) {
         switch rawValue {
-        case "DEFAULT":
-            self = .default
         case "FLAT":
             self = .flat
         case "CALL_TO_ACTION":

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+CustomStyle.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView+CustomStyle.swift
@@ -9,6 +9,7 @@ extension TransactionStepView {
     public enum CustomStyle: String {
         case warning = "WARNING"
         case error = "ERROR"
+        case `default` = "DEFAULT"
 
         public init(rawValue: String) {
             switch rawValue {
@@ -17,16 +18,19 @@ extension TransactionStepView {
             case "ERROR":
                 self = .error
             default:
-                fatalError("No supported custom style exists for rawValue: '\(rawValue)'")
+                self = .default
             }
         }
 
-        public var backgroundColor: UIColor {
+        /// Use custom style provided by the backend or fallback to the style defined locally
+        public func backgroundColor(style: TransactionStepView.Style) -> UIColor {
             switch self {
             case .error:
                 return .bgCritical
             case .warning:
                 return .bgAlert
+            case .default:
+                return style.backgroundColor
             }
         }
     }

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -58,7 +58,7 @@ public class TransactionStepView: UIView {
 
     private lazy var verticalStackView: UIStackView = {
         let view = UIStackView(withAutoLayout: true)
-        view.backgroundColor = customStyle?.backgroundColor ?? style.backgroundColor
+        view.backgroundColor = customStyle?.backgroundColor(style: style) ?? style.backgroundColor
         view.axis = .vertical
         view.distribution = .fill
         view.alignment = .leading
@@ -85,7 +85,7 @@ public class TransactionStepView: UIView {
     }
 
     private func setup() {
-        backgroundColor = customStyle?.backgroundColor ?? style.backgroundColor
+        backgroundColor = customStyle?.backgroundColor(style: style) ?? style.backgroundColor
         layer.cornerRadius = style.cornerRadius
 
         if let mainContent = model.main {


### PR DESCRIPTION
# Why?

- If the backend sends us a nonsense value (`DEFAULT`), the client will handle it gracefully

# What?

- Make the `backgroundColor` property into a func
- If the value provided to the `CustomStyle` enum is `DEFAULT` use the local styling instead.

# Show me
No UI changes