### PR TITLE
Propagate forRowAt indexPath to delegate

### DIFF
--- a/Demo/Demo/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyDemoView.swift
+++ b/Demo/Demo/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyDemoView.swift
@@ -31,7 +31,8 @@ public class MotorTransactionInviteCounterpartyDemoView: UIView {
 extension MotorTransactionInviteCounterpartyDemoView: MotorTransactionInviteCounterpartyViewDelegate {
     public func motorTransactionInviteCounterpartyView(
         _ motorTransactionInviteCounterpartyView: MotorTransactionInviteCounterpartyView,
-        didSelect profile: MotorTransactionInviteCounterpartyProfileViewModel
+        didSelect profile: MotorTransactionInviteCounterpartyProfileViewModel,
+        forRowAt indexPath: IndexPath
     ) {
         LoadingView.show(afterDelay: 0)
 

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyView.swift
@@ -5,7 +5,8 @@
 public protocol MotorTransactionInviteCounterpartyViewDelegate: AnyObject {
     func motorTransactionInviteCounterpartyView(
         _ motorTransactionInviteCounterpartyView: MotorTransactionInviteCounterpartyView,
-        didSelect profile: MotorTransactionInviteCounterpartyProfileViewModel
+        didSelect profile: MotorTransactionInviteCounterpartyProfileViewModel,
+        forRowAt indexPath: IndexPath
     )
 
     func motorTransactionInviteCounterpartyView(
@@ -85,7 +86,7 @@ extension MotorTransactionInviteCounterpartyView: BuyerPickerViewDelegate {
         forRowAt indexPath: IndexPath
     ) {
         let counterPartyProfile = MotorTransactionInviteCounterpartyProfileViewModel(name: profile.name, image: profile.image)
-        delegate?.motorTransactionInviteCounterpartyView(self, didSelect: counterPartyProfile)
+        delegate?.motorTransactionInviteCounterpartyView(self, didSelect: counterPartyProfile, forRowAt: indexPath)
     }
 
     public func buyerPickerView(

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionInviteCounterpartyView/MotorTransactionInviteCounterpartyView.swift
@@ -117,7 +117,10 @@ extension MotorTransactionInviteCounterpartyView: BuyerPickerViewDelegate {
         )
     }
 
-    public func buyerPickerViewCenterTitleInHeaderView(_ buyerPickerView: BuyerPickerView, viewForHeaderInSection section: Int) -> Bool {
+    public func buyerPickerViewCenterTitleInHeaderView(
+        _ buyerPickerView: BuyerPickerView,
+        viewForHeaderInSection section: Int
+    ) -> Bool {
         return true
     }
 }


### PR DESCRIPTION
# Why?

-  Forgot to expose this in my previous PR

# What?

- Add the parameter `forRowAt indexPath: IndexPath` to the method 

```
public func motorTransactionInviteCounterpartyView(
    _ motorTransactionInviteCounterpartyView: MotorTransactionInviteCounterpartyView, 
    didSelect profile: MotorTransactionInviteCounterpartyProfileViewModel
)
```