### PR TITLE
Check if row should be editable when editing

### DIFF
--- a/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -442,7 +442,7 @@ extension FavoriteFoldersListView: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         if tableView.isEditing {
-            return Section(rawValue: indexPath.section) == .folders
+            return Section(rawValue: indexPath.section) == .folders && canEditRow(at: indexPath)
         } else {
             return canEditRow(at: indexPath)
         }


### PR DESCRIPTION
# Why?
Thuy discovered a bug within the list of favorite folders. If you were to swipe (to delete) any editable folder and then tried 'Mine funn', which shouldn't be deletable, this would let the user try to delete that folder.

# What?
- Check if row/folder should be editable, even when `isEditing` is `true`.

# Show me
| Before | After |
| --- | --- |
| ![Kapture 2020-06-08 at 16 02 50](https://user-images.githubusercontent.com/1901556/84039676-e1b84480-a9a1-11ea-9995-f957943e400d.gif) | ![Kapture 2020-06-08 at 15 59 49](https://user-images.githubusercontent.com/1901556/84039680-e2e97180-a9a1-11ea-8dfa-af75b3c81b99.gif) |