### PR TITLE
Fix: Make it possible to set text of TextField

### DIFF
--- a/FinniversKit/Sources/Components/TextField/TextField.swift
+++ b/FinniversKit/Sources/Components/TextField/TextField.swift
@@ -149,7 +149,13 @@ public class TextField: UIView {
     }
 
     public var text: String? {
-        return textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        get {
+            textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        set {
+            textField.text = newValue
+            evaluateCurrentTextState()
+        }
     }
 
     public var helpText: String? {


### PR DESCRIPTION
# Why?
When using this view I noticed that it's not possible to set the text manually, which I need for a form I'm adding.

# What?
- Add `set` block for `TextField`'s `text`-property.

# Version Change
- Minor.

# UI Changes
_No UI._