### PR TITLE
Add emailRegEx property to TexField

### DIFF
--- a/FinniversKit/Sources/Components/TextField/TextField.swift
+++ b/FinniversKit/Sources/Components/TextField/TextField.swift
@@ -137,6 +137,7 @@ public class TextField: UIView {
 
     public let inputType: InputType
     public var phoneNumberRegEx = "^(?:\\s*\\d){8,11}$"
+    public var emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
 
     public var placeholderText: String = "" {
         didSet {
@@ -318,7 +319,7 @@ public class TextField: UIView {
     }
 
     private func isValidEmail(_ emailAdress: String) -> Bool {
-        return evaluate("[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}", with: emailAdress)
+        return evaluate(emailRegEx, with: emailAdress)
     }
 
     private func isValidPhoneNumber(_ phoneNumber: String) -> Bool {

--- a/FinniversKit/Sources/Components/TextField/TextField.swift
+++ b/FinniversKit/Sources/Components/TextField/TextField.swift
@@ -136,8 +136,9 @@ public class TextField: UIView {
     }()
 
     public let inputType: InputType
+    public let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+
     public var phoneNumberRegEx = "^(?:\\s*\\d){8,11}$"
-    public var emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
 
     public var placeholderText: String = "" {
         didSet {


### PR DESCRIPTION
# Why?

- Would like to reuse this regular expression pattern in conjunction with the `TextField` class

# What?

- Add `var emailRegEx` to the public interface
- Assign the hardcoded regular expression for email validation to the `emailRegEx` property