### PR TITLE
BottomSheet should support screens with variable refresh rate

### DIFF
--- a/FinniversKit/Sources/Components/BottomSheet/Animator/SpringAnimator.swift
+++ b/FinniversKit/Sources/Components/BottomSheet/Animator/SpringAnimator.swift
@@ -103,10 +103,12 @@ class SpringAnimator: NSObject {
 
 private extension SpringAnimator {
     @objc func step(displayLink: CADisplayLink) {
+        // Get duration in a way that supports screens with variable refresh rates
+        let duration = displayLink.targetTimestamp - CACurrentMediaTime()
         // Calculate new potision
+        position += velocity * CGFloat(duration)
         let acceleration = -velocity * damping - position * stiffness
-        velocity += acceleration * CGFloat(displayLink.duration)
-        position += velocity * CGFloat(displayLink.duration)
+        velocity += acceleration * CGFloat(duration)
         // If it moves less than a pixel, animation is done
         if position < scale, velocity < scale {
             stopAnimation(false)


### PR DESCRIPTION
# Why?
Because using the CADisplayLink without thinking of screens with variable refresh rate is not good for iPhone 13 prod devices.

# What?
Do same change as in the BottomSheet repo.

Which reminds me, we should aim to remove the BottomSheet in this repo. But for now let's simply try to fix the issue

# Version Change
Patch