### PR TITLE
Set state to .default instead of fatalError

### DIFF
--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -28,7 +28,7 @@ public enum TransactionStepViewState: String {
         case "COMPLETED":
             self = .completed
         default:
-            fatalError("No supported state exists for rawValue: '\(rawValue)'")
+            self = .notStarted
         }
     }
 


### PR DESCRIPTION
# Why?

- Better to handle invalid input gracefully

# What?

- Set the `StepState` to `.default` instead of `fatalError`'ing
