### PR TITLE
Fix: AddressComponentView accessibility

### DIFF
--- a/Demo/Sources/Components/AddressComponentView/AddressComponentDemoView.swift
+++ b/Demo/Sources/Components/AddressComponentView/AddressComponentDemoView.swift
@@ -42,13 +42,13 @@ extension AddressComponentDemoView: AddressComponentViewDelegate {
 private extension Array where Element == AddressComponentKind {
     static var demoItems: [AddressComponentKind] {
         [
-            .regular(.init(value: "Vei veien", placeholder: "Gatenavn")),
-            .regular(.init(value: "123", placeholder: "Gatenummer")),
-            .regular(.init(value: "1", placeholder: "Etasje")),
-            .regular(.init(value: nil, placeholder: "Leilighet")),
+            .regular(.init(value: "Vei veien", placeholder: "Gatenavn", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: "123", placeholder: "Gatenummer", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: "1", placeholder: "Etasje", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: nil, placeholder: "Leilighet", noValueAccessibilityLabel: "Ikke fylt ut")),
             .postalCodeAndPlace(
-                postalCode: .init(value: "0001", placeholder: "Postnummer"),
-                postalPlace: .init(value: "Oslo", placeholder: "Poststed")
+                postalCode: .init(value: "0001", placeholder: "Postnummer", noValueAccessibilityLabel: "Fyll inn adresse først"),
+                postalPlace: .init(value: "Oslo", placeholder: "Poststed", noValueAccessibilityLabel: "Fyll inn adresse først")
             )
         ]
     }

--- a/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
@@ -7,10 +7,12 @@ public enum AddressComponentKind {
     public struct Model {
         public let value: String?
         public let placeholder: String
+        public let noValueAccessibilityLabel: String?
 
-        public init(value: String?, placeholder: String) {
+        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String?) {
             self.value = value
             self.placeholder = placeholder
+            self.noValueAccessibilityLabel = noValueAccessibilityLabel
         }
     }
 }

--- a/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
@@ -9,7 +9,7 @@ public enum AddressComponentKind {
         public let placeholder: String
         public let noValueAccessibilityLabel: String?
 
-        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String?) {
+        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String? = nil) {
             self.value = value
             self.placeholder = placeholder
             self.noValueAccessibilityLabel = noValueAccessibilityLabel

--- a/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentFieldView.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentFieldView.swift
@@ -56,6 +56,13 @@ public class AddressComponentFieldView: UIView {
             hairlineView.bottomAnchor.constraint(equalTo: bottomAnchor),
             hairlineView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale)
         ])
+
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
     }
 
     // MARK: - Internal methods
@@ -79,6 +86,8 @@ public class AddressComponentFieldView: UIView {
             stackView.addArrangedSubview(placeholderLabel)
             stackView.alignment = .leading
         }
+
+        accessibilityLabel = [model.placeholder, model.value ?? model.noValueAccessibilityLabel].compactMap { $0 }.joined(separator: ": ")
     }
 }
 

--- a/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentPostalFieldView.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentPostalFieldView.swift
@@ -36,6 +36,8 @@ public class AddressComponentPostalFieldView: UIView {
     // MARK: - Setup
 
     private func setup() {
+        isAccessibilityElement = true
+
         backgroundColor = .bgTertiary
 
         addSubview(stackView)
@@ -73,6 +75,10 @@ public class AddressComponentPostalFieldView: UIView {
         ])
 
         hairlineView.backgroundColor = showHairline ? .placeholderText : .clear
+
+        accessibilityLabel = [postalCodeModel, postalPlaceModel].map { model in
+            [model.placeholder, model.value ?? model.noValueAccessibilityLabel].compactMap { $0 }.joined(separator: ": ")
+        }.joined(separator: ", ")
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
# Why?
**This PR points to my other PR/branch in #1121**

The view `AddressComponentView` had not been set as accessibility element, and was hard to read using VoiceOver.

# What?
- Add optional property `noValueAccessibilityLabel` to `AddressComponentKind.Model`.
- Set `accessibilityLabel` in `AddressComponentFieldView` and `AddressComponentPostalFieldView`.

# Version Change
Patch. Optional property with default value added.

# UI Changes

| Before | After |
| --- | --- |
| ![Screenshot 2022-06-16 at 12 06 56](https://user-images.githubusercontent.com/1901556/174051016-a64fc2cf-f3e2-4230-9997-58d90715bfea.png) | ![Screenshot 2022-06-16 at 12 21 50](https://user-images.githubusercontent.com/1901556/174051031-d87d035d-7d41-418b-9837-11bd7d43040e.png) |