### PR TITLE
Fix: LinkButtonView customize button style

### DIFF
--- a/Demo/Sources/Components/LinkButtonList/LinkButtonListDemoView.swift
+++ b/Demo/Sources/Components/LinkButtonList/LinkButtonListDemoView.swift
@@ -4,7 +4,16 @@
 
 import FinniversKit
 
-class LinkButtonListDemoView: UIView {
+class LinkButtonListDemoView: UIView, Tweakable {
+    lazy var tweakingOptions: [TweakingOption] = [
+        .init(title: "Misc. buttons", action: { [weak self] in
+            self?.configure(viewModels: .defaults)
+        }),
+        .init(title: "Flat buttons", action: { [weak self] in
+            self?.configure(viewModels: .alternateStyle)
+        })
+    ]
+
     private lazy var linkListView: LinkButtonListView = {
         let view = LinkButtonListView(withAutoLayout: true)
         view.delegate = self
@@ -16,6 +25,7 @@ class LinkButtonListDemoView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        tweakingOptions.first?.action?()
     }
 
     public required init?(coder aDecoder: NSCoder) { fatalError() }
@@ -23,8 +33,6 @@ class LinkButtonListDemoView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        linkListView.configure(with: .defaults)
-
         addSubview(linkListView)
         NSLayoutConstraint.activate([
             linkListView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingM),
@@ -32,13 +40,23 @@ class LinkButtonListDemoView: UIView {
             linkListView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
+
+    // MARK: - Private methods
+
+    func configure(viewModels: [LinkButtonViewModel]) {
+        linkListView.configure(with: viewModels)
+    }
 }
+
+// MARK: - LinkButtonListViewDelegate
 
 extension LinkButtonListDemoView: LinkButtonListViewDelegate {
     func linksListView(_ view: LinkButtonListView, didTapButtonWithIdentifier identifier: String?, url: URL) {
-        print("🔥🔥🔥🔥 \(#function) - buttonIdentifier: \(identifier ?? "") - url: \(url)")
+        print("✅ \(#function) - buttonIdentifier: \(identifier ?? "") - url: \(url)")
     }
 }
+
+// MARK: - Private extensions
 
 private extension Array where Element == LinkButtonViewModel {
     static var `defaults`: [LinkButtonViewModel] = {
@@ -68,7 +86,44 @@ private extension Array where Element == LinkButtonViewModel {
                 subtitle: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.",
                 linkUrl: URL(string: "https://www.finn.no/")!,
                 isExternal: false
+            )
+        ]
+    }()
+
+    static var alternateStyle: [LinkButtonViewModel] = {
+        [
+            LinkButtonViewModel(
+                buttonIdentifier: "b1",
+                buttonTitle: "Button 1",
+                linkUrl: URL(string: "https://www.finn.no/")!,
+                isExternal: false,
+                buttonStyle: .flat,
+                buttonSize: .normal
             ),
+            LinkButtonViewModel(
+                buttonIdentifier: "b2",
+                buttonTitle: "Button 2",
+                linkUrl: URL(string: "https://www.finn.no/")!,
+                isExternal: false,
+                buttonStyle: .flat,
+                buttonSize: .normal
+            ),
+            LinkButtonViewModel(
+                buttonIdentifier: "b3",
+                buttonTitle: "Button 3",
+                linkUrl: URL(string: "https://www.finn.no/")!,
+                isExternal: false,
+                buttonStyle: .flat,
+                buttonSize: .normal
+            ),
+            LinkButtonViewModel(
+                buttonIdentifier: "b4",
+                buttonTitle: "Button 4",
+                linkUrl: URL(string: "https://www.finn.no/")!,
+                isExternal: false,
+                buttonStyle: .flat,
+                buttonSize: .normal
+            )
         ]
     }()
 }

--- a/FinniversKit/Sources/Components/LinkButton/LinkButtonView.swift
+++ b/FinniversKit/Sources/Components/LinkButton/LinkButtonView.swift
@@ -16,7 +16,8 @@ class LinkButtonView: UIView {
 
     private let buttonIdentifier: String?
     private let linkUrl: URL
-    private let linkButtonStyle = Button.Style.link.overrideStyle(smallFont: .body)
+    private let buttonStyle: Button.Style
+    private let buttonSize: Button.Size
     private lazy var fillerView = UIView(withAutoLayout: true)
     private lazy var externalImage = UIImage(named: .webview).withRenderingMode(.alwaysTemplate)
 
@@ -36,7 +37,7 @@ class LinkButtonView: UIView {
     }()
 
     private lazy var linkButton: Button = {
-        let button = Button(style: linkButtonStyle, size: .small, withAutoLayout: true)
+        let button = Button(style: buttonStyle, size: buttonSize, withAutoLayout: true)
         button.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
         button.contentHorizontalAlignment = .leading
         return button
@@ -59,12 +60,30 @@ class LinkButtonView: UIView {
     // MARK: - Init
 
     convenience init(viewModel: LinkButtonViewModel) {
-        self.init(buttonIdentifier: viewModel.buttonIdentifier, buttonTitle: viewModel.buttonTitle, subtitle: viewModel.subtitle, linkUrl: viewModel.linkUrl, isExternal: viewModel.isExternal)
+        self.init(
+            buttonIdentifier: viewModel.buttonIdentifier,
+            buttonTitle: viewModel.buttonTitle,
+            subtitle: viewModel.subtitle,
+            linkUrl: viewModel.linkUrl,
+            isExternal: viewModel.isExternal,
+            buttonStyle: viewModel.buttonStyle,
+            buttonSize: viewModel.buttonSize
+        )
     }
 
-    init(buttonIdentifier: String?, buttonTitle: String, subtitle: String?, linkUrl: URL, isExternal: Bool) {
+    init(
+        buttonIdentifier: String?,
+        buttonTitle: String,
+        subtitle: String?,
+        linkUrl: URL,
+        isExternal: Bool,
+        buttonStyle: Button.Style? = nil,
+        buttonSize: Button.Size = .small
+    ) {
         self.buttonIdentifier = buttonIdentifier
         self.linkUrl = linkUrl
+        self.buttonStyle = buttonStyle ?? .defaultButtonStyle
+        self.buttonSize = buttonSize
         super.init(frame: .zero)
 
         externalImageView.isHidden = !isExternal
@@ -98,4 +117,8 @@ class LinkButtonView: UIView {
 
 private extension UIColor {
     static var externalIconColor = dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
+}
+
+private extension Button.Style {
+    static var defaultButtonStyle = Button.Style.link.overrideStyle(smallFont: .body)
 }

--- a/FinniversKit/Sources/Components/LinkButton/Models/LinkButtonViewModel.swift
+++ b/FinniversKit/Sources/Components/LinkButton/Models/LinkButtonViewModel.swift
@@ -8,12 +8,24 @@ public struct LinkButtonViewModel {
     let subtitle: String?
     let linkUrl: URL
     let isExternal: Bool
+    let buttonStyle: Button.Style?
+    let buttonSize: Button.Size
 
-    public init(buttonIdentifier: String?, buttonTitle: String, subtitle: String? = nil, linkUrl: URL, isExternal: Bool) {
+    public init(
+        buttonIdentifier: String?,
+        buttonTitle: String,
+        subtitle: String? = nil,
+        linkUrl: URL,
+        isExternal: Bool,
+        buttonStyle: Button.Style? = nil,
+        buttonSize: Button.Size = .small
+    ) {
         self.buttonIdentifier = buttonIdentifier
         self.buttonTitle = buttonTitle
         self.subtitle = subtitle
         self.linkUrl = linkUrl
         self.isExternal = isExternal
+        self.buttonStyle = buttonStyle
+        self.buttonSize = buttonSize
     }
 }


### PR DESCRIPTION
# Why?
I can use this view in a new component I'm adding, but I need to make the buttons styles customizable.

# What?
- Added `buttonStyle` and `buttonSize` to `LinkButtonViewModel`.
- Use the provided style and size for each button in the view.

# Version Change
Minor.

# UI Changes
Buttons using the `.flat` style with size `.normal`.

<img width="320" alt="Screenshot 2021-11-16 at 10 14 29" src="https://user-images.githubusercontent.com/1901556/141956759-e67cd89e-3f48-470c-aa9f-3187a4f2bf13.png">


