### PR TITLE
NC - Add refresh controls to table views

### DIFF
--- a/Demo/Demo/Fullscreen/NotificationCenter/NotificationCenterDemoView.swift
+++ b/Demo/Demo/Fullscreen/NotificationCenter/NotificationCenterDemoView.swift
@@ -95,6 +95,12 @@ extension NotificationCenterDemoView: NotificationCenterViewDelegate {
     func notificationCenterView(_ view: NotificationCenterView, segment: Int, didSelectFooterButtonInSection section: Int) {
         
     }
+    
+    func notificationCenterView(_ view: NotificationCenterView, segment: Int, didPullToRefreshUsing refreshControl: UIRefreshControl) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            refreshControl.endRefreshing()
+        }
+    }
 }
 
 extension NotificationCenterDemoView: FeedbackViewDelegate {

--- a/Demo/Demo/Fullscreen/NotificationCenter/NotificationCenterDemoView.swift
+++ b/Demo/Demo/Fullscreen/NotificationCenter/NotificationCenterDemoView.swift
@@ -97,7 +97,7 @@ extension NotificationCenterDemoView: NotificationCenterViewDelegate {
     }
     
     func notificationCenterView(_ view: NotificationCenterView, segment: Int, didPullToRefreshUsing refreshControl: UIRefreshControl) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             refreshControl.endRefreshing()
         }
     }

--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -20,6 +20,7 @@ public protocol NotificationCenterViewDelegate: AnyObject {
     func notificationCenterView(_ view: NotificationCenterView, segment: Int, didSelectModelAt indexPath: IndexPath)
     func notificationCenterView(_ view: NotificationCenterView, segment: Int, didSelectSavedSearchButtonIn section: Int)
     func notificationCenterView(_ view: NotificationCenterView, segment: Int, didSelectFooterButtonInSection section: Int)
+    func notificationCenterView(_ view: NotificationCenterView, segment: Int, didPullToRefreshUsing refreshControl: UIRefreshControl)
 }
 
 final public class NotificationCenterView: UIView {
@@ -170,6 +171,13 @@ extension NotificationCenterView: NotificationCenterFooterViewDelegate {
     }
 }
 
+// MARK: - RefreshControlDelegate
+extension NotificationCenterView: RefreshControlDelegate {
+    public func refreshControlDidBeginRefreshing(_ refreshControl: RefreshControl) {
+        delegate?.notificationCenterView(self, segment: selectedSegment, didPullToRefreshUsing: refreshControl)
+    }
+}
+
 // MARK: - Private Methods
 private extension NotificationCenterView {
     func setup() {
@@ -198,6 +206,7 @@ private extension NotificationCenterView {
         for segment in 0 ..< dataSource.numberOfSegments(in: self) {
             let title = dataSource.notificationCenterView(self, titleInSegment: segment)
             let tableView = UITableView.createNotificationCenterTableView()
+            tableView.refreshControl = RefreshControl(delegate: self)
             tableView.dataSource = self
             tableView.delegate = self
             
@@ -276,7 +285,11 @@ private class SegmentContainer {
     let tableView: UITableView
     let leadingConstraint: NSLayoutConstraint
     
-    init(title: String, tableView: UITableView, leadingConstraint: NSLayoutConstraint) {
+    init(
+        title: String,
+        tableView: UITableView,
+        leadingConstraint: NSLayoutConstraint
+    ) {
         self.title = title
         self.tableView = tableView
         self.leadingConstraint = leadingConstraint
@@ -299,5 +312,13 @@ private extension UITableView {
         tableView.register(NotificationCenterFooterView.self)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         return tableView
+    }
+}
+
+// MARK: - RefreshControl
+private extension RefreshControl {
+    convenience init(delegate: RefreshControlDelegate) {
+        self.init(frame: .zero)
+        self.delegate = delegate
     }
 }

--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -159,6 +159,7 @@ extension NotificationCenterView: UITableViewDelegate {
     
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard reloadOnEndDragging, let refreshControl = scrollView.refreshControl else { return }
+        reloadOnEndDragging = false
         delegate?.notificationCenterView(self, segment: selectedSegment, didPullToRefreshUsing: refreshControl)
     }
 }

--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -320,11 +320,3 @@ private extension UITableView {
         return tableView
     }
 }
-
-// MARK: - RefreshControl
-private extension RefreshControl {
-    convenience init(delegate: RefreshControlDelegate) {
-        self.init(frame: .zero)
-        self.delegate = delegate
-    }
-}

--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -178,13 +178,6 @@ extension NotificationCenterView: NotificationCenterFooterViewDelegate {
     }
 }
 
-// MARK: - RefreshControlDelegate
-extension NotificationCenterView: RefreshControlDelegate {
-    public func refreshControlDidBeginRefreshing(_ refreshControl: RefreshControl) {
-        reloadOnEndDragging = true
-    }
-}
-
 // MARK: - Private Methods
 private extension NotificationCenterView {
     func setup() {
@@ -203,6 +196,10 @@ private extension NotificationCenterView {
         ])
     }
     
+    @objc func handleRefreshBegan() {
+        reloadOnEndDragging = true
+    }
+    
     func setupSegmentedControl() {
         segmentContainers = []
         
@@ -213,7 +210,9 @@ private extension NotificationCenterView {
         for segment in 0 ..< dataSource.numberOfSegments(in: self) {
             let title = dataSource.notificationCenterView(self, titleInSegment: segment)
             let tableView = UITableView.createNotificationCenterTableView()
-            tableView.refreshControl = RefreshControl(delegate: self)
+            let refreshControl = UIRefreshControl(frame: .zero)
+            refreshControl.addTarget(self, action: #selector(handleRefreshBegan), for: .valueChanged)
+            tableView.refreshControl = refreshControl
             tableView.dataSource = self
             tableView.delegate = self
             

--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -50,6 +50,7 @@ final public class NotificationCenterView: UIView {
     }()
     
     private var segmentContainers: [SegmentContainer]?
+    private var reloadOnEndDragging = false
     
     // MARK: - Init
     
@@ -155,6 +156,11 @@ extension NotificationCenterView: UITableViewDelegate {
         footerView.configure(with: title, inSection: section)
         return footerView
     }
+    
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        guard reloadOnEndDragging, let refreshControl = scrollView.refreshControl else { return }
+        delegate?.notificationCenterView(self, segment: selectedSegment, didPullToRefreshUsing: refreshControl)
+    }
 }
 
 // MARK: - NotificationCenterHeaderViewDelegate
@@ -174,7 +180,7 @@ extension NotificationCenterView: NotificationCenterFooterViewDelegate {
 // MARK: - RefreshControlDelegate
 extension NotificationCenterView: RefreshControlDelegate {
     public func refreshControlDidBeginRefreshing(_ refreshControl: RefreshControl) {
-        delegate?.notificationCenterView(self, segment: selectedSegment, didPullToRefreshUsing: refreshControl)
+        reloadOnEndDragging = true
     }
 }
 


### PR DESCRIPTION
# Why?

Users should be able to reload the content

# What?

- Set the refresh control of each table view when created
- Implement `RefreshControlDelegate`
- Adds `didPullToRefresh` delegate method