### PR TITLE
Add optional action button in ResultView

### DIFF
--- a/Demo/Sources/Fullscreen/ResultView/ResultDemoView.swift
+++ b/Demo/Sources/Fullscreen/ResultView/ResultDemoView.swift
@@ -43,6 +43,7 @@ class ResultDemoView: UIView, Tweakable {
             self.resultView.configure(
                 title: "Usjda!",
                 description: "Noe gikk galt.",
+                actionButtonTitle: "Prøv igjen",
                 icon: UIImage(named: .dissatisfiedFace),
                 backgroundColor: .bgPrimary,
                 iconTintColor: .textCritical,

--- a/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
+++ b/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
@@ -4,6 +4,10 @@
 
 import UIKit
 
+public protocol ResultViewDelegate: AnyObject {
+    func resultViewDidTapActionButton(_ resultView: ResultView)
+}
+
 public class ResultView: UIView {
     // MARK: - Private variables
     private lazy var titleLabel: Label = {
@@ -29,10 +33,19 @@ public class ResultView: UIView {
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(withAutoLayout: true)
         stackView.axis = .vertical
+        stackView.alignment = .center
         return stackView
     }()
 
+    private lazy var actionButton: Button = {
+        let button = Button(style: .callToAction, size: .small)
+        button.addTarget(self, action: #selector(handleTapOnActionButton), for: .touchUpInside)
+        return button
+    }()
+
     private lazy var iconHeightConstraint: NSLayoutConstraint = iconImageView.heightAnchor.constraint(equalToConstant: 40)
+
+    public weak var delegate: ResultViewDelegate?
 
     // MARK: - Initializers
     public override init(frame: CGRect) {
@@ -51,6 +64,7 @@ public class ResultView: UIView {
         title: String,
         titleColor: UIColor = .textPrimary,
         description: String? = nil,
+        actionButtonTitle: String? = nil,
         icon: UIImage? = nil,
         backgroundColor: UIColor = .bgTertiary,
         iconTintColor: UIColor? = .iconSecondary,
@@ -64,6 +78,11 @@ public class ResultView: UIView {
         descriptionLabel.isHidden = description == nil
         iconImageView.image = icon
         iconImageView.isHidden = icon == nil
+
+        actionButton.isHidden = actionButtonTitle == nil
+        if let actionButtonTitle = actionButtonTitle {
+            actionButton.setTitle(actionButtonTitle, for: .normal)
+        }
 
         self.backgroundColor = backgroundColor
         iconImageView.tintColor = iconTintColor
@@ -79,6 +98,7 @@ public class ResultView: UIView {
         stackView.addArrangedSubview(iconImageView)
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(descriptionLabel)
+        stackView.addArrangedSubview(actionButton)
 
         addSubview(stackView)
 
@@ -86,6 +106,13 @@ public class ResultView: UIView {
             iconHeightConstraint,
         ])
 
+        stackView.setCustomSpacing(.spacingM, after: descriptionLabel)
         stackView.centerAndConstraintInSuperview()
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleTapOnActionButton() {
+        delegate?.resultViewDidTapActionButton(self)
     }
 }

--- a/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
+++ b/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
@@ -45,6 +45,7 @@ public class ResultView: UIView {
 
     private lazy var iconHeightConstraint: NSLayoutConstraint = iconImageView.heightAnchor.constraint(equalToConstant: 40)
 
+    // MARK: Public variables
     public weak var delegate: ResultViewDelegate?
 
     // MARK: - Initializers


### PR DESCRIPTION
# Why?

Modify our `ResultView` to have an optional action button. Going to use it as a retry-this-search view in search quest, when backend fetch fails.

# What?

- Add action button to `ResultView`
- Make it optional in `configure` func

# Version Change

Patch 

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-12 at 09 21 02](https://user-images.githubusercontent.com/17450858/125247251-042e3700-e2f3-11eb-819c-2beeced6dd87.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-12 at 09 21 49](https://user-images.githubusercontent.com/17450858/125247245-02fd0a00-e2f3-11eb-98c4-95f3433413a7.png) |
