### PR TITLE
messageUserRequiredViewDelegate => MessageUserRequiredSheetDelegate

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
@@ -9,7 +9,7 @@ public protocol MessageUserRequiredSheetDelegate: AnyObject {
 public class MessageUserRequiredSheet: BottomSheet {
     private let sheetHeight: CGFloat = 280
 
-    public weak var messageUserRequiredViewDelegate: MessageUserRequiredSheetDelegate?
+    public weak var messageUserRequiredSheetDelegate: MessageUserRequiredSheetDelegate?
     weak var viewController: MessageUserRequiredSheetViewController?
 
     // MARK: - Initalization
@@ -37,7 +37,7 @@ public class MessageUserRequiredSheet: BottomSheet {
 
 extension MessageUserRequiredSheet: MessageUserRequiredViewDelegate {
     public func didTapActionButton(_ sender: Button) {
-        messageUserRequiredViewDelegate?.didTapActionButton(sender)
+        messageUserRequiredSheetDelegate?.didTapActionButton(sender)
     }
 }
 


### PR DESCRIPTION
# Why?

- Name of delegate wasn't consistent with the class name

# What?

- Title says it all