### PR TITLE
Fix: SwiftUI color initializers

### DIFF
--- a/FinniversKit/Sources/Base Components/ButtonStyle.swift
+++ b/FinniversKit/Sources/Base Components/ButtonStyle.swift
@@ -70,7 +70,7 @@ public struct DefaultStyle: ButtonStyle {
         .padding(.vertical, .spacingS)
         .padding(.horizontal, .spacingM)
         .background(
-            configuration.isPressed ? Color(.defaultButtonHighlightedBodyColor) : Color.bgPrimary
+            configuration.isPressed ? Color(UIColor.defaultButtonHighlightedBodyColor) : Color.bgPrimary
         )
         .roundedBorder(
             radius: .spacingS,

--- a/FinniversKit/Sources/DNA/Color/Color+SwiftUI.swift
+++ b/FinniversKit/Sources/DNA/Color/Color+SwiftUI.swift
@@ -10,44 +10,44 @@ import SwiftUI
 extension Color {
     // MARK: - Background
 
-    public static var bgPrimary: Color     { Color(.bgPrimary) }
-    public static var bgSecondary: Color   { Color(.bgSecondary) }
-    public static var bgTertiary: Color    { Color(.bgTertiary) }
-    public static var bgBottomSheet: Color { Color(.bgBottomSheet) }
-    public static var bgAlert: Color       { Color(.bgAlert) }
-    public static var bgSuccess: Color     { Color(.bgSuccess) }
-    public static var bgCritical: Color    { Color(.bgCritical) }
+    public static var bgPrimary: Color     { Color(UIColor.bgPrimary) }
+    public static var bgSecondary: Color   { Color(UIColor.bgSecondary) }
+    public static var bgTertiary: Color    { Color(UIColor.bgTertiary) }
+    public static var bgBottomSheet: Color { Color(UIColor.bgBottomSheet) }
+    public static var bgAlert: Color       { Color(UIColor.bgAlert) }
+    public static var bgSuccess: Color     { Color(UIColor.bgSuccess) }
+    public static var bgCritical: Color    { Color(UIColor.bgCritical) }
 
     // MARK: - Button
 
-    public static var btnPrimary: Color  { Color(.btnPrimary) }
-    public static var btnDisabled: Color { Color(.btnDisabled) }
-    public static var btnCritical: Color { Color(.btnCritical) }
-    public static var btnAction: Color   { Color(.btnAction) }
+    public static var btnPrimary: Color  { Color(UIColor.btnPrimary) }
+    public static var btnDisabled: Color { Color(UIColor.btnDisabled) }
+    public static var btnCritical: Color { Color(UIColor.btnCritical) }
+    public static var btnAction: Color   { Color(UIColor.btnAction) }
 
     // MARK: - Text
 
-    public static var textPrimary: Color     { Color(.textPrimary) }
-    public static var textSecondary: Color   { Color(.textSecondary) }
-    public static var textTertiary: Color    { Color(.textTertiary) }
-    public static var textAction: Color      { Color(.textAction) }
-    public static var textDisabled: Color    { Color(.textDisabled) }
-    public static var textCritical: Color    { Color(.textCritical) }
-    public static var textToast: Color       { Color(.textToast) }
-    public static var textCTADisabled: Color { Color(.textCTADisabled) }
+    public static var textPrimary: Color     { Color(UIColor.textPrimary) }
+    public static var textSecondary: Color   { Color(UIColor.textSecondary) }
+    public static var textTertiary: Color    { Color(UIColor.textTertiary) }
+    public static var textAction: Color      { Color(UIColor.textAction) }
+    public static var textDisabled: Color    { Color(UIColor.textDisabled) }
+    public static var textCritical: Color    { Color(UIColor.textCritical) }
+    public static var textToast: Color       { Color(UIColor.textToast) }
+    public static var textCTADisabled: Color { Color(UIColor.textCTADisabled) }
 
     // MARK: - Icon
 
-    public static var iconPrimary: Color   { Color(.iconPrimary) }
-    public static var iconSecondary: Color { Color(.iconSecondary) }
-    public static var iconTertiary: Color  { Color(.iconTertiary) }
+    public static var iconPrimary: Color   { Color(UIColor.iconPrimary) }
+    public static var iconSecondary: Color { Color(UIColor.iconSecondary) }
+    public static var iconTertiary: Color  { Color(UIColor.iconTertiary) }
 
     // MARK: - Others
 
-    public static var accentSecondaryBlue: Color { Color(.accentSecondaryBlue) }
-    public static var accentPea: Color           { Color(.accentPea) }
-    public static var accentToothpaste: Color    { Color(.accentToothpaste) }
-    public static var tableViewSeparator: Color  { Color(.tableViewSeparator) }
-    public static var imageBorder: Color         { Color(.imageBorder) }
-    public static var decorationSubtle: Color    { Color(.decorationSubtle) }
+    public static var accentSecondaryBlue: Color { Color(UIColor.accentSecondaryBlue) }
+    public static var accentPea: Color           { Color(UIColor.accentPea) }
+    public static var accentToothpaste: Color    { Color(UIColor.accentToothpaste) }
+    public static var tableViewSeparator: Color  { Color(UIColor.tableViewSeparator) }
+    public static var imageBorder: Color         { Color(UIColor.imageBorder) }
+    public static var decorationSubtle: Color    { Color(UIColor.decorationSubtle) }
 }


### PR DESCRIPTION
# Why?

`FinniversKit` doesn't compile on iOS14 because now there are more `Color` initializers, `init(_ cgColor: CGColor)` and `init(_ uiColor: UIColor)`.

# What?

Specify which `Color` initializer we want to use.

# Version Change

Patch to FinniversKit.

# UI Changes

No UI changes.