### PR TITLE
Front page: Fix pull-to-refresh bug where all data is reloaded in a loop

### DIFF
--- a/Demo/Sources/Fullscreen/FrontPage/FrontPageViewDemoView.swift
+++ b/Demo/Sources/Fullscreen/FrontPage/FrontPageViewDemoView.swift
@@ -27,7 +27,7 @@ public class FrontpageViewDemoView: UIView {
                                                 adsButtonTitle: "Se annonsene")
         view.showChristmasPromotion(withModel: model, andDelegate: self)
         
-        let shelfModel = FrontPageShelfViewModel(favoritedItems:RecentlyFavoritedFactory.create(numberOfItems: 10),
+        let shelfModel = FrontPageShelfViewModel(favoritedItems: RecentlyFavoritedFactory.create(numberOfItems: 10),
                                                  savedSearchItems: SavedSearchShelfFactory.create(numberOfItems: 10),
                                                  sectionTitles: ["Lagrede søk", "Nylige favoritter"],
                                                  buttonTitles: ["Se alle", "Se alle"])

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -119,8 +119,10 @@ public class AdRecommendationsGridView: UIView {
     // MARK: - Public methods
 
     public func reloadData() {
-        endRefreshing()
         collectionView.reloadData()
+        collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
+            self?.endRefreshing()
+        })
     }
 
     public func endRefreshing() {

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -120,9 +120,11 @@ public class AdRecommendationsGridView: UIView {
 
     public func reloadData() {
         collectionView.reloadData()
-        collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
-            self?.endRefreshing()
-        })
+        if refreshControl.isRefreshing {
+            collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
+                self?.endRefreshing()
+            })
+        }
     }
 
     public func endRefreshing() {


### PR DESCRIPTION
# Why?

We have a bug with pull-to-refresh on the front page, where all data is reloaded multiple times. If you do a pretty fast pull, it's often reloaded twice. If you hold on a little bit longer, we just keep reloading in a loop. The view jumps up and down while doing so.

# What?

I found the problem is that for some reason - the collection view's content offset is 0 for a split second when doing `reloadData()`.
So say the offset is 100, we `reloadData()` in the collection view, content offset drops to 0, then is goes right back to 100.
Our `RefreshControl` treats that as a new pull-to-refresh, and notifies views to start refreshing again. This goes on in a loop until you let go.

I found one simple way of fixing this.
If we do a `collectionView.reloadData()` followed by `collectionView.performBatchUpdates()`, the collection view should have finished reloading it's content in the completion block of the latter. If we move `endRefreshing()` there, the glitch where the content offset is 0 happens while the `RefreshControl` is still in "refresh" mode, not after, so it doesn't trigger a new refresh.

# Version Change

Patch

# UI Changes


| Before | After |
| --- | --- |
| ![RPReplay_Final1643961285](https://user-images.githubusercontent.com/17450858/152495184-5e1bf13a-02e6-44e9-9fe6-8b013cb60566.gif) | ![RPReplay_Final1643961224](https://user-images.githubusercontent.com/17450858/152495498-787d6f73-8235-49fa-9af1-f728b11a0c0c.gif) |
