### PR TITLE
Add reset ownership transfer action

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
@@ -52,6 +52,7 @@ extension MotorTransactionButton {
 
         // Re-register
         case reregister = "REREGISTER"
+        case resetOwnershipTransfer = "RESET_OWNERSHIP_TRANSFER"
 
         // Web
         case url = "URL"
@@ -69,6 +70,8 @@ extension MotorTransactionButton {
                 self = .purchaseInsurance
             case "REREGISTER":
                 self = .reregister
+            case "RESET_OWNERSHIP_TRANSFER":
+                self = .resetOwnershipTransfer
             case "URL":
                 self = .url
             default:


### PR DESCRIPTION
# Why?

- During reregistration the user may end up in a error state (e.g: if the buyer hasn't signed with bankID)
- This action will restart the ownership transfer process.

# What?

- Add `RESET_OWNERSHIP_TRANSFER` action

# Version Change

Breaking