### PR TITLE
Make Panel.Style conform to String

### DIFF
--- a/FinniversKit/Sources/Components/Panel/Panel+Style.swift
+++ b/FinniversKit/Sources/Components/Panel/Panel+Style.swift
@@ -3,7 +3,7 @@
 //
 
 extension Panel {
-    public enum Style {
+    public enum Style: String {
         case plain
         case info
         case tips

--- a/FinniversKit/Sources/Components/Panel/Panel+Style.swift
+++ b/FinniversKit/Sources/Components/Panel/Panel+Style.swift
@@ -7,7 +7,7 @@ extension Panel {
         case plain
         case info
         case tips
-        case newFunctionality
+        case newFunctionality = "new-functionality"
         case success
         case warning
         case error


### PR DESCRIPTION
# Why?

Want to be able to use `init(rawValue: String) -> Panel.Style?` to get a style

# What?

Made `Panel.Style` conform to `String`

# Version Change

Patch
