### PR TITLE
Fix: SelectionListView accessibility

### DIFF
--- a/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
@@ -129,7 +129,29 @@ class SelectionListItemView: UIView {
             detailViewsStackViewBottomConstraint,
         ])
 
+        setupAccessibility()
         updateSelection(shouldAnimate: false)
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+
+        let description = { () -> String in
+            switch model.description {
+            case .plain(let text):
+                return text
+            case .attributed(let attributedText):
+                return attributedText.string
+            }
+        }()
+
+        var detailItemsString: String?
+        if let detailItems = model.detailItems, !detailItems.isEmpty {
+            detailItemsString = detailItems.joined(separator: ", ")
+        }
+
+        accessibilityLabel = [model.title, description, detailItemsString].compactMap { $0 }.joined(separator: ", ")
     }
 
     // MARK: - Private methods

--- a/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
@@ -165,6 +165,12 @@ class SelectionListItemView: UIView {
             }
         }
 
+        if isSelected {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
+
         let duration = shouldAnimate ? 0.15 : 0
         UIView.animate(withDuration: duration, animations: { [weak self] in
             guard let self = self else { return }


### PR DESCRIPTION
# Why?
The view `SelectionListView` had not been set as accessibility element, and was hard to read using VoiceOver.

# What?
- Set it as accessibility element and set its label.
- Set/remove accessibilityTrait `.selected` when view is selected/deselected.

# Version Change
Patch.

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-06-16 at 10 24 52](https://user-images.githubusercontent.com/1901556/174026945-91896806-7053-44d2-99ab-fd685b91c6f9.png) | ![Screenshot 2022-06-16 at 10 24 32](https://user-images.githubusercontent.com/1901556/174026953-17d28030-0838-42ba-ac37-b37b05198ff3.png) | 