### PR TITLE
Fix: Support country code in phone number regex

### DIFF
--- a/FinniversKit/Sources/Components/TextField/TextField.swift
+++ b/FinniversKit/Sources/Components/TextField/TextField.swift
@@ -140,7 +140,7 @@ public class TextField: UIView {
     public let inputType: InputType
     public let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
 
-    public var phoneNumberRegEx = "^(?:\\s*\\d){8,11}$"
+    public var phoneNumberRegEx = "^((\\+|00)\\d{2}\\s?)?(?:\\s*\\d){8,11}$"
 
     public var placeholderText: String = "" {
         didSet {


### PR DESCRIPTION
# Why?
The numbers we receive from the backend contains country code, which is not supported by the current regex in `TextField`.

Test the regex here:
https://regex101.com/r/EeGAxD/1

It will now support either an optional `00xx` or `+xx` as country code prefix.

# What?
- Update to support country codes.

# Version Change
Patch.

# UI Changes
_No UI changes._