### PR TITLE
Tweaks to FeedbackView size and presentation

### DIFF
--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -88,7 +88,6 @@ public class FeedbackView: UIView {
         backgroundColor = .bgSecondary
 
         layer.borderWidth = 1
-        layer.borderColor = .decorationSubtle
         layer.cornerRadius = 8
         layer.masksToBounds = true
 
@@ -178,6 +177,8 @@ public class FeedbackView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         hasBeenPresented = true
+
+        layer.borderColor = .decorationSubtle
 
         guard allowDynamicPresentation else { return }
 

--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -40,7 +40,6 @@ public class FeedbackView: UIView {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.image = UIImage(named: .ratingCat)
         imageView.contentMode = .scaleAspectFit
-        imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         return imageView
     }()
 
@@ -65,6 +64,7 @@ public class FeedbackView: UIView {
     private lazy var listPresentationConstraints: [NSLayoutConstraint] = [
         imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingS),
         imageView.widthAnchor.constraint(equalToConstant: 130),
+        imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 100),
         titleView.topAnchor.constraint(equalTo: topAnchor, constant: .spacingS),
         titleView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
         buttonView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
@@ -237,7 +237,7 @@ private class TitleView: UIView {
             titleLabelLeadingConstraint,
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
-            heightAnchor.constraint(equalTo: titleLabel.heightAnchor, constant: 0, priority: .defaultHigh)
+            heightAnchor.constraint(greaterThanOrEqualTo: titleLabel.heightAnchor)
         ])
     }
 

--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -56,7 +56,7 @@ public class FeedbackView: UIView {
     private lazy var gridPresentationConstraints: [NSLayoutConstraint] = [
         imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
         imageView.heightAnchor.constraint(equalToConstant: 130),
-        titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: TitleView.verticalSpacing),
+        titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: .spacingS),
         titleView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
         buttonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
         buttonView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingM)
@@ -65,7 +65,7 @@ public class FeedbackView: UIView {
     private lazy var listPresentationConstraints: [NSLayoutConstraint] = [
         imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingS),
         imageView.widthAnchor.constraint(equalToConstant: 130),
-        titleView.topAnchor.constraint(equalTo: topAnchor, constant: TitleView.verticalSpacing),
+        titleView.topAnchor.constraint(equalTo: topAnchor, constant: .spacingS),
         titleView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
         buttonView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
         buttonView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingS)
@@ -100,7 +100,7 @@ public class FeedbackView: UIView {
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
 
             titleView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
-            titleView.bottomAnchor.constraint(equalTo: buttonView.topAnchor, constant: -TitleView.verticalSpacing),
+            titleView.bottomAnchor.constraint(equalTo: buttonView.topAnchor, constant: -.spacingS),
 
             buttonView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS)
         ])
@@ -202,7 +202,6 @@ private enum FeedbackViewPresentation {
 // MARK: - TitleView
 
 private class TitleView: UIView {
-    static let verticalSpacing: CGFloat = .spacingS
 
     // MARK: - Private properties
 
@@ -238,8 +237,7 @@ private class TitleView: UIView {
             titleLabelLeadingConstraint,
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
-
-            heightAnchor.constraint(equalTo: titleLabel.heightAnchor, constant: 2 * TitleView.verticalSpacing, priority: .defaultLow)
+            heightAnchor.constraint(equalTo: titleLabel.heightAnchor, constant: 0, priority: .defaultHigh)
         ])
     }
 

--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -56,7 +56,7 @@ public class FeedbackView: UIView {
     private lazy var gridPresentationConstraints: [NSLayoutConstraint] = [
         imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
         imageView.heightAnchor.constraint(equalToConstant: 130),
-        titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: .spacingS),
+        titleView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: TitleView.verticalSpacing),
         titleView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
         buttonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
         buttonView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingM)
@@ -65,7 +65,7 @@ public class FeedbackView: UIView {
     private lazy var listPresentationConstraints: [NSLayoutConstraint] = [
         imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingS),
         imageView.widthAnchor.constraint(equalToConstant: 130),
-        titleView.topAnchor.constraint(equalTo: topAnchor, constant: .spacingS),
+        titleView.topAnchor.constraint(equalTo: topAnchor, constant: TitleView.verticalSpacing),
         titleView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
         buttonView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: .spacingS),
         buttonView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -.spacingS)
@@ -101,7 +101,7 @@ public class FeedbackView: UIView {
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS),
 
             titleView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
-            titleView.bottomAnchor.constraint(equalTo: buttonView.topAnchor, constant: -.spacingS),
+            titleView.bottomAnchor.constraint(equalTo: buttonView.topAnchor, constant: -TitleView.verticalSpacing),
 
             buttonView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS)
         ])
@@ -201,6 +201,7 @@ private enum FeedbackViewPresentation {
 // MARK: - TitleView
 
 private class TitleView: UIView {
+    static let verticalSpacing: CGFloat = .spacingS
 
     // MARK: - Private properties
 
@@ -211,6 +212,7 @@ private class TitleView: UIView {
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.8
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
 
@@ -234,9 +236,10 @@ private class TitleView: UIView {
 
         NSLayoutConstraint.activate([
             titleLabelLeadingConstraint,
-            titleLabel.topAnchor.constraint(equalTo: topAnchor),
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS)
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.spacingS),
+
+            heightAnchor.constraint(equalTo: titleLabel.heightAnchor, constant: 2 * TitleView.verticalSpacing, priority: .defaultLow)
         ])
     }
 

--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -34,7 +34,7 @@ public class FeedbackView: UIView {
     private var hasBeenPresented = false
     private var state: State = .initial
     private var presentation: FeedbackViewPresentation?
-    private var allowDynamicPresentation: Bool = true
+    private var allowAutomaticPresentationSwitch: Bool = true
 
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
@@ -109,7 +109,7 @@ public class FeedbackView: UIView {
     // MARK: - Public methods
 
     public func configureWithFixedPresentation(isGrid: Bool) {
-        allowDynamicPresentation = false
+        allowAutomaticPresentationSwitch = false
         let presentation: FeedbackViewPresentation = isGrid ? .grid : .list
         configure(forPresentation: presentation)
     }
@@ -180,7 +180,7 @@ public class FeedbackView: UIView {
 
         layer.borderColor = .decorationSubtle
 
-        guard allowDynamicPresentation else { return }
+        guard allowAutomaticPresentationSwitch else { return }
 
         let newPresentation: FeedbackViewPresentation = bounds.size.height >= bounds.size.width ? .grid : .list
 
@@ -213,7 +213,6 @@ private class TitleView: UIView {
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.8
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
 


### PR DESCRIPTION
# Why?

I'm gonna insert `FeedbackView` into the new search result cells. Since the cells are self-sizing, I have to make some adjustments to this view to make it layout correctly.

# What?

Be explicit about what kind of presentation to use for the cell (grid or list), so I added an option to set a fixed presentation, instead of using the automatic one (which determines display type based on the view's dimensions).

Set a `heightAnchor` for the title label, so self-sizing cells don't give it zero height.
Also set a max height for image in list presentation - since self-sizing cells allowed it to be much larger than how it was designed.

A small dark mode fix.

# Version Change

Patch.

# UI Changes

There shouldn't be any UI changes.