### PR TITLE
Increase MessageFormBottomSheet height

### DIFF
--- a/FinniversKit/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageForm/MessageFormBottomSheet.swift
@@ -123,7 +123,7 @@ extension MessageFormBottomSheet: BottomSheetDelegate {
 public extension BottomSheet.Height {
     static var messageFormHeight: BottomSheet.Height {
         let screenSize = UIScreen.main.bounds.size
-        let height = screenSize.height / 2
+        let height = screenSize.height - 64
         return BottomSheet.Height(compact: height, expanded: height)
     }
 }


### PR DESCRIPTION
# Why?

The keyboard covers the Message form bottom sheet text fields

# What?

Expand height to make room for keyboard