### PR TITLE
Set text in caption label via public method

### DIFF
--- a/Demo/Sources/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Sources/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -47,6 +47,12 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
 
             TweakingOption(title: "BAP for sale", action: { [weak self] in
                 self?.priceView.configure(with: .bapSaleAd)
+
+                let captionText = "Selger har sagt ja til å sende varen med Helthjem for 80kr"
+                let attributedCaptionText = NSMutableAttributedString(string: captionText)
+                let range = (captionText as NSString).range(of: "80kr")
+                attributedCaptionText.addAttribute(.font, value: UIFont.captionStrong, range: range)
+                self?.priceView.showCaptionLabel(attributedCaptionText)
             }),
 
             TweakingOption(title: "BAP wanted", action: { [weak self] in
@@ -283,15 +289,9 @@ extension ObjectPagePriceViewModel {
     }()
 
     static var bapSaleAd: ObjectPagePriceViewModel = {
-        let captionText = "Selger har sagt ja til å sende varen med Helthjem for 80kr"
-        let attributedCaptionText = NSMutableAttributedString(string: captionText)
-        let range = (captionText as NSString).range(of: "80kr")
-        attributedCaptionText.addAttribute(.font, value: UIFont.captionStrong, range: range)
-
         return ObjectPagePriceViewModel(
             totalPrice: "1 500 kr",
-            adTypeText: "Til salgs",
-            captionText: attributedCaptionText
+            adTypeText: "Til salgs"
         )
     }()
 

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -39,6 +39,8 @@ public class ObjectPagePriceView: UIView {
         return view
     }()
 
+    private lazy var captionLabel = Label(style: .caption, withAutoLayout: true)
+
     // MARK: - Init
 
     public override init(frame: CGRect) {
@@ -81,7 +83,6 @@ public class ObjectPagePriceView: UIView {
         wrapperStackView.addArrangedSubview(pricesStackView)
 
         if let captionText = viewModel.captionText {
-            let captionLabel = Label(style: style.captionStyle, withAutoLayout: true)
             captionLabel.attributedText = captionText
             wrapperStackView.addArrangedSubview(captionLabel)
         }
@@ -98,6 +99,15 @@ public class ObjectPagePriceView: UIView {
         linkButtonListView.isHidden = viewModel.links.isEmpty
 
         pricesStackView.isHidden = pricesStackView.arrangedSubviews.isEmpty
+    }
+
+    public func showCaptionLabel(_ text: NSAttributedString) {
+        if wrapperStackView.subviews.contains(captionLabel) {
+            captionLabel.attributedText = text
+        } else {
+            captionLabel.attributedText = text
+            wrapperStackView.addArrangedSubview(captionLabel)
+        }
     }
 }
 
@@ -165,20 +175,17 @@ public extension ObjectPagePriceView {
         let priceStyle: Label.Style
         let subtitleStyle: Label.Style
         let adTypeStyle: Label.Style
-        let captionStyle: Label.Style
 
         public init(
             titleStyle: Label.Style = .body,
             priceStyle: Label.Style = .title3Strong,
             subtitleStyle: Label.Style = .caption,
-            adTypeStyle: Label.Style = .bodyStrong,
-            captionStyle: Label.Style = .caption
+            adTypeStyle: Label.Style = .bodyStrong
         ) {
             self.titleStyle = titleStyle
             self.priceStyle = priceStyle
             self.subtitleStyle = subtitleStyle
             self.adTypeStyle = adTypeStyle
-            self.captionStyle = captionStyle
         }
     }
 }


### PR DESCRIPTION
# Why?

- Be able to present the `caption` label below the `price` in the `ObjectPagePriceView` without having to copying, mutate the view model and re-assign it.

# What?

- Create a public method `showCaptionLabel(_ text: NSAttributedText)`:
  - If `captionLabel` is a subview => Update the text label
- If `captionLabel` is not a subview => Add to the `UIStackView` and update the text label

# Version Change

- Minor
