### PR TITLE
Add centerTitle() to BuyerPickerTextHeader

### DIFF
--- a/Demo/Demo/Fullscreen/BuyerPicker/BuyerPickerDemoView.swift
+++ b/Demo/Demo/Fullscreen/BuyerPicker/BuyerPickerDemoView.swift
@@ -58,4 +58,8 @@ extension BuyerPickerDemoView: BuyerPickerViewDelegate {
     }
 
     public func buyerPickerView(_ buyerPickerView: BuyerPickerView, cancelLoadingImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat) {}
+
+    public func buyerPickerViewCenterTitleInHeaderView(_ buyerPickerView: BuyerPickerView, viewForHeaderInSection section: Int) -> Bool {
+        return false
+    }
 }

--- a/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
+++ b/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
@@ -8,6 +8,7 @@ public protocol BuyerPickerViewDelegate: AnyObject {
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, cancelLoadingImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat)
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, didSelect profile: BuyerPickerProfileModel, forRowAt indexPath: IndexPath)
+    func buyerPickerViewCenterTitleInHeaderView(_ buyerPickerView: BuyerPickerView, viewForHeaderInSection section: Int) -> Bool
 }
 
 public class BuyerPickerView: UIView {
@@ -98,6 +99,9 @@ extension BuyerPickerView: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeue(BuyerPickerTextHeader.self)
         header.title.text = model?.title
+        if delegate?.buyerPickerViewCenterTitleInHeaderView(self, viewForHeaderInSection: section) == true {
+            header.centerTitle()
+        }
         return header
     }
 

--- a/FinniversKit/Sources/Fullscreen/Review/Cell/BuyerPickerTextHeader.swift
+++ b/FinniversKit/Sources/Fullscreen/Review/Cell/BuyerPickerTextHeader.swift
@@ -26,9 +26,14 @@ class BuyerPickerTextHeader: UITableViewHeaderFooterView {
         title.fillInSuperview(insets: inset, isActive: true)
     }
 
+    public func centerTitle() {
+        title.textAlignment = .center
+    }
+
     public override func prepareForReuse() {
         super.prepareForReuse()
         title.text = ""
+        title.textAlignment = .natural
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
# Why?

- Would like to center the title in my current use case

# What?

- Add `centerTitle()` which sets the `titleLabel` text alignment to `.center` and back to `.normal` on `prepareForReuse()`
