### PR TITLE
Fix: Make it possible for buttons to have multiple lines in ObjectPagePriceView

### DIFF
--- a/Demo/Sources/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
+++ b/Demo/Sources/Components/ObjectPagePriceView/ObjectPagePriceDemoView.swift
@@ -13,6 +13,10 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
                 self?.priceView.configure(with: .withLinks)
             }),
 
+            TweakingOption(title: "With long link titles", action: { [weak self] in
+                self?.priceView.configure(with: .withLongLinkTitles)
+            }),
+
             TweakingOption(title: "Without links", action: { [weak self] in
                 self?.priceView.configure(with: .withoutLinks)
             }),
@@ -74,6 +78,7 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        tweakingOptions.first?.action?()
     }
 
     public required init?(coder aDecoder: NSCoder) { fatalError() }
@@ -81,8 +86,6 @@ class ObjectPagePriceDemoView: UIView, Tweakable {
     // MARK: - Setup
 
     private func setup() {
-        priceView.configure(with: .withLinks)
-
         addSubview(priceView)
         NSLayoutConstraint.activate([
             priceView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingM),
@@ -121,6 +124,35 @@ extension ObjectPagePriceViewModel {
                 PriceLinkButtonViewModel(
                     buttonIdentifier: "used-car-guarantee",
                     buttonTitle: "Bruktbilgaranti 272 kr",
+                    linkUrl: URL(string: "https://www.finn.no/")!,
+                    isExternal: true
+                )
+            ]
+        )
+    }()
+
+    static var withLongLinkTitles: ObjectPagePriceViewModel = {
+        ObjectPagePriceViewModel(
+            title: "Totalpris",
+            totalPrice: "1 389 588 kr",
+            accessibilityLabel: "Totalpris: \(NumberFormatter.spokenFormatter.string(from: 1389588) ?? String(1389588)) kroner",
+            links: [
+                PriceLinkButtonViewModel(
+                    buttonIdentifier: "loan",
+                    buttonTitle: "Lån fra 16 581 kr",
+                    subtitle: "Eff.rente 3,89 %. 903 232 o/5 år. Kostnad: 91 628 kr. Totalt 994 860 kr.",
+                    linkUrl: URL(string: "https://www.finn.no/")!,
+                    isExternal: true
+                ),
+                PriceLinkButtonViewModel(
+                    buttonIdentifier: "pulse",
+                    buttonTitle: "Se hva solgte boliger i området ble lagt ut for det siste året",
+                    linkUrl: URL(string: "https://www.finn.no/")!,
+                    isExternal: true
+                ),
+                PriceLinkButtonViewModel(
+                    buttonIdentifier: "used-car-guarantee",
+                    buttonTitle: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                     linkUrl: URL(string: "https://www.finn.no/")!,
                     isExternal: true
                 )

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonListView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonListView.swift
@@ -16,12 +16,7 @@ public class PriceLinkButtonListView: UIView {
 
     // MARK: - Private properties
 
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(withAutoLayout: true)
-        stackView.axis = .vertical
-        stackView.spacing = .spacingS
-        return stackView
-    }()
+    private lazy var stackView = UIStackView(axis: .vertical, spacing: .spacingS, withAutoLayout: true)
 
     // MARK: - Init
 

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
@@ -17,7 +17,6 @@ class PriceLinkButtonView: UIView {
     // MARK: - Private properties
 
     private let viewModel: PriceLinkButtonViewModel
-    private let linkButtonStyle = Button.Style.link.overrideStyle(smallFont: .body)
     private lazy var fillerView = UIView(withAutoLayout: true)
     private lazy var externalImage = UIImage(named: .webview).withRenderingMode(.alwaysTemplate)
 
@@ -35,10 +34,9 @@ class PriceLinkButtonView: UIView {
         return stackView
     }()
 
-    private lazy var linkButton: Button = {
-        let button = Button(style: linkButtonStyle, size: .small, withAutoLayout: true)
+    private lazy var linkButton: UIButton = {
+        let button = PriceLinkButton(withAutoLayout: true)
         button.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
-        button.contentHorizontalAlignment = .leading
         return button
     }()
 
@@ -144,8 +142,52 @@ class PriceLinkButtonView: UIView {
     }
 }
 
-// MARK: - Private extensions
+// MARK: - Private types/extensions
 
 private extension UIColor {
     static var externalIconColor = dynamicColorIfAvailable(defaultColor: .sardine, darkModeColor: .darkSardine)
+}
+
+private class PriceLinkButton: UIButton {
+    override var intrinsicContentSize: CGSize {
+        /// We need to override this to get the correct height for button with multiple lines of text.
+        guard let titleSize = titleLabel?.intrinsicContentSize else { return .zero }
+
+        return CGSize(
+            width: titleSize.width,
+            height: titleSize.height + 10 // 2 * .spacingXS + 2 (aka. magic number).
+        )
+    }
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        titleLabel?.font = .body
+        titleLabel?.adjustsFontForContentSizeCategory = true
+        titleLabel?.numberOfLines = 0
+        titleLabel?.lineBreakMode = .byWordWrapping
+
+        titleEdgeInsets = .zero
+        contentEdgeInsets = UIEdgeInsets(vertical: .spacingXS, horizontal: 0)
+        contentHorizontalAlignment = .leading
+
+        setTitleColor(.textAction, for: .normal)
+        setTitleColor(.linkButtonHighlightedTextColor, for: .highlighted)
+        setTitleColor(.textDisabled, for: .disabled)
+    }
+
+    // MARK: - Overrides
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        titleLabel?.preferredMaxLayoutWidth = titleLabel?.frame.size.width ?? 0
+    }
 }

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
@@ -2,6 +2,8 @@
 //  Copyright © FINN.no AS, Inc. All rights reserved.
 //
 
+import UIKit
+
 protocol PriceLinkButtonViewDelegate: AnyObject {
     func priceLinkButton(withIdentifier identifier: String?, wasTappedWithUrl url: URL)
 }
@@ -27,8 +29,8 @@ class PriceLinkButtonView: UIView {
     }()
 
     private lazy var buttonStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [linkButton, fillerView, externalImageView])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let stackView = UIStackView(axis: .horizontal, spacing: .spacingS, withAutoLayout: true)
+        stackView.addArrangedSubviews([linkButton, fillerView, externalImageView])
         stackView.alignment = .center
         return stackView
     }()
@@ -120,9 +122,8 @@ class PriceLinkButtonView: UIView {
         subheadingLabel.text = viewModel.subheading
         subheadingLabel.setContentHuggingPriority(.required, for: .horizontal)
 
-        let horizontalStackView = UIStackView(withAutoLayout: true)
+        let horizontalStackView = UIStackView(axis: .horizontal, spacing: .spacingS, withAutoLayout: true)
         horizontalStackView.addArrangedSubviews([subheadingLabel, buttonStackView])
-        horizontalStackView.spacing = .spacingS
 
         stackView.addArrangedSubviews([horizontalStackView, subtitleLabel])
 


### PR DESCRIPTION
# Why?
We need to support longer titles for the link buttons in `ObjectPagePriceView`. We seem to already have support by setting `button.titleLabel?.numberOfLines` to `0`, but the extra lines are not accounted for when `Button` calculates its `intrinsicContentSize` so the buttons end up looking pretty cramped because of the missing space. See the 'Before'-image below, where I've set `numberOfLines = 0`.

I found a solution thanks to [this answer](https://stackoverflow.com/a/34228276), which has a pretty good explanation on how to solve this issue and why it exists to begin with.

# What?
- Add ad-hoc `UIButton`-subclass for price link buttons.
- Cleanup stackView usages.

# Version Change
Patch. Only changes within the view itself.

# UI Changes
| Before | After |
| --- | --- |
| <img width="605" alt="Screenshot 2022-01-25 at 17 26 45" src="https://user-images.githubusercontent.com/1901556/151018299-376eaf3f-3769-4988-9cfe-00b94ce9171d.png"> | <img width="605" alt="Screenshot 2022-01-25 at 16 47 04" src="https://user-images.githubusercontent.com/1901556/151018309-c8770e54-f062-473b-ab61-ca2b15b3d8f5.png"> |