### PR TITLE
Fix: `IconCollectionView` cell sizes

### DIFF
--- a/Demo/Sources/Components/IconCollection/IconCollectionViewDemo.swift
+++ b/Demo/Sources/Components/IconCollection/IconCollectionViewDemo.swift
@@ -11,10 +11,10 @@ public class IconCollectionDemoView: UIView, Tweakable {
     lazy var tweakingOptions: [TweakingOption] = {
         [
             .init(title: "Vertical alignment") { [weak self] in
-                self?.collectionViewAlignment = .vertical
+                self?.setupIconCollectionView(withAlignment: .vertical)
             },
             .init(title: "Horizontal alignment") { [weak self] in
-                self?.collectionViewAlignment = .horizontal
+                self?.setupIconCollectionView(withAlignment: .horizontal)
             }
         ]
     }()
@@ -22,12 +22,6 @@ public class IconCollectionDemoView: UIView, Tweakable {
     // MARK: - Private properties
 
     private var collectionView: IconCollectionView?
-
-    private var collectionViewAlignment = IconCollectionView.Alignment.vertical {
-        didSet {
-            setupIconCollectionView(withAlignment: collectionViewAlignment)
-        }
-    }
 
     // MARK: - Init
 
@@ -44,7 +38,7 @@ public class IconCollectionDemoView: UIView, Tweakable {
 
     private func setup() {
         backgroundColor = .bgPrimary
-        setupIconCollectionView(withAlignment: collectionViewAlignment)
+        tweakingOptions.first?.action?()
     }
 
     // MARK: - Private methods

--- a/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
@@ -139,9 +139,11 @@ extension IconCollectionView: UICollectionViewDelegateFlowLayout {
         margins
     }
 
-    public func collectionView(_ collectionView: UICollectionView,
-                               layout collectionViewLayout: UICollectionViewLayout,
-                               sizeForItemAt indexPath: IndexPath) -> CGSize {
+    public func collectionView(
+        _ collectionView: UICollectionView,
+       layout collectionViewLayout: UICollectionViewLayout,
+       sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
         let viewModel = viewModels[indexPath.item]
         let width = cellWidth(forWidth: collectionView.frame.width - margins.horizontalMargins, viewModel: viewModel)
         let height = cellHeight(for: viewModel, withWidth: width)
@@ -151,7 +153,7 @@ extension IconCollectionView: UICollectionViewDelegateFlowLayout {
 
     private func cellWidth(forWidth width: CGFloat, viewModel: IconCollectionViewModel) -> CGFloat {
         let width = isHorizontalSizeClassRegular
-            ? max(width / CGFloat(viewModels.count), viewModel.image.size.width * 2)
+            ? max(width / min(4, CGFloat(viewModels.count)), viewModel.image.size.width * 2)
             : width / 2
         return width
     }


### PR DESCRIPTION
# Why?
I noticed an issue with `IconCollectionView` when implementing EFS. These ads usually have more than 4 items presented, and the size calculation was not prepared for this.

# What?
- Make cells take <25% of available width when `horizontalSizeClass == .regular`.

# Version Change
Patch

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-03-15 at 14 18 56](https://user-images.githubusercontent.com/1901556/158389893-f4ecf661-3c42-415d-922f-dcea6b6ba93e.png) | ![Screenshot 2022-03-15 at 14 34 34](https://user-images.githubusercontent.com/1901556/158389902-fb5fb48b-411b-4659-86a3-44f31e00eb53.png) |