### PR TITLE
Support recommendation cells without icon

### DIFF
--- a/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoView.swift
+++ b/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoView.swift
@@ -7,7 +7,7 @@ import FinniversKit
 /// For use with AdRecommendationsGridView.
 public struct AdDataSource {
     let models: [AdRecommendation] = {
-        var ads: [AdRecommendation] = AdFactory.create(numberOfModels: 9).map { .ad($0) }
+        var ads: [AdRecommendation] = AdFactory.create(numberOfModels: 11).map { .ad($0) }
         ads.insert(contentsOf: JobAdFactory.create(numberOfModels: 2).map { .job($0) }, at: 1)
         ads.insert(.ad(AdFactory.googleDemoAd), at: 4)
         ads.insert(.ad(AdFactory.nativeDemoAd), at: 8)
@@ -120,7 +120,7 @@ extension AdRecommendationsGridViewDemoView: AdRecommendationsGridViewDataSource
                 cell.imageDataSource = adRecommendationsGridView
                 cell.delegate = adRecommendationsGridView
                 cell.configure(with: ad, atIndex: indexPath.item)
-                cell.showImageDescriptionView = ad.scaleImageToFillView
+                //cell.showImageDescriptionView = ad.scaleImageToFillView
                 return cell
             }
         case .job(let ad):

--- a/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoViewHelpers.swift
+++ b/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoViewHelpers.swift
@@ -45,6 +45,19 @@ public struct Ad: StandardAdRecommendationViewModel {
     }
 
     public var favoriteButtonAccessibilityLabel = "Sett annonsen som favoritt"
+
+    public var hideImageOverlay: Bool {
+        imageText.isNilOrEmpty && iconImage == nil
+    }
+}
+
+extension Optional where Wrapped == String {
+    var isNilOrEmpty: Bool {
+        guard let value = self else {
+            return true
+        }
+        return value.isEmpty
+    }
 }
 
 /// A model confirming to the JobAdRecommendationViewModel protocol for showcasing JobAdRecommendationCell in playground.
@@ -92,7 +105,7 @@ struct AdFactory {
                 iconImage: icon,
                 title: title,
                 subtitle: subtitle,
-                accessory: index % 2 == 0 ? "Totalpris \(price)" : nil,
+                accessory: index % 2 == 0 ? "Totalpris \(price ?? "mangler")" : nil,
                 imageText: price,
                 isFavorite: false,
                 scaleImageToFillView: scaleImageToFillView,
@@ -102,17 +115,19 @@ struct AdFactory {
         }
     }
 
-    private static var iconImages: [UIImage] {
+    private static var iconImages: [UIImage?] {
         return [
             UIImage(named: .realestate),
             UIImage(named: .realestate),
             UIImage(named: .realestate),
-            UIImage(named: .jobs),
+            nil,
             UIImage(named: .realestate),
             UIImage(named: .realestate),
             UIImage(named: .realestate),
             UIImage(named: .realestate),
-            UIImage(named: .realestate)
+            UIImage(named: .realestate),
+            nil,
+            nil
         ]
     }
 
@@ -126,7 +141,9 @@ struct AdFactory {
             "Privat slott",
             "Pent brukt bolig",
             "Enebolig i rolig strøk",
-            "Hus til slags"
+            "Hus til slags",
+            "Hus uten ikon",
+            "Hus uten ikon og pris"
         ]
     }
 
@@ -141,34 +158,41 @@ struct AdFactory {
             "Langtvekkistan",
             "Elverum",
             "Brønnøysund",
-            "Bodø"
+            "Bodø",
+            "Langtvekkistan"
         ]
     }
 
-    private static var prices: [String] {
-        return ["845 000,-",
-                "164 000,-",
-                "355 000,-",
-                "",
-                "746 000,-",
-                "347 000,-",
-                "546 000,-",
-                "647 000,-",
-                "264 000,-"]
+    private static var prices: [String?] {
+        return [
+            "845 000,-",
+            "164 000,-",
+            "355 000,-",
+            "",
+            "746 000,-",
+            "347 000,-",
+            "546 000,-",
+            "647 000,-",
+            "264 000,-",
+            "123 456,-",
+            nil
+        ]
     }
 
     private static var scaleImagesToFillView: [Bool] {
-        return [true,
-                true,
-                true,
-                false,
-                true,
-                true,
-                true,
-                true,
-                true,
-                true,
-                true]
+        return [
+            true,
+            true,
+            true,
+            false,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true
+        ]
     }
 
     private static var imageSources: [ImageSource] {

--- a/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
@@ -33,3 +33,12 @@ public extension String {
         NSAttributedString(string: self, attributes: attributes)
     }
 }
+
+extension Optional where Wrapped == String {
+    var isNilOrEmpty: Bool {
+        guard let value = self else {
+            return true
+        }
+        return value.isEmpty
+    }
+}

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Model/StandardAdRecommendationViewModel.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Model/StandardAdRecommendationViewModel.swift
@@ -17,6 +17,7 @@ public protocol StandardAdRecommendationViewModel {
     var sponsoredAdData: SponsoredAdData? { get }
     var accessibilityLabel: String { get }
     var favoriteButtonAccessibilityLabel: String { get }
+    var hideImageOverlay: Bool { get }
 }
 
 public struct SponsoredAdData {


### PR DESCRIPTION
# Why?
Because we will be removing the market icons in the cells.

# What?
I thought it best to keep the code for having icons a little longer incase we decide to go back on this.

- Reworked support for configuring the cells to hide the image overlay completely, since the old way felt a bit error prone and could override my first attempt at hiding the overlay whenever the icon or image text was not set.
- Made the overlay in the cells handle either missing icon or missing text (using a stackview).

# Version Change
Major change since it changes the public api 😞 

# UI Changes
Added a couple of cells to demo how it looks without icon and when hiding the overlay completely:
![Simulator Screen Shot - iPhone 12 Pro - 2021-11-10 at 11 28 21](https://user-images.githubusercontent.com/3169203/141096891-c7ae73f4-0a18-44cf-8262-d8fb06d9a612.png)
