### PR TITLE
TopShadowView: convert frames to window

### DIFF
--- a/FinniversKit/Sources/Util/TopShadowView.swift
+++ b/FinniversKit/Sources/Util/TopShadowView.swift
@@ -32,14 +32,17 @@ public class TopShadowView: UIView {
     // MARK: - Shadow
 
     public func updateShadow(using scrollView: UIScrollView) {
+        let scrollViewFrameInWindow = scrollView.convert(scrollView.bounds, to: nil)
+        let frameInWindow = convert(bounds, to: nil)
+
         let contentFrame = CGRect(
             x: -scrollView.contentOffset.x,
-            y: scrollView.frame.minY - scrollView.contentOffset.y - scrollView.contentInset.top,
+            y: scrollViewFrameInWindow.minY - scrollView.contentOffset.y - scrollView.contentInset.top,
             width: scrollView.contentSize.width,
             height: scrollView.contentSize.height + scrollView.contentInset.top
         )
 
-        let intersection = contentFrame.intersection(frame)
+        let intersection = contentFrame.intersection(frameInWindow)
         layer.shadowRadius = min(intersection.height * 0.2, TopShadowView.maxShadowRadius)
     }
 


### PR DESCRIPTION
# Why?

In some cases the `scrollView` is not a sibling of the `TopShadowView`, making the intersection equal to zero.

# What?

Convert the `scrollView` frame and `TopShadowView` to the coordinate space of `window` before calculating the intersection. I've tested `SettingsDetailsView` and `FooterBottomView` and they still seem to work as expected.

# Version Change

Patch

# UI Changes

_No UI change_