### PR TITLE
SearchListEmptyView: Add new state for save search disabled

### DIFF
--- a/FinniversKit/Sources/Components/SearchListEmptyView/SearchListEmptyView.swift
+++ b/FinniversKit/Sources/Components/SearchListEmptyView/SearchListEmptyView.swift
@@ -18,6 +18,7 @@ public protocol SearchListEmptyViewDelegate: AnyObject {
         case initial
         case searchSaved
         case searchSavedNoPush
+        case saveSearchDisabled
     }
 
     public weak var delegate: SearchListEmptyViewDelegate?

--- a/FinniversKit/Sources/Components/SearchListEmptyView/SearchListEmptyViewModel.swift
+++ b/FinniversKit/Sources/Components/SearchListEmptyView/SearchListEmptyViewModel.swift
@@ -7,10 +7,10 @@ import Foundation
 public struct SearchListEmptyViewModel {
 
     let title: String
-    let body: String
+    let body: String?
     let buttonTitle: String?
 
-    public init(title: String, body: String, buttonTitle: String? = nil) {
+    public init(title: String, body: String?, buttonTitle: String? = nil) {
         self.title = title
         self.body = body
         self.buttonTitle = buttonTitle


### PR DESCRIPTION
# Why?

`SearchListEmptyView` was originally made to help users save a search when there's no hits. We recently did a change in the app where you're no longer allowed to save search for a user's ads. Instead of showing a blank page in these cases, I am adding a new state to this view, called `saveSearchDisabled`, to be used when there's no hits, but you're not allowed to save the search. 

Also made body text optional, since I am only providing a header title for this state.