### PR TITLE
OverflowCollectionView: Offer delegate to configure cell, if needed

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
@@ -2,11 +2,11 @@ import UIKit
 
 public protocol OverflowCollectionViewDelegate: AnyObject {
     func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didSelectItemAtIndex index: Int)
-    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didDequeueCell cell: Cell)
+    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didConfigureCell cell: Cell, atIndex index: Int)
 }
 
 public extension OverflowCollectionViewDelegate {
-    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didDequeueCell cell: Cell) {}
+    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didConfigureCell cell: Cell, atIndex index: Int) {}
 }
 
 public class OverflowCollectionView<Cell: OverflowCollectionViewCell>: UIView, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -87,7 +87,7 @@ public class OverflowCollectionView<Cell: OverflowCollectionViewCell>: UIView, U
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(cellType.self, for: indexPath)
         cell.configure(using: models[indexPath.item])
-        delegate?.overflowCollectionView(self, didDequeueCell: cell)
+        delegate?.overflowCollectionView(self, didConfigureCell: cell, atIndex: indexPath.item)
         return cell
     }
 

--- a/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
@@ -2,6 +2,11 @@ import UIKit
 
 public protocol OverflowCollectionViewDelegate: AnyObject {
     func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didSelectItemAtIndex index: Int)
+    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didDequeueCell cell: Cell)
+}
+
+public extension OverflowCollectionViewDelegate {
+    func overflowCollectionView<Cell>(_ view: OverflowCollectionView<Cell>, didDequeueCell cell: Cell) {}
 }
 
 public class OverflowCollectionView<Cell: OverflowCollectionViewCell>: UIView, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -82,6 +87,7 @@ public class OverflowCollectionView<Cell: OverflowCollectionViewCell>: UIView, U
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(cellType.self, for: indexPath)
         cell.configure(using: models[indexPath.item])
+        delegate?.overflowCollectionView(self, didDequeueCell: cell)
         return cell
     }
 


### PR DESCRIPTION
# Why?
I need to re-use one cell for `OverflowCollectionView` in multiple places, but I need to configure the label dynamically. This isn't possible today, so I'm adding an optional method to the delegate protocol for this which will be called after the cell has been dequeued and configured by the view.

# What?
- Added method `overflowCollectionView<Cell>(_:didConfigureCell:atIndex:)`.

# Version Change
Minor. There is a default implementation for the delegate method.

# UI Changes
_No UI._