### PR TITLE
Add flag to hide grouping options

### DIFF
--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationCenterView.swift
@@ -54,6 +54,12 @@ final public class NotificationCenterView: UIView {
         }
     }
 
+    public var isSavedSearchGroupingEnabled: Bool = true {
+        didSet {
+            savedSearchesHeaderView.groupSelectionView.alpha = isSavedSearchGroupingEnabled ? 1 : 0
+        }
+    }
+
     // MARK: - Private properties
 
     private lazy var segmentedControl: UISegmentedControl = {


### PR DESCRIPTION
This is because some backend issues makes us to have some unleash toggle
in the app to release the grouping for notification center