### PR TITLE
Add public setImage method to FeedbackView

### DIFF
--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -118,6 +118,10 @@ public class FeedbackView: UIView {
         configure(withViewModel: viewModel)
     }
 
+    public func setImage(_ image: UIImage) {
+        imageView.image = image
+    }
+
     // MARK: - Private methods
 
     private func configure(withViewModel viewModel: FeedbackViewModel) {


### PR DESCRIPTION
# Why?

- Would like to have the option of changing the `image` used in the `FeedbackView` from outside of the module. 

# What?

- Add 
```
public func setImage(_ image: UIImage)  {
    imageView.image = image
}
```
to the public API

# Version Change

Minor