### PR TITLE
Improvement: make `NotificationCellModel.isRead` writable

### DIFF
--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Models/NotificationsCellModels.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Models/NotificationsCellModels.swift
@@ -5,7 +5,7 @@
 import FinniversKit
 
 public protocol NotificationCellModel {
-    var isRead: Bool { get }
+    var isRead: Bool { get set }
     var content: NotificationCellContent? { get }
 }
 


### PR DESCRIPTION
# Why?

Needed by https://trello.com/c/gpcfOLKH/866-notifications-mark-everything-as-read

This is in strict sense a breaking change. My plan is to make a FinnUI release
right after this change is merged, then make an iOS PR that patches the breaking
change.
