### PR TITLE
Fix: make grouping alternatives optional for Notification Center

### DIFF
--- a/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationGroupOptionsView.swift
+++ b/FinnUI/Sources/Fullscreen/NotificationCenter/Views/NotificationGroupOptionsView.swift
@@ -19,11 +19,11 @@ public enum NotificationCenterSearchGroupOption: String, CaseIterable {
 }
 
 public struct NotificationGroupOptionsViewModel {
-    let bySearchTitle: String
-    let byDayTitle: String
-    let flatTitle: String
+    let bySearchTitle: String?
+    let byDayTitle: String?
+    let flatTitle: String?
 
-    public init(bySearchTitle: String, byDayTitle: String, flatTitle: String) {
+    public init(bySearchTitle: String?, byDayTitle: String?, flatTitle: String?) {
         self.bySearchTitle = bySearchTitle
         self.byDayTitle = byDayTitle
         self.flatTitle = flatTitle
@@ -53,12 +53,14 @@ public class NotificationGroupOptionsView: UIView {
     }
 
     private lazy var optionsView: SelectionView = {
+        var sortOptions: [SortOption] = [
+            viewModel.byDayTitle.map { SortOption(groupOption: .byDay, title: $0) },
+            viewModel.bySearchTitle.map { SortOption(groupOption: .bySearch, title: $0) },
+            viewModel.flatTitle.map { SortOption(groupOption: .flat, title: $0) },
+        ].compactMap({ $0 })
+
         let view = SelectionView(
-            options: [
-                SortOption(groupOption: .byDay, title: viewModel.byDayTitle),
-                SortOption(groupOption: .bySearch, title: viewModel.bySearchTitle),
-                SortOption(groupOption: .flat, title: viewModel.flatTitle),
-            ],
+            options: sortOptions,
             selectedOptionIdentifier: selectedOption.rawValue
         )
         view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# Why?

We had some issues in the backend related to "group by search", then
solfrid wanted a feature flag for a single grouping option.

For that reason, if the `NotificationGroupOptionsViewModel` doesn't
include a given title, then the grouping option won't be used when
presenting the available grouping options.

I use a more "functional" approach to implement this with `Optional.map`
and `[SortOption].compactMap` to deal with the optionals. Hopefully it's
understandable enough.

# What?

- `NotificationGroupOptionsViewModel` model properties are now optional.

This is a patch-like change for FinnUI