### PR TITLE
Make MessageUserRequiredDelegate public

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
@@ -9,7 +9,7 @@ public protocol MessageUserRequiredSheetDelegate: AnyObject {
 public class MessageUserRequiredSheet: BottomSheet {
     private let sheetHeight: CGFloat = 280
 
-    public weak var messageUserRequiredViewDelegate: MessageUserRequiredViewDelegate?
+    public weak var messageUserRequiredViewDelegate: MessageUserRequiredSheetDelegate?
     weak var viewController: MessageUserRequiredSheetViewController?
 
     // MARK: - Initalization

--- a/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
@@ -9,7 +9,7 @@ public protocol MessageUserRequiredSheetDelegate: AnyObject {
 public class MessageUserRequiredSheet: BottomSheet {
     private let sheetHeight: CGFloat = 280
 
-    weak var messageUserRequiredViewDelegate: MessageUserRequiredViewDelegate?
+    public weak var messageUserRequiredViewDelegate: MessageUserRequiredViewDelegate?
     weak var viewController: MessageUserRequiredSheetViewController?
 
     // MARK: - Initalization


### PR DESCRIPTION
# Why?

- In order to conform to the delegate and handle button tap events.

# What?

- Title says it all