### PR TITLE
Add shadow when scrolling to SaveSearchView

### DIFF
--- a/FinnUI/Sources/Components/SaveSearchView/SaveSearchView.swift
+++ b/FinnUI/Sources/Components/SaveSearchView/SaveSearchView.swift
@@ -12,7 +12,7 @@ public protocol SaveSearchViewDelegate: AnyObject {
     func saveSearchViewDidSelectDeleteSearchButton(_ saveSearchView: SaveSearchView)
 }
 
-public class SaveSearchView: UIView {
+public class SaveSearchView: ShadowScrollView {
 
     // MARK: - Public properties
 
@@ -28,6 +28,7 @@ public class SaveSearchView: UIView {
     private lazy var pushSwitchView = createSwitchView()
     private lazy var emailSwitchView = createSwitchView()
     private var heightConstraint: NSLayoutConstraint!
+    private var usingShadowWhenScrolling: Bool = false
 
     private let switchStyle = SwitchViewStyle(
         titleLabelStyle: .bodyStrong,
@@ -66,6 +67,7 @@ public class SaveSearchView: UIView {
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView(withAutoLayout: true)
         scrollView.contentInsetAdjustmentBehavior = .always
+        scrollView.delegate = self
         return scrollView
     }()
 
@@ -77,6 +79,12 @@ public class SaveSearchView: UIView {
     }()
 
     // MARK: - Initializers
+
+    public init(usingShadowWhenScrolling: Bool = false) {
+        super.init(frame: .zero)
+        self.usingShadowWhenScrolling = usingShadowWhenScrolling
+        setup()
+    }
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -130,9 +138,15 @@ public class SaveSearchView: UIView {
     private func setup() {
         backgroundColor = .bgPrimary
 
-        scrollView.addSubview(contentView)
-        addSubview(scrollView)
+        if usingShadowWhenScrolling {
+            insertSubview(scrollView, belowSubview: topShadowView)
+            topShadowView.bottomAnchor.constraint(equalTo: topAnchor).isActive = true
+        } else {
+            addSubview(scrollView)
+        }
         scrollView.fillInSuperview()
+
+        scrollView.addSubview(contentView)
         contentView.fillInSuperview()
 
         contentView.addSubview(iconImageView)

--- a/FinniversKit/Sources/Recycling/ListViews/Basic/ShadowScrollView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Basic/ShadowScrollView.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 open class ShadowScrollView: UIView, UIScrollViewDelegate {
-    private(set) lazy var topShadowView = ShadowView()
+    private(set) public lazy var topShadowView = ShadowView()
 
     override public init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
# Why?

Since other views presented in the bottom sheet has a shadow below the navigation bar when scrolling, we want to be consistent and do the same for `SaveSearchView`.

# What?

- Add scroll view below `topShadowView` if `usingShadowWhenScrolling`
- Make `SaveSearchView` into a `ShadowScrollView`, which handles the shadow for us

# Show me

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/17450858/86895727-31a33c00-c105-11ea-8697-9aaddba88386.gif) | ![after](https://user-images.githubusercontent.com/17450858/86895714-2cde8800-c105-11ea-8bd0-cd09a6eaeae8.gif) |
