### PR TITLE
SwitchView: Implement setOn(_:animated:)

### DIFF
--- a/FinniversKit/Sources/Components/Switch/SwitchView.swift
+++ b/FinniversKit/Sources/Components/Switch/SwitchView.swift
@@ -67,6 +67,10 @@ public class SwitchView: UIView {
 
     // MARK: - Public methods
 
+    public func setOn(_ isOn: Bool, animated: Bool) {
+        uiSwitch.setOn(isOn, animated: animated)
+    }
+
     public func configure(with model: SwitchViewModel) {
         titleLabel.text = model.title
         detailLabel.text = model.detail


### PR DESCRIPTION
# Why?
This view only had the capability to set the switch on/off without animation. This PR adds an implementation for `setOn(_:animated:)`.