### PR TITLE
Make CTA disabled if style is "DISABLED"

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionButton/MotorTransactionButton.swift
@@ -5,6 +5,7 @@
 public enum MotorTransactionButton: String {
     case flat = "FLAT"
     case callToAction = "CALL_TO_ACTION"
+    case disabled = "DISABLED"
     case `default` = "DEFAULT"
 
     public init(rawValue: String) {
@@ -13,6 +14,8 @@ public enum MotorTransactionButton: String {
             self = .flat
         case "CALL_TO_ACTION":
             self = .callToAction
+        case "DISABLED":
+            self = .disabled
         default:
             self = .default
         }
@@ -20,13 +23,22 @@ public enum MotorTransactionButton: String {
 
     var style: Button.Style {
         switch self {
-        case .default:
-            return .default
-        case .callToAction:
-            return .callToAction
         case .flat:
             return .flat
+        case .callToAction:
+            return .callToAction
+        case .disabled:
+            return .callToAction
+        case .default:
+            return .default
         }
+    }
+
+    var isEnabled: Bool {
+        if self == .disabled {
+            return false
+        }
+        return true
     }
 }
 

--- a/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
+++ b/FinniversKit/Sources/Fullscreen/MotorTransactionView/MotorTransactionStepView/MotorTransactionStepContentView/MotorTransactionStepContentView.swift
@@ -253,11 +253,13 @@ private extension MotorTransactionStepContentView {
     private func setupButton(_ buttonModel: MotorTransactionButtonViewModel?, tag: MotorTransactionButton.Tag) {
         if let buttonModel = buttonModel {
             let buttonText = buttonModel.text
-            let buttonStyle = MotorTransactionButton(rawValue: buttonModel.style ?? "").style
-            let buttonAction = MotorTransactionButton.Action(rawValue: buttonModel.action ?? "")
 
-            let button = Button(style: buttonStyle, withAutoLayout: true)
+            let buttonType = MotorTransactionButton(rawValue: buttonModel.style ?? "DEFAULT")
+            let buttonAction = MotorTransactionButton.Action(rawValue: buttonModel.action ?? "FALLBACK")
+
+            let button = Button(style: buttonType.style, withAutoLayout: true)
             button.setTitle(buttonText, for: .normal)
+            button.isEnabled = buttonType.isEnabled
             button.tag = tag.rawValue
             button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
 


### PR DESCRIPTION
# Why?

- There's a couple of preliminary steps the user has to complete before they can send the ownership document

# What?

- Add support for the style `DISABLED` which will set the `CTA` button in a disabled state.

# Version Change

Minor

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro (14 0) - 2021-03-04 at 11 51 30](https://user-images.githubusercontent.com/8507719/109953899-f3d0d480-7ce0-11eb-9f1a-b1f32ddc58ad.png) |  ![Simulator Screen Shot - iPhone 11 Pro (14 0) - 2021-03-04 at 11 50 31](https://user-images.githubusercontent.com/8507719/109953747-c1bf7280-7ce0-11eb-8fc4-e04ea8d56cc8.png) |