### PR TITLE
Add accessibilityLabel

### DIFF
--- a/FinniversKit/Sources/Components/Panel/Panel.swift
+++ b/FinniversKit/Sources/Components/Panel/Panel.swift
@@ -31,6 +31,7 @@ public class Panel: UIView {
     public func configure(with viewModel: PanelViewModel) {
         layer.cornerRadius = viewModel.cornerRadius
         textLabel.text = viewModel.text
+        accessibilityLabel = viewModel.text
         setNeedsLayout()
     }
 


### PR DESCRIPTION
# Why?

We didn't read the content

# What?

The panel component had `isAccessibilityElement` set to `true`, but didn't set an `accessibilityLabel` and thus didn't read the content of the label. 


# Version Change

patch

# UI Changes

No