### PR TITLE
Make TransactionProcess more protocol oriented

### DIFF
--- a/Demo/Demo/Components/TransactionProcessSummaryView/TransactionProcessSummaryDemoView.swift
+++ b/Demo/Demo/Components/TransactionProcessSummaryView/TransactionProcessSummaryDemoView.swift
@@ -15,7 +15,7 @@ public class TransactionProcessSummaryDemoView: UIView {
         title: "Salgsprosess",
         detail: "Kontrakt",
         description: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt",
-        externalView: TransactionButtonModel(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
+        externalView: .init(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
         style: "ERROR"
     )
 

--- a/Demo/Demo/Components/TransactionProcessSummaryView/TransactionProcessSummaryDemoView.swift
+++ b/Demo/Demo/Components/TransactionProcessSummaryView/TransactionProcessSummaryDemoView.swift
@@ -15,7 +15,7 @@ public class TransactionProcessSummaryDemoView: UIView {
         title: "Salgsprosess",
         detail: "Kontrakt",
         description: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt",
-        externalView: .init(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
+        externalView: TransactionButtonModel(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
         style: "ERROR"
     )
 

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AdExpiredDemoViewModel.swift
@@ -21,7 +21,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Annonsen er utløpt",
                     body: NSAttributedString(string: "Legg ut annonsen på nytt, sånn at kjøpere kan ta kontakt med deg."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Legg ut på nytt",
                         style: "CALL_TO_ACTION",
                         action: "REPUBLISH_AD",
@@ -29,7 +29,7 @@ extension TransactionDemoViewDefaultData {
                 detail: TransactionStepContentModel(
                     title: "Ønsker du hjelp med salget?",
                     body: NSAttributedString(string: "Nettbil hjelper deg kostnadsfritt med å selge bilen til forhandlere gjennom en budrunde. De trenger bare levere deg bilen, så ordner Nettbil resten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Mer om Nettbil",
                         style: "DEFAULT",
                         fallbackUrl: "https://www.finn.no/nettbil/velkommen"))),
@@ -40,7 +40,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Opprett digital kontrakt",
                         style: "FLAT",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/AwaitingPaymentDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -38,7 +38,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         url: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesConfirmedHandoverDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -37,7 +37,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         url: "https://www.google.com/search?q=contract+signed"))),
@@ -63,7 +63,7 @@ extension TransactionDemoViewDefaultData {
                     nativeBody: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under Eide før.")),
                 detail: TransactionStepContentModel(
                     body: NSAttributedString(string: "Det kan ta noen dager før pengene dukker opp på kontoen din."),
-                    nativeButton: .init(
+                    nativeButton: TransactionButtonModel(
                         text: "Gå til Mine kjøretøy",
                         style: "FLAT",
                         url: "/minekjoretoy"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BothPartiesSignedDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -37,7 +37,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         url: "https://www.google.com/search?q=contract+signed"))),
@@ -48,7 +48,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Betaling",
                     body: NSAttributedString(string: "Før kjøper kan overføre pengene, må du forberede betalingen."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Forbered betaling",
                         style: "CALL_TO_ACTION",
                         url: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerConfirmedHandoverDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -38,7 +38,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         url: "https://www.google.com/search?q=contract+signed"))),
@@ -57,11 +57,11 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Kjøper har bekreftet.</p><p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
-                    nativeButton: .init(
+                    nativeButton: TransactionButtonModel(
                         text: "Registrer eierskifte",
                         style: "DEFAULT",
                         url: "https://www.vegvesen.no/"),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Bekreft overlevering",
                         style: "CALL_TO_ACTION",
                         action: "URL",

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerInvitedDemoViewModel.swift
@@ -25,7 +25,7 @@ extension TransactionDemoViewDefaultData {
                 state: .completed,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -37,7 +37,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Kjøper har blitt invitert."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Signer kontrakt",
                         style: "CALL_TO_ACTION",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/BuyerOnlySignedDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -38,7 +38,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Kjøper har signert, nå mangler bare din signatur."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                     text: "Signer kontrakt",
                     style: "CALL_TO_ACTION",
                     fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractCreatedDemoViewModel.swift
@@ -19,7 +19,7 @@ extension TransactionDemoViewDefaultData {
                 state: .completed,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -31,7 +31,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Du har opprettet kontrakt."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Inviter kjøper",
                         style: "CALL_TO_ACTION",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/ContractNotCreatedDemoViewModel.swift
@@ -20,7 +20,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -32,7 +32,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Når du har funnet en kjøper er det neste steget å skrive en kontrakt."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Opprett digital kontrakt",
                         style: "CALL_TO_ACTION",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCancelledDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -37,7 +37,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),
@@ -49,7 +49,7 @@ extension TransactionDemoViewDefaultData {
                     title: "Betaling",
                     body: NSAttributedString(string: "<p>Betalingen er kansellert.</p><p>Ta kontakt med <a href=\"https://swiftcourt.com/\">Swiftcourt</a> for å starte betalingen på nytt.</p"),
                     nativeBody: NSAttributedString(string: "<p>Betalingen er kansellert.</p><p>Ta kontakt med Swiftcourt for å starte betalingen på nytt.</p"),
-                    nativeButton: .init(
+                    nativeButton: TransactionButtonModel(
                         text: "Gå til swiftcourt",
                         style: "FLAT",
                         url: "https://swiftcourt.com/"))),

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/PaymentCompletedDemoViewModel.swift
@@ -25,7 +25,7 @@ extension TransactionDemoViewDefaultData {
                 state: .completed,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -36,7 +36,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                     text: "Gå til kontrakt",
                     style: "FLAT",
                     url: "https://www.google.com/search?q=contract+signed"))),
@@ -56,11 +56,11 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
-                    nativeButton: .init(
+                    nativeButton: TransactionButtonModel(
                         text: "Registrer eierskifte",
                         style: "DEFAULT",
                         url: "https://www.vegvesen.no/"),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Bekreft overlevering",
                         style: "CALL_TO_ACTION",
                         action: "URL",

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerConfirmedHandoverDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -37,7 +37,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Begge har signert kontrakten."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "FLAT",
                         url: "https://www.google.com/search?q=contract+signed"))),
@@ -56,11 +56,11 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Overlevering",
                     body: NSAttributedString(string: "<p>Du har bekreftet overleveringen.<br/>Venter på kjøper.</p><p>Dere må bekrefte før:<br/><strong>8. februar 2020.</strong></p><ol><li>Ved oppmøte registrerer dere først eierskiftet digitalt hos Statens vegvesen.</li><li>Deretter må <strong>begge</strong> bekrefte at overleveringen har skjedd, og at pengene kan utbetales.</li></ol>"),
-                    nativeButton: .init(
+                    nativeButton: TransactionButtonModel(
                         text: "Registrer eierskifte",
                         style: "DEFAULT",
                         url: "https://www.vegvesen.no/"),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Bekreft overlevering",
                         style: "CALL_TO_ACTION",
                         action: "URL",

--- a/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/DemoViewModels/SellerOnlySignedDemoViewModel.swift
@@ -26,7 +26,7 @@ extension TransactionDemoViewDefaultData {
                 style: .default,
                 main: TransactionStepContentModel(
                     title: "Annonsen er lagt ut",
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Se annonsen",
                         style: "FLAT",
                         action: "SEE_AD",
@@ -38,7 +38,7 @@ extension TransactionDemoViewDefaultData {
                 main: TransactionStepContentModel(
                     title: "Kontrakt",
                     body: NSAttributedString(string: "Venter på at kjøper skal signere."),
-                    primaryButton: .init(
+                    primaryButton: TransactionButtonModel(
                         text: "Gå til kontrakt",
                         style: "DEFAULT",
                         fallbackUrl: "https://www.google.com/search?q=contract+signed"))),

--- a/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
@@ -67,12 +67,15 @@ extension TransactionDemoView: TransactionViewDelegate {
         refreshControl.endRefreshing()
     }
 
+    //swiftlint:disable:next function_parameter_count
     func transactionViewDidTapActionButton(_ view: TransactionView,
+                                           inContentView kind: TransactionStepContentView.Kind,
+                                           withButtonTag tag: TransactionActionButton.Tag,
                                            withAction action: TransactionActionButton.Action,
                                            withUrl urlString: String?,
                                            withFallbackUrl fallbackUrlString: String?) {
 
-        print("Did tap button in step: \(step), with action: \(action.rawValue), with urlString: \(urlString ?? ""), with fallbackUrl:\(fallbackUrlString ?? "")")
+        print("Did tap button with tag: \(tag) in contentView: \(kind), with action: \(action.rawValue), with urlString: \(urlString ?? ""), with fallbackUrl:\(fallbackUrlString ?? "")")
     }
 }
 

--- a/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
@@ -68,7 +68,6 @@ extension TransactionDemoView: TransactionViewDelegate {
     }
 
     func transactionViewDidTapActionButton(_ view: TransactionView,
-                                           inTransactionStep step: Int,
                                            withAction action: TransactionActionButton.Action,
                                            withUrl urlString: String?,
                                            withFallbackUrl fallbackUrlString: String?) {

--- a/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/TransactionDemoView.swift
@@ -69,13 +69,14 @@ extension TransactionDemoView: TransactionViewDelegate {
 
     //swiftlint:disable:next function_parameter_count
     func transactionViewDidTapActionButton(_ view: TransactionView,
+                                           inStep step: Int,
                                            inContentView kind: TransactionStepContentView.Kind,
                                            withButtonTag tag: TransactionActionButton.Tag,
                                            withAction action: TransactionActionButton.Action,
                                            withUrl urlString: String?,
                                            withFallbackUrl fallbackUrlString: String?) {
 
-        print("Did tap button with tag: \(tag) in contentView: \(kind), with action: \(action.rawValue), with urlString: \(urlString ?? ""), with fallbackUrl:\(fallbackUrlString ?? "")")
+        print("Did tap button with tag: \(tag) in step: \(step) in view: \(kind), with action: \(action.rawValue), with urlString: \(urlString ?? ""), with fallbackUrl:\(fallbackUrlString ?? "")")
     }
 }
 

--- a/Demo/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
+++ b/Demo/Demo/Fullscreen/TransactionView/TransactionDemoViewDefaultData.swift
@@ -31,6 +31,22 @@ public struct TransactionStepModel: TransactionStepViewModel {
     public var detail: TransactionStepContentViewModel?
 }
 
+public struct TransactionButtonModel: TransactionActionButtonViewModel {
+    public var text: String
+    public var style: String?
+    public var action: String?
+    public var url: String?
+    public var fallbackUrl: String?
+
+    public init(text: String, style: String? = nil, action: String? = nil, url: String? = nil, fallbackUrl: String? = nil) {
+        self.text = text
+        self.style = style
+        self.action = action
+        self.url = url
+        self.fallbackUrl = fallbackUrl
+    }
+}
+
 public struct TransactionStepContentModel: TransactionStepContentViewModel {
     public var title: String?
     /*

--- a/Demo/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -68,7 +68,7 @@ public class AdManagementDemoView: UIView {
         title: "Salgsprosess",
         detail: "Overlevering",
         description: "Kjøper har bekreftet. Dere må bekrefte før 8.februar 2020.",
-        externalView: .init(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
+        externalView: TransactionButtonModel(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
         style: "ERROR"
     )
 

--- a/Demo/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Demo/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -68,7 +68,7 @@ public class AdManagementDemoView: UIView {
         title: "Salgsprosess",
         detail: "Overlevering",
         description: "Kjøper har bekreftet. Dere må bekrefte før 8.februar 2020.",
-        externalView: TransactionButtonModel(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
+        externalView: .init(text: "Mine kjøretøy", url: "https://www.finn.no/minekjoretoy"),
         style: "ERROR"
     )
 

--- a/FinnUI/Sources/AdView/BapAdView/BapAdView.swift
+++ b/FinnUI/Sources/AdView/BapAdView/BapAdView.swift
@@ -229,6 +229,7 @@ extension BapAdView {
 }
 
 @available(iOS 13.0.0, *)
+//swiftlint:disable:next type_name
 struct BapAdView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/FinnUI/Sources/AdView/Components/AuthorView/AuthorView.swift
+++ b/FinnUI/Sources/AdView/Components/AuthorView/AuthorView.swift
@@ -59,6 +59,7 @@ extension AuthorView {
 }
 
 @available(iOS 13.0, *)
+//swiftlint:disable:next type_name
 struct AuthorView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/FinnUI/Sources/AdView/Components/DescriptionView/DescriptionView.swift
+++ b/FinnUI/Sources/AdView/Components/DescriptionView/DescriptionView.swift
@@ -48,6 +48,7 @@ struct DescriptionView: View {
 }
 
 @available(iOS 13.0, *)
+//swiftlint:disable:next type_name
 struct DescriptionView_Previews: PreviewProvider {
     static let ad = BapAdViewModel.sampleData
 

--- a/FinnUI/Sources/AdView/Components/PhoneNumberView/PhoneNumberView.swift
+++ b/FinnUI/Sources/AdView/Components/PhoneNumberView/PhoneNumberView.swift
@@ -39,6 +39,7 @@ struct PhoneNumberView: View {
 }
 
 @available(iOS 13.0.0, *)
+//swiftlint:disable:next type_name
 struct PhoneNumberView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/FinnUI/Sources/AdView/Components/TryHeltHjemView/TryHeltHjemView.swift
+++ b/FinnUI/Sources/AdView/Components/TryHeltHjemView/TryHeltHjemView.swift
@@ -50,6 +50,7 @@ struct TryHeltHjemView: View {
 }
 
 @available(iOS 13.0, *)
+//swiftlint:disable:next type_name
 struct TryHeltHjemView_Previews: PreviewProvider {
     static var previews: some View {
         TryHeltHjemView(viewModel: .sampleData)

--- a/FinniversKit/Sources/Components/TransactionProcessSummaryView/TransactionProcessSummaryViewModel.swift
+++ b/FinniversKit/Sources/Components/TransactionProcessSummaryView/TransactionProcessSummaryViewModel.swift
@@ -6,14 +6,30 @@ public struct TransactionProcessSummaryViewModel {
     public let title: String
     public let detail: String
     public let description: String
-    public let externalView: TransactionActionButtonViewModel?
+    public let externalView: TransactionProcessSummaryButtonViewModel?
     public let style: String?
 
-    public init(title: String, detail: String, description: String, externalView: TransactionActionButtonViewModel?, style: String?) {
+    public init(title: String, detail: String, description: String, externalView: TransactionProcessSummaryButtonViewModel?, style: String?) {
         self.title = title
         self.detail = detail
         self.description = description
         self.externalView = externalView
         self.style = style
+    }
+}
+
+public struct TransactionProcessSummaryButtonViewModel: TransactionActionButtonViewModel {
+    public var text: String
+    public var style: String?
+    public var action: String?
+    public var url: String?
+    public var fallbackUrl: String?
+
+    public init(text: String, style: String? = nil, action: String? = nil, url: String? = nil, fallbackUrl: String? = nil) {
+        self.text = text
+        self.style = style
+        self.action = action
+        self.url = url
+        self.fallbackUrl = fallbackUrl
     }
 }

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButton.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButton.swift
@@ -34,6 +34,16 @@ public enum TransactionActionButton: String {
 }
 
 extension TransactionActionButton {
+    public enum Tag: Int {
+        /// Native meaning that the button is just an inline link refering to some content on an external website.
+        case native = 1
+
+        /// Primary meaning that the button is part of the actual transaction flow
+        case primary = 2
+    }
+}
+
+extension TransactionActionButton {
     public enum Action: String {
         // Native actions
         case seeAd = "SEE_AD"

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButtonViewModel.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButtonViewModel.swift
@@ -2,18 +2,10 @@
 //  Copyright © 2020 FINN AS. All rights reserved.
 //
 
-public struct TransactionActionButtonViewModel {
-    public let text: String
-    public let style: String?
-    public let action: String?
-    public let url: String?
-    public let fallbackUrl: String?
-
-    public init(text: String, style: String? = nil, action: String? = nil, url: String? = nil, fallbackUrl: String? = nil) {
-        self.text = text
-        self.style = style
-        self.action = action
-        self.url = url
-        self.fallbackUrl = fallbackUrl
-    }
+public protocol TransactionActionButtonViewModel {
+    var text: String { get set }
+    var style: String? { get set }
+    var action: String? { get set }
+    var url: String? { get set }
+    var fallbackUrl: String? { get set }
 }

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButtonViewModel.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionActionButton/TransactionActionButtonViewModel.swift
@@ -8,4 +8,6 @@ public protocol TransactionActionButtonViewModel {
     var action: String? { get set }
     var url: String? { get set }
     var fallbackUrl: String? { get set }
+
+    init(text: String, style: String?, action: String?, url: String?, fallbackUrl: String?)
 }

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
@@ -5,8 +5,12 @@
 import UIKit
 
 public protocol TransactionStepContentViewDelegate: AnyObject {
+
+    //swiftlint:disable:next function_parameter_count
     func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
+        inContentView kind: TransactionStepContentView.Kind,
+        withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -26,6 +30,7 @@ public class TransactionStepContentView: UIView {
 
     // MARK: - Private properties
 
+    private var kind: TransactionStepContentView.Kind
     private var state: TransactionStepViewState
     private var model: TransactionStepContentViewModel
 
@@ -74,12 +79,14 @@ public class TransactionStepContentView: UIView {
     // MARK: - Init
 
     public init(
+        kind: TransactionStepContentView.Kind,
         state: TransactionStepViewState,
         model: TransactionStepContentViewModel,
         withFontForTitle font: UIFont,
         withColorForTitle textColor: UIColor,
         withAutoLayout autoLayout: Bool = false
     ) {
+        self.kind = kind
         self.state = state
         self.model = model
 
@@ -260,6 +267,8 @@ private extension TransactionStepContentView {
 
         delegate?.transactionStepContentViewDidTapActionButton(
             self,
+            inContentView: kind,
+            withButtonTag: tag,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
@@ -9,6 +9,7 @@ public protocol TransactionStepContentViewDelegate: AnyObject {
     //swiftlint:disable:next function_parameter_count
     func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
+        inStep step: Int,
         inContentView kind: TransactionStepContentView.Kind,
         withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
@@ -30,6 +31,7 @@ public class TransactionStepContentView: UIView {
 
     // MARK: - Private properties
 
+    private var step: Int
     private var kind: TransactionStepContentView.Kind
     private var state: TransactionStepViewState
     private var model: TransactionStepContentViewModel
@@ -79,6 +81,7 @@ public class TransactionStepContentView: UIView {
     // MARK: - Init
 
     public init(
+        step: Int,
         kind: TransactionStepContentView.Kind,
         state: TransactionStepViewState,
         model: TransactionStepContentViewModel,
@@ -86,6 +89,7 @@ public class TransactionStepContentView: UIView {
         withColorForTitle textColor: UIColor,
         withAutoLayout autoLayout: Bool = false
     ) {
+        self.step = step
         self.kind = kind
         self.state = state
         self.model = model
@@ -267,6 +271,7 @@ private extension TransactionStepContentView {
 
         delegate?.transactionStepContentViewDidTapActionButton(
             self,
+            inStep: step,
             inContentView: kind,
             withButtonTag: tag,
             withAction: action,

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
@@ -20,12 +20,12 @@ public class TransactionStepContentView: UIView {
 
     public weak var delegate: TransactionStepContentViewDelegate?
 
-    // MARK: - Private properties
-
-    private enum ButtonTag: Int {
-        case native = 1
-        case primary = 2
+    public enum Kind {
+        case main
+        case detail
     }
+
+    // MARK: - Private properties
 
     private var step: Int
     private var state: TransactionStepViewState
@@ -148,8 +148,8 @@ private extension TransactionStepContentView {
         setupBodyView(model.nativeBody, model.body)
 
         // NativeButton should always precede primaryButton
-        setupButton(model.nativeButton, tag: ButtonTag.native)
-        setupButton(model.primaryButton, tag: ButtonTag.primary)
+        setupButton(model.nativeButton, tag: .native)
+        setupButton(model.primaryButton, tag: .primary)
 
         bottomAnchorConstraint?.isActive = true
     }
@@ -166,7 +166,7 @@ private extension TransactionStepContentView {
         bottomAnchorConstraint = bottomAnchor.constraint(equalTo: bodyView.bottomAnchor, constant: .spacingM)
     }
 
-    private func setupButton(_ buttonModel: TransactionActionButtonViewModel?, tag: ButtonTag) {
+    private func setupButton(_ buttonModel: TransactionActionButtonViewModel?, tag: TransactionActionButton.Tag) {
         if let buttonModel = buttonModel {
             let buttonText = buttonModel.text
             let buttonStyle = TransactionActionButton(rawValue: buttonModel.style ?? "").style
@@ -248,15 +248,14 @@ private extension TransactionStepContentView {
 
 private extension TransactionStepContentView {
     @objc func handleButtonTap(_ sender: Button) {
+        guard let tag = TransactionActionButton.Tag(rawValue: sender.tag) else { return }
         var model: TransactionActionButtonViewModel?
 
-        switch sender.tag {
-        case ButtonTag.native.rawValue:
+        switch tag {
+        case .native:
             model = nativeButtonModel
-        case ButtonTag.primary.rawValue:
+        case .primary:
             model = primaryButtonModel
-        default:
-            model = nil
         }
 
         let action = TransactionActionButton.Action(rawValue: model?.action ?? "unknown")

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepContentView/TransactionStepContentView.swift
@@ -7,7 +7,6 @@ import UIKit
 public protocol TransactionStepContentViewDelegate: AnyObject {
     func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
-        inTransactionStep step: Int,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -27,7 +26,6 @@ public class TransactionStepContentView: UIView {
 
     // MARK: - Private properties
 
-    private var step: Int
     private var state: TransactionStepViewState
     private var model: TransactionStepContentViewModel
 
@@ -76,14 +74,12 @@ public class TransactionStepContentView: UIView {
     // MARK: - Init
 
     public init(
-        step: Int,
         state: TransactionStepViewState,
         model: TransactionStepContentViewModel,
         withFontForTitle font: UIFont,
         withColorForTitle textColor: UIColor,
         withAutoLayout autoLayout: Bool = false
     ) {
-        self.step = step
         self.state = state
         self.model = model
 
@@ -264,7 +260,6 @@ private extension TransactionStepContentView {
 
         delegate?.transactionStepContentViewDidTapActionButton(
             self,
-            inTransactionStep: step,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -5,8 +5,11 @@
 import UIKit
 
 public protocol TransactionStepViewDelegate: AnyObject {
+    //swiftlint:disable:next function_parameter_count
     func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
+        inContentView kind: TransactionStepContentView.Kind,
+        withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -89,6 +92,7 @@ public class TransactionStepView: UIView {
 
         if let mainContent = model.main {
             let mainContentView = TransactionStepContentView(
+                kind: .main,
                 state: model.state,
                 model: mainContent,
                 withFontForTitle: .title3Strong,
@@ -102,6 +106,7 @@ public class TransactionStepView: UIView {
 
         if let detailContent = model.detail {
             let detailContentView = TransactionStepContentView(
+                kind: .detail,
                 state: model.state,
                 model: detailContent,
                 withFontForTitle: .captionStrong,
@@ -123,14 +128,19 @@ public class TransactionStepView: UIView {
 }
 
 extension TransactionStepView: TransactionStepContentViewDelegate {
+    //swiftlint:disable:next function_parameter_count
     public func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
+        inContentView kind: TransactionStepContentView.Kind,
+        withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
     ) {
         delegate?.transactionStepViewDidTapActionButton(
             self,
+            inContentView: kind,
+            withButtonTag: tag,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -7,7 +7,6 @@ import UIKit
 public protocol TransactionStepViewDelegate: AnyObject {
     func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
-        inTransactionStep step: Int,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -90,7 +89,6 @@ public class TransactionStepView: UIView {
 
         if let mainContent = model.main {
             let mainContentView = TransactionStepContentView(
-                step: step,
                 state: model.state,
                 model: mainContent,
                 withFontForTitle: .title3Strong,
@@ -104,7 +102,6 @@ public class TransactionStepView: UIView {
 
         if let detailContent = model.detail {
             let detailContentView = TransactionStepContentView(
-                step: step,
                 state: model.state,
                 model: detailContent,
                 withFontForTitle: .captionStrong,
@@ -128,14 +125,12 @@ public class TransactionStepView: UIView {
 extension TransactionStepView: TransactionStepContentViewDelegate {
     public func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
-        inTransactionStep step: Int,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
     ) {
         delegate?.transactionStepViewDidTapActionButton(
             self,
-            inTransactionStep: step,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionStepView/TransactionStepView.swift
@@ -8,6 +8,7 @@ public protocol TransactionStepViewDelegate: AnyObject {
     //swiftlint:disable:next function_parameter_count
     func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
+        inStep step: Int,
         inContentView kind: TransactionStepContentView.Kind,
         withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
@@ -92,6 +93,7 @@ public class TransactionStepView: UIView {
 
         if let mainContent = model.main {
             let mainContentView = TransactionStepContentView(
+                step: step,
                 kind: .main,
                 state: model.state,
                 model: mainContent,
@@ -106,6 +108,7 @@ public class TransactionStepView: UIView {
 
         if let detailContent = model.detail {
             let detailContentView = TransactionStepContentView(
+                step: step,
                 kind: .detail,
                 state: model.state,
                 model: detailContent,
@@ -131,6 +134,7 @@ extension TransactionStepView: TransactionStepContentViewDelegate {
     //swiftlint:disable:next function_parameter_count
     public func transactionStepContentViewDidTapActionButton(
         _ view: TransactionStepContentView,
+        inStep step: Int,
         inContentView kind: TransactionStepContentView.Kind,
         withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
@@ -139,6 +143,7 @@ extension TransactionStepView: TransactionStepContentViewDelegate {
     ) {
         delegate?.transactionStepViewDidTapActionButton(
             self,
+            inStep: step,
             inContentView: kind,
             withButtonTag: tag,
             withAction: action,

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -8,7 +8,6 @@ public protocol TransactionViewDelegate: AnyObject {
     func transactionViewDidBeginRefreshing(_ refreshControl: RefreshControl)
     func transactionViewDidTapActionButton(
         _ view: TransactionView,
-        inTransactionStep step: Int,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -260,14 +259,12 @@ private extension TransactionView {
 extension TransactionView: TransactionStepViewDelegate {
     public func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
-        inTransactionStep step: Int,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
     ) {
         delegate?.transactionViewDidTapActionButton(
             self,
-            inTransactionStep: step,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString)

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -9,6 +9,7 @@ public protocol TransactionViewDelegate: AnyObject {
     //swiftlint:disable:next function_parameter_count
     func transactionViewDidTapActionButton(
         _ view: TransactionView,
+        inStep step: Int,
         inContentView kind: TransactionStepContentView.Kind,
         withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
@@ -263,6 +264,7 @@ extension TransactionView: TransactionStepViewDelegate {
     //swiftlint:disable:next function_parameter_count
     public func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
+        inStep step: Int,
         inContentView kind: TransactionStepContentView.Kind,
         withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
@@ -271,6 +273,7 @@ extension TransactionView: TransactionStepViewDelegate {
     ) {
         delegate?.transactionViewDidTapActionButton(
             self,
+            inStep: step,
             inContentView: kind,
             withButtonTag: tag,
             withAction: action,

--- a/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
+++ b/FinniversKit/Sources/Fullscreen/TransactionView/TransactionView.swift
@@ -6,8 +6,11 @@ import Foundation
 
 public protocol TransactionViewDelegate: AnyObject {
     func transactionViewDidBeginRefreshing(_ refreshControl: RefreshControl)
+    //swiftlint:disable:next function_parameter_count
     func transactionViewDidTapActionButton(
         _ view: TransactionView,
+        inContentView kind: TransactionStepContentView.Kind,
+        withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
@@ -257,14 +260,19 @@ private extension TransactionView {
 // MARK: - TransactionStepViewDelegate
 
 extension TransactionView: TransactionStepViewDelegate {
+    //swiftlint:disable:next function_parameter_count
     public func transactionStepViewDidTapActionButton(
         _ view: TransactionStepView,
+        inContentView kind: TransactionStepContentView.Kind,
+        withButtonTag tag: TransactionActionButton.Tag,
         withAction action: TransactionActionButton.Action,
         withUrl urlString: String?,
         withFallbackUrl fallbackUrlString: String?
     ) {
         delegate?.transactionViewDidTapActionButton(
             self,
+            inContentView: kind,
+            withButtonTag: tag,
             withAction: action,
             withUrl: urlString,
             withFallbackUrl: fallbackUrlString)


### PR DESCRIPTION
# Why?

- Need this in place in order to do tracking

# What?

- Turn `TransactionActionButtonViewModel` into a struct
- Create `TransactionProcessSummaryButtonViewModel ` struct instead of having this in the `AdInsertion` module
- Add `TransactionStepContentView.Kind` to know if button that was tapped is in the `main` or `detail` content view
- Add `TransactionActionButton.Tag,` to know if the button is of type `native` or `primary`
- Add `Kind`, `Tag` and `step` to delegate methods
- Update test models