### PR TITLE
NC - Fix color bug when switching between light and dark mode

### DIFF
--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Cells/NotificationCell.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Cells/NotificationCell.swift
@@ -67,14 +67,7 @@ final class NotificationCell: UITableViewCell {
         return separatorView
     }()
 
-    private lazy var gradientLayer: CAGradientLayer = {
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.colors = [
-            UIColor.bgPrimary.withAlphaComponent(0).cgColor,
-            UIColor.bgPrimary.cgColor
-        ]
-        return gradientLayer
-    }()
+    private lazy var gradientLayer = CAGradientLayer()
 
     private let imageWidth: CGFloat = 80
     private let fallbackImage = UIImage(named: .noImage)
@@ -95,6 +88,12 @@ final class NotificationCell: UITableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        gradientLayer.colors = [
+            UIColor.bgPrimary.withAlphaComponent(0).cgColor,
+            UIColor.bgPrimary.cgColor
+        ]
+
         gradientLayer.frame = contentView.bounds
     }
 


### PR DESCRIPTION
# Why?

There was a bug where the gradient layer did not change it's colors when switching between light and dark mode.

# What?

- Mode setting gradient colors to `layoutSubviews`

# Show me

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-06-17 at 10 13 48](https://user-images.githubusercontent.com/19956175/84873470-937f0180-b083-11ea-9486-af8300d375c4.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-06-17 at 10 17 08](https://user-images.githubusercontent.com/19956175/84873561-b90c0b00-b083-11ea-886b-cd8800573aec.png) |
