### PR TITLE
Open message bottom sheet height api

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -2475,6 +2475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 71.0.1;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -2498,6 +2499,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 71.0.1;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -2475,7 +2475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 71.0.1;
+				MARKETING_VERSION = 71.0.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -2499,7 +2499,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 71.0.1;
+				MARKETING_VERSION = 71.0.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Demo/Demo/Info.plist
+++ b/Demo/Demo/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '71.0.0'
+  s.version      = '71.0.1'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/FinniversKit.podspec
+++ b/FinniversKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinniversKit'
-  s.version      = '71.0.1'
+  s.version      = '71.0.0'
   s.summary      = "FINN's iOS Components"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -3764,7 +3764,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 55.0.0;
+				MARKETING_VERSION = 71.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = no.finn.FinniversKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3802,7 +3802,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 55.0.0;
+				MARKETING_VERSION = 71.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = no.finn.FinniversKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -3764,7 +3764,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 71.0.1;
+				MARKETING_VERSION = 71.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = no.finn.FinniversKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3802,7 +3802,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 71.0.1;
+				MARKETING_VERSION = 71.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = no.finn.FinniversKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/FinniversKit/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
@@ -117,9 +117,9 @@ extension MessageFormBottomSheet: BottomSheetDelegate {
     }
 }
 
-// MARK: - Private extensions
+// MARK: - Public extensions
 
-private extension BottomSheet.Height {
+public extension BottomSheet.Height {
     static var messageFormHeight: BottomSheet.Height {
         let screenSize = UIScreen.main.bounds.size
         let height = screenSize.height - 64


### PR DESCRIPTION
# Why?
Would be nice to use this extension for the new messaging component in the main app. 
No need for inventing the wheel again. 

# What?
Make extension BottomSheet.Height.messageFormHeight public. 

# UI Changes
None.