### PR TITLE
Build to update ImageAsset enum

### DIFF
--- a/Demo/Sources/Assets/ImageAsset.swift
+++ b/Demo/Sources/Assets/ImageAsset.swift
@@ -63,8 +63,6 @@ enum ImageAsset: String {
     case iconRealestateBedrooms
     case iconRealestateOwner
     case iconRealestatePrice
-    case illustrasjonMedFarge
-    case illustrasjonUtenFarge
     case jobs
     case magnifyingGlass
     case mc
@@ -141,8 +139,6 @@ enum ImageAsset: String {
             .iconRealestateBedrooms,
             .iconRealestateOwner,
             .iconRealestatePrice,
-            .illustrasjonMedFarge,
-            .illustrasjonUtenFarge,
             .jobs,
             .magnifyingGlass,
             .mc,


### PR DESCRIPTION
# Why?

Forgot to include a file before merging #1007 . 

# What?

Building the project resulted in a change in `ImageAsset` enum, that I want to include before bumping FinniversKit + FinnUI.