### PR TITLE
Fix: Make it possible to enable/disable button in FooterButtonView

### DIFF
--- a/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
+++ b/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
@@ -19,6 +19,11 @@ public final class FooterButtonView: TopShadowView {
         }
     }
 
+    public var isEnabled: Bool {
+        get { button.isEnabled }
+        set { button.isEnabled = newValue }
+    }
+
     // MARK: - Private properties
 
     private let button: UIButton = {


### PR DESCRIPTION
# Why?
I want to reuse this view, but I need to disable the button in a few scenarios.

# What?
- Added property `isEnabled` to `FooterButtonView`.

# Version Change
Patch.
