### PR TITLE
MotorTransaction: Add support for FOCUS style

### DIFF
--- a/Demo/Demo/Fullscreen/MotorTransactionView/DemoViewModels/SalesProcess/BothPartiesConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionView/DemoViewModels/SalesProcess/BothPartiesConfirmedHandoverDemoViewModel.swift
@@ -56,7 +56,7 @@ extension MotorTransactionDefaultData {
 
             MotorTransactionStepModel(
                 state: .active,
-                style: .default,
+                style: .focus,
                 main: MotorTransactionStepContentModel(
                     title: "Gratulerer med salget!",
                     body: NSAttributedString(string: "Du kan finne igjen bilen i Mine kjøretøy under «<a href=\"/minekjoretoy\">Eide før</a>»."),

--- a/Demo/Demo/Fullscreen/MotorTransactionView/DemoViewModels/SalesProcess/BothPartiesConfirmedHandoverDemoViewModel.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionView/DemoViewModels/SalesProcess/BothPartiesConfirmedHandoverDemoViewModel.swift
@@ -55,7 +55,7 @@ extension MotorTransactionDefaultData {
                     body: NSAttributedString(string: "Dere har bekreftet at overleveringen har skjedd."))),
 
             MotorTransactionStepModel(
-                state: .active,
+                state: .completed,
                 style: .focus,
                 main: MotorTransactionStepContentModel(
                     title: "Gratulerer med salget!",

--- a/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
@@ -166,10 +166,10 @@ extension MotorTransactionDemoView: MotorTransactionViewDataSource {
     }
 
     func motorTransactionViewCurrentStep(_ view: MotorTransactionView) -> Int {
-		let hasCompletedAllSteps = model.steps.allSatisfy({ $0.state == .completed })
-		let activeStep = model.steps.firstIndex(where: { $0.state == .active }) ?? 0
-		let lastStep = model.steps.count - 1
-		return hasCompletedAllSteps ? lastStep : activeStep
+        let hasCompletedAllSteps = model.steps.allSatisfy({ $0.state == .completed })
+        let activeStep = model.steps.firstIndex(where: { $0.state == .active }) ?? 0
+        let lastStep = model.steps.count - 1
+        return hasCompletedAllSteps ? lastStep : activeStep
     }
 
     func motorTransactionViewModelForIndex(_ view: MotorTransactionView, forStep step: Int) -> MotorTransactionStepViewModel {

--- a/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
@@ -166,7 +166,10 @@ extension MotorTransactionDemoView: MotorTransactionViewDataSource {
     }
 
     func motorTransactionViewCurrentStep(_ view: MotorTransactionView) -> Int {
-        return model.steps.firstIndex(where: { $0.state == .active }) ?? 0
+		let hasCompletedAllSteps = model.steps.allSatisfy({ $0.state == .completed })
+		let activeStep = model.steps.firstIndex(where: { $0.state == .active }) ?? 0
+		let lastStep = model.steps.count - 1
+		return hasCompletedAllSteps ? lastStep : activeStep
     }
 
     func motorTransactionViewModelForIndex(_ view: MotorTransactionView, forStep step: Int) -> MotorTransactionStepViewModel {

--- a/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionView/MotorTransactionDemoView.swift
@@ -168,7 +168,7 @@ extension MotorTransactionDemoView: MotorTransactionViewDataSource {
     func motorTransactionViewCurrentStep(_ view: MotorTransactionView) -> Int {
         let hasCompletedAllSteps = model.steps.allSatisfy({ $0.state == .completed })
         let activeStep = model.steps.firstIndex(where: { $0.state == .active }) ?? 0
-        let lastStep = model.steps.count - 1
+        let lastStep = model.steps.count
         return hasCompletedAllSteps ? lastStep : activeStep
     }
 

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
@@ -83,14 +83,14 @@ public class MotorTransactionStepContentView: UIView {
     // MARK: - Init
 
     public init(
-        step: Int,
+		step: Int,
 		currentStep: Int,
-        kind: MotorTransactionStepContentView.Kind,
-        state: MotorTransactionStepViewState,
-        model: MotorTransactionStepContentViewModel,
-        withFontForTitle font: UIFont,
-        withColorForTitle textColor: UIColor,
-        withAutoLayout autoLayout: Bool = false
+		kind: MotorTransactionStepContentView.Kind,
+		state: MotorTransactionStepViewState,
+		model: MotorTransactionStepContentViewModel,
+		withFontForTitle font: UIFont,
+		withColorForTitle textColor: UIColor,
+		withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
 		self.currentStep = currentStep
@@ -159,7 +159,6 @@ private extension MotorTransactionStepContentView {
             verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
 				equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
 		case .completed:
-			// If the last step is completed it should have the .active constraints
 			if step == currentStep {
 				verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
 					equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
@@ -45,6 +45,7 @@ public class MotorTransactionStepContentView: UIView {
     private var verticalStackViewTopAnchor: NSLayoutConstraint?
 
     private var bottomAnchorConstraint: NSLayoutConstraint?
+	private lazy var isLastStep = step == currentStep
 
     private lazy var verticalStackView: UIStackView = {
         let view = UIStackView(withAutoLayout: true)
@@ -122,30 +123,7 @@ private extension MotorTransactionStepContentView {
         backgroundColor = .clear
 
         addSubview(verticalStackView)
-
-        switch state {
-        case .notStarted, .completed:
-            verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
-            verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
-            verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
-
-            NSLayoutConstraint.activate([
-                verticalStackViewLeadingAnchor!,
-                verticalStackViewTrailingAnchor!,
-                verticalStackViewTopAnchor!,
-            ])
-
-        case .active:
-            verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
-            verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
-            verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
-
-            NSLayoutConstraint.activate([
-                verticalStackViewLeadingAnchor!,
-                verticalStackViewTrailingAnchor!,
-                verticalStackViewTopAnchor!,
-            ])
-        }
+		setupStackViewConstraints()
 
         if let titleText = model.title {
             titleView.text = titleText
@@ -163,6 +141,48 @@ private extension MotorTransactionStepContentView {
 
         bottomAnchorConstraint?.isActive = true
     }
+
+	private func setupStackViewConstraints() {
+		switch state {
+		case .notStarted:
+            verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
+            verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+            verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.topAnchor)
+		case .active:
+            verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
+            verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+            verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+				equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
+		case .completed:
+			// If the last step is completed it should have the .active constraints
+			if step == currentStep {
+				verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
+				verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+				verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
+			} else {
+				verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
+				verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+				verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+					equalTo: safeAreaLayoutGuide.topAnchor)
+			}
+        }
+
+		NSLayoutConstraint.activate([
+			verticalStackViewLeadingAnchor!,
+			verticalStackViewTrailingAnchor!,
+			verticalStackViewTopAnchor!,
+		])
+	}
 
     private func setupBodyView(_ nativeBody: NSAttributedString?, _ body: NSAttributedString?) {
         let text = nativeBody != nil ? nativeBody : body

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
@@ -32,7 +32,7 @@ public class MotorTransactionStepContentView: UIView {
     // MARK: - Private properties
 
     private var step: Int
-	private var currentStep: Int
+    private var currentStep: Int
     private var kind: MotorTransactionStepContentView.Kind
     private var state: MotorTransactionStepViewState
     private var model: MotorTransactionStepContentViewModel
@@ -45,7 +45,6 @@ public class MotorTransactionStepContentView: UIView {
     private var verticalStackViewTopAnchor: NSLayoutConstraint?
 
     private var bottomAnchorConstraint: NSLayoutConstraint?
-	private lazy var isLastStep = step == currentStep
 
     private lazy var verticalStackView: UIStackView = {
         let view = UIStackView(withAutoLayout: true)
@@ -83,17 +82,17 @@ public class MotorTransactionStepContentView: UIView {
     // MARK: - Init
 
     public init(
-		step: Int,
-		currentStep: Int,
-		kind: MotorTransactionStepContentView.Kind,
-		state: MotorTransactionStepViewState,
-		model: MotorTransactionStepContentViewModel,
-		withFontForTitle font: UIFont,
-		withColorForTitle textColor: UIColor,
-		withAutoLayout autoLayout: Bool = false
+        step: Int,
+        currentStep: Int,
+        kind: MotorTransactionStepContentView.Kind,
+        state: MotorTransactionStepViewState,
+        model: MotorTransactionStepContentViewModel,
+        withFontForTitle font: UIFont,
+        withColorForTitle textColor: UIColor,
+        withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
-		self.currentStep = currentStep
+        self.currentStep = currentStep
         self.kind = kind
         self.state = state
         self.model = model
@@ -123,7 +122,7 @@ private extension MotorTransactionStepContentView {
         backgroundColor = .clear
 
         addSubview(verticalStackView)
-		setupStackViewConstraints()
+        setupStackViewConstraints()
 
         if let titleText = model.title {
             titleView.text = titleText
@@ -142,45 +141,45 @@ private extension MotorTransactionStepContentView {
         bottomAnchorConstraint?.isActive = true
     }
 
-	private func setupStackViewConstraints() {
-		switch state {
-		case .notStarted:
+    private func setupStackViewConstraints() {
+        switch state {
+        case .notStarted:
             verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
+                equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
             verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+                equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
             verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.topAnchor)
-		case .active:
+                equalTo: safeAreaLayoutGuide.topAnchor)
+        case .active:
             verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
+                equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
             verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+                equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
             verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
-				equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
-		case .completed:
-			if step == currentStep {
-				verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
-				verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
-				verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
-			} else {
-				verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
-				verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
-				verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
-					equalTo: safeAreaLayoutGuide.topAnchor)
-			}
+                equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
+        case .completed:
+            if step == currentStep {
+                verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingM)
+                verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+                verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.topAnchor, constant: .spacingM)
+            } else {
+                verticalStackViewLeadingAnchor = verticalStackView.leadingAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.leadingAnchor, constant: .spacingXS)
+                verticalStackViewTrailingAnchor = verticalStackView.trailingAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -.spacingS)
+                verticalStackViewTopAnchor = verticalStackView.topAnchor.constraint(
+                    equalTo: safeAreaLayoutGuide.topAnchor)
+            }
         }
 
-		NSLayoutConstraint.activate([
-			verticalStackViewLeadingAnchor!,
-			verticalStackViewTrailingAnchor!,
-			verticalStackViewTopAnchor!,
-		])
+        NSLayoutConstraint.activate([
+            verticalStackViewLeadingAnchor!,
+            verticalStackViewTrailingAnchor!,
+            verticalStackViewTopAnchor!,
+        ])
 	}
 
     private func setupBodyView(_ nativeBody: NSAttributedString?, _ body: NSAttributedString?) {

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
@@ -32,6 +32,7 @@ public class MotorTransactionStepContentView: UIView {
     // MARK: - Private properties
 
     private var step: Int
+	private var currentStep: Int
     private var kind: MotorTransactionStepContentView.Kind
     private var state: MotorTransactionStepViewState
     private var model: MotorTransactionStepContentViewModel
@@ -82,6 +83,7 @@ public class MotorTransactionStepContentView: UIView {
 
     public init(
         step: Int,
+		currentStep: Int,
         kind: MotorTransactionStepContentView.Kind,
         state: MotorTransactionStepViewState,
         model: MotorTransactionStepContentViewModel,
@@ -90,6 +92,7 @@ public class MotorTransactionStepContentView: UIView {
         withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
+		self.currentStep = currentStep
         self.kind = kind
         self.state = state
         self.model = model

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView+CustomStyle.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView+CustomStyle.swift
@@ -9,6 +9,8 @@ extension MotorTransactionStepView {
     public enum CustomStyle: String {
         case warning = "WARNING"
         case error = "ERROR"
+        case focus = "FOCUS"
+        /// will use the styling that is defined localy
         case `default` = "DEFAULT"
 
         public init(rawValue: String) {
@@ -17,18 +19,23 @@ extension MotorTransactionStepView {
                 self = .warning
             case "ERROR":
                 self = .error
+            case "FOCUS":
+                self = .focus
             default:
                 self = .default
             }
         }
 
-        /// Use custom style provided by the backend or fallback to the style defined locally
+        /// Use the custom style provided by the backend
+        /// if the style does not exist, it will fallback  to the default styling defined locally
         public func backgroundColor(style: MotorTransactionStepView.Style) -> UIColor {
             switch self {
             case .error:
                 return .bgCritical
             case .warning:
                 return .bgAlert
+            case .focus:
+                return .bgSecondary
             case .default:
                 return style.backgroundColor
             }

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView+CustomStyle.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView+CustomStyle.swift
@@ -10,7 +10,7 @@ extension MotorTransactionStepView {
         case warning = "WARNING"
         case error = "ERROR"
         case focus = "FOCUS"
-        /// will use the styling that is defined localy
+        /// Fallback to use styling that is defined in the MotorTransactionStepView.Style enum
         case `default` = "DEFAULT"
 
         public init(rawValue: String) {
@@ -26,8 +26,6 @@ extension MotorTransactionStepView {
             }
         }
 
-        /// Use the custom style provided by the backend
-        /// if the style does not exist, it will fallback  to the default styling defined locally
         public func backgroundColor(style: MotorTransactionStepView.Style) -> UIColor {
             switch self {
             case .error:

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
@@ -55,7 +55,7 @@ public class MotorTransactionStepView: UIView {
     // MARK: - Private properties
 
     private var step: Int
-	private var currentStep: Int
+    private var currentStep: Int
     private var model: MotorTransactionStepViewModel
     private var style: MotorTransactionStepView.Style
     private var customStyle: MotorTransactionStepView.CustomStyle? // Styling provided by the backend
@@ -72,14 +72,14 @@ public class MotorTransactionStepView: UIView {
     // MARK: - Init
 
     public init(
-		step: Int,
-		currentStep: Int,
-		model: MotorTransactionStepViewModel,
-		withCustomStyle customStyle: MotorTransactionStepView.CustomStyle? = nil,
-		withAutoLayout autoLayout: Bool = false
+        step: Int,
+        currentStep: Int,
+        model: MotorTransactionStepViewModel,
+        withCustomStyle customStyle: MotorTransactionStepView.CustomStyle? = nil,
+        withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
-		self.currentStep = currentStep
+        self.currentStep = currentStep
         self.model = model
         self.style = model.state.style
         self.customStyle = customStyle
@@ -97,7 +97,7 @@ public class MotorTransactionStepView: UIView {
         if let mainContent = model.main {
             let mainContentView = MotorTransactionStepContentView(
                 step: step,
-				currentStep: currentStep,
+                currentStep: currentStep,
                 kind: .main,
                 state: model.state,
                 model: mainContent,
@@ -113,7 +113,7 @@ public class MotorTransactionStepView: UIView {
         if let detailContent = model.detail {
             let detailContentView = MotorTransactionStepContentView(
                 step: step,
-				currentStep: currentStep,
+                currentStep: currentStep,
                 kind: .detail,
                 state: model.state,
                 model: detailContent,

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
@@ -72,11 +72,11 @@ public class MotorTransactionStepView: UIView {
     // MARK: - Init
 
     public init(
-        step: Int,
+		step: Int,
 		currentStep: Int,
-        model: MotorTransactionStepViewModel,
-        withCustomStyle customStyle: MotorTransactionStepView.CustomStyle? = nil,
-        withAutoLayout autoLayout: Bool = false
+		model: MotorTransactionStepViewModel,
+		withCustomStyle customStyle: MotorTransactionStepView.CustomStyle? = nil,
+		withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
 		self.currentStep = currentStep

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepView.swift
@@ -55,6 +55,7 @@ public class MotorTransactionStepView: UIView {
     // MARK: - Private properties
 
     private var step: Int
+	private var currentStep: Int
     private var model: MotorTransactionStepViewModel
     private var style: MotorTransactionStepView.Style
     private var customStyle: MotorTransactionStepView.CustomStyle? // Styling provided by the backend
@@ -72,11 +73,13 @@ public class MotorTransactionStepView: UIView {
 
     public init(
         step: Int,
+		currentStep: Int,
         model: MotorTransactionStepViewModel,
         withCustomStyle customStyle: MotorTransactionStepView.CustomStyle? = nil,
         withAutoLayout autoLayout: Bool = false
     ) {
         self.step = step
+		self.currentStep = currentStep
         self.model = model
         self.style = model.state.style
         self.customStyle = customStyle
@@ -94,6 +97,7 @@ public class MotorTransactionStepView: UIView {
         if let mainContent = model.main {
             let mainContentView = MotorTransactionStepContentView(
                 step: step,
+				currentStep: currentStep,
                 kind: .main,
                 state: model.state,
                 model: mainContent,
@@ -109,6 +113,7 @@ public class MotorTransactionStepView: UIView {
         if let detailContent = model.detail {
             let detailContentView = MotorTransactionStepContentView(
                 step: step,
+				currentStep: currentStep,
                 kind: .detail,
                 state: model.state,
                 model: detailContent,

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionView.swift
@@ -180,8 +180,9 @@ private extension MotorTransactionView {
     }
 
     func setupTransactionStepView(_ step: Int, _ model: MotorTransactionStepViewModel) {
-        let transactionStepView = MotorTransactionStepView(
+		let transactionStepView = MotorTransactionStepView(
             step: step,
+			currentStep: currentStep,
             model: model,
             withCustomStyle: model.style,
             withAutoLayout: true

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionView.swift
@@ -180,9 +180,9 @@ private extension MotorTransactionView {
     }
 
     func setupTransactionStepView(_ step: Int, _ model: MotorTransactionStepViewModel) {
-		let transactionStepView = MotorTransactionStepView(
+        let transactionStepView = MotorTransactionStepView(
             step: step,
-			currentStep: currentStep,
+            currentStep: currentStep,
             model: model,
             withCustomStyle: model.style,
             withAutoLayout: true


### PR DESCRIPTION
# Why?

- The final step in the process (when handover of the vehicle is confirmed by both parties) will use the `FOCUS` styling on the last step.
- I added this logic in the client for the first iteration. Since we get it it from the backend now, it would be nice to have support for it, as we can apply the same styling for arbitrary steps if needed.

# What?

- Add the `FOCUS` case to the `CustomStyle` enum
- Split up the constraints for each state
- Add `currentStep` to the init signature where necessary.