### PR TITLE
Set number of lines in TransactionStepView to 5

### DIFF
--- a/FinniversKit/Sources/Components/TransactionEntryView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Components/TransactionEntryView/TransactionStepView.swift
@@ -17,7 +17,7 @@ public class TransactionStepView: UIView {
 
     private lazy var textLabel: Label = {
         let label = Label(style: .detail, withAutoLayout: true)
-        label.numberOfLines = 5
+        label.numberOfLines = 2
         return label
     }()
 
@@ -67,9 +67,10 @@ public class TransactionStepView: UIView {
 
     // MARK: - Public methods
 
-    public func configure(withTitle title: String?, text: String?, showWarningIcon: Bool) {
+    public func configure(withTitle title: String?, text: String?, showWarningIcon: Bool, numberOfTextLines: Int = 2) {
         titleLabel.text = title
         textLabel.text = text
+        textLabel.numberOfLines = numberOfTextLines
         warningIconImageView.isHidden = !showWarningIcon
     }
 }

--- a/FinniversKit/Sources/Components/TransactionEntryView/TransactionStepView.swift
+++ b/FinniversKit/Sources/Components/TransactionEntryView/TransactionStepView.swift
@@ -17,7 +17,7 @@ public class TransactionStepView: UIView {
 
     private lazy var textLabel: Label = {
         let label = Label(style: .detail, withAutoLayout: true)
-        label.numberOfLines = 2
+        label.numberOfLines = 5
         return label
     }()
 


### PR DESCRIPTION
# Why?

- We might get strings that exceeds 2 lines

# What?

- Increase `numberOfLines` from `2` to `5`

# Version Change

- Minor