### PR TITLE
Front page shelves bug fixes

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -263,6 +263,10 @@ public final class FrontPageView: UIView {
             frontPageShelfView = FrontPageShelfView(withDatasource: self)
             frontPageShelfView?.translatesAutoresizingMaskIntoConstraints = false
             shelfContainer.addSubview(frontPageShelfView!)
+
+            // Add a minimum height, since cells are never queried if the frame initially has height 0.
+            frontPageShelfView?.heightAnchor.constraint(greaterThanOrEqualToConstant: 100).isActive = true
+
             frontPageShelfView?.reloadShelf()
             frontPageShelfView?.fillInSuperview(insets: .init(top: .spacingL,
                                                               leading: 0,

--- a/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -199,9 +199,9 @@ public final class FrontPageView: UIView {
             christmasPromotionContainer.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: .spacingM),
             christmasPromotionContainer.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -.spacingM),
             
-            shelfContainer.topAnchor.constraint(equalTo: christmasPromotionContainer.bottomAnchor, constant: 0),
-            shelfContainer.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 0),
-            shelfContainer.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: 0),
+            shelfContainer.topAnchor.constraint(equalTo: christmasPromotionContainer.bottomAnchor),
+            shelfContainer.leadingAnchor.constraint(equalTo: headerView.leadingAnchor),
+            shelfContainer.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
             
             headerLabel.topAnchor.constraint(equalTo: shelfContainer.bottomAnchor, constant: .spacingM),
             headerLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: .spacingM),
@@ -268,10 +268,10 @@ public final class FrontPageView: UIView {
                                                               leading: 0,
                                                               bottom: 0,
                                                               trailing: 0))
-            setupFrames()
         } else {
             frontPageShelfView?.reloadShelf()
         }
+        setupFrames()
     }
     
     public func removeFrontShelf() {

--- a/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
+++ b/FinniversKit/Sources/Fullscreen/FrontPage/FrontPageView.swift
@@ -264,17 +264,15 @@ public final class FrontPageView: UIView {
             frontPageShelfView?.translatesAutoresizingMaskIntoConstraints = false
             shelfContainer.addSubview(frontPageShelfView!)
 
+            frontPageShelfView?.fillInSuperview(
+                insets: .init(top: .spacingL, leading: 0, bottom: 0, trailing: 0)
+            )
+
             // Add a minimum height, since cells are never queried if the frame initially has height 0.
             frontPageShelfView?.heightAnchor.constraint(greaterThanOrEqualToConstant: 100).isActive = true
-
-            frontPageShelfView?.reloadShelf()
-            frontPageShelfView?.fillInSuperview(insets: .init(top: .spacingL,
-                                                              leading: 0,
-                                                              bottom: 0,
-                                                              trailing: 0))
-        } else {
-            frontPageShelfView?.reloadShelf()
         }
+
+        frontPageShelfView?.reloadShelf()
         setupFrames()
     }
     


### PR DESCRIPTION
# Why?

We have a bug where the shelf would sometimes be empty:
It was a bit difficult to reproduce, it happened randomly now and then.

![empty-shelf](https://user-images.githubusercontent.com/17450858/151316722-3274f35d-e61b-46df-9a6a-cd3fecc52634.png)

# What?

I think I found the cause behind this bug, as least I haven't been able to reproduce it anymore after this fix.
The problem was that the cells were never created (`cellForItemAt` never called) since the frame of the shelf container ended up being squeezed by the container above and getting 0 height. And cells are never created if the height is 0, so it never ended up "claiming" the space that it needed.
I added a height anchor:
`frontPageShelfView?.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)`
that makes sure the view always has a minimum height.  The constant 100 is a bit random, the shelf will always end up with a taller height anyways.

**Other bug fix**
We used to `setupFrames()` only when setting up the view for the first time. This caused the height to be wrong if one of the shelves disappeared or reappeared. We should always update the height, since the state could have changed.

# Version Change

None, merging this into Sutha's PR #1083 
