### PR TITLE
Visual fix for empty state in notification center saved search

### DIFF
--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Cells/EmptyNotificationsCell.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Cells/EmptyNotificationsCell.swift
@@ -72,6 +72,8 @@ class EmptyNotificationsCell: UITableViewCell {
         iconImageView.image = model?.icon
         titleLabel.text = model?.title
         bodyLabel.text = model?.body
+        contentView.backgroundColor = .clear
+        backgroundColor = .clear
 
         switch model?.kind {
         case .personal:


### PR DESCRIPTION
# Why?

We had some small issues for dark mode

# What?

- make the background color of the cell clear

I was gonna fix the icons for this and saved searches, but Thuy need to make some adjustments to it, so I will add that fix later.
# Show me

| Before |  After Dark | After Light |
| --- | --- | --- |
| ![before](https://user-images.githubusercontent.com/167989/84498930-d1f67400-acb1-11ea-872d-4c1e33260f76.png) | ![after-dark-3](https://user-images.githubusercontent.com/167989/84500887-bbeab280-acb5-11ea-960a-237767756523.png) | ![after-light-3](https://user-images.githubusercontent.com/167989/84500876-b725fe80-acb5-11ea-9c50-8a9f07e68149.png) |