### PR TITLE
Add support for SEND_OWNERSHIP_DOCUMENT

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
@@ -65,6 +65,7 @@ extension MotorTransactionButton {
         // Re-register
         case reregister = "REREGISTER"
         case resetOwnershipTransfer = "RESET_OWNERSHIP_TRANSFER"
+        case sendOwnershipDocument = "SEND_OWNERSHIP_DOCUMENT"
 
         // Web
         case url = "URL"
@@ -84,6 +85,8 @@ extension MotorTransactionButton {
                 self = .reregister
             case "RESET_OWNERSHIP_TRANSFER":
                 self = .resetOwnershipTransfer
+            case "SEND_OWNERSHIP_DOCUMENT":
+                self = .sendOwnershipDocument
             case "URL":
                 self = .url
             default:


### PR DESCRIPTION
# Why?

- The last action for the user to  complete the re-registration step

# What?

- add `SEND_OWNERSHIP_DOCUMENT`

# Version Change

Breaking