### PR TITLE
Fix: SearchView accessibility

### DIFF
--- a/Demo/Sources/Components/AddressComponentView/AddressComponentDemoView.swift
+++ b/Demo/Sources/Components/AddressComponentView/AddressComponentDemoView.swift
@@ -42,13 +42,13 @@ extension AddressComponentDemoView: AddressComponentViewDelegate {
 private extension Array where Element == AddressComponentKind {
     static var demoItems: [AddressComponentKind] {
         [
-            .regular(.init(value: "Vei veien", placeholder: "Gatenavn")),
-            .regular(.init(value: "123", placeholder: "Gatenummer")),
-            .regular(.init(value: "1", placeholder: "Etasje")),
-            .regular(.init(value: nil, placeholder: "Leilighet")),
+            .regular(.init(value: "Vei veien", placeholder: "Gatenavn", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: "123", placeholder: "Gatenummer", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: "1", placeholder: "Etasje", noValueAccessibilityLabel: "Ikke fylt ut")),
+            .regular(.init(value: nil, placeholder: "Leilighet", noValueAccessibilityLabel: "Ikke fylt ut")),
             .postalCodeAndPlace(
-                postalCode: .init(value: "0001", placeholder: "Postnummer"),
-                postalPlace: .init(value: "Oslo", placeholder: "Poststed")
+                postalCode: .init(value: "0001", placeholder: "Postnummer", noValueAccessibilityLabel: "Fyll inn adresse først"),
+                postalPlace: .init(value: "Oslo", placeholder: "Poststed", noValueAccessibilityLabel: "Fyll inn adresse først")
             )
         ]
     }

--- a/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
@@ -7,10 +7,12 @@ public enum AddressComponentKind {
     public struct Model {
         public let value: String?
         public let placeholder: String
+        public let noValueAccessibilityLabel: String?
 
-        public init(value: String?, placeholder: String) {
+        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String?) {
             self.value = value
             self.placeholder = placeholder
+            self.noValueAccessibilityLabel = noValueAccessibilityLabel
         }
     }
 }

--- a/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Models/AddressComponentKind.swift
@@ -9,7 +9,7 @@ public enum AddressComponentKind {
         public let placeholder: String
         public let noValueAccessibilityLabel: String?
 
-        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String?) {
+        public init(value: String?, placeholder: String, noValueAccessibilityLabel: String? = nil) {
             self.value = value
             self.placeholder = placeholder
             self.noValueAccessibilityLabel = noValueAccessibilityLabel

--- a/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentFieldView.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentFieldView.swift
@@ -56,6 +56,13 @@ public class AddressComponentFieldView: UIView {
             hairlineView.bottomAnchor.constraint(equalTo: bottomAnchor),
             hairlineView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale)
         ])
+
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
     }
 
     // MARK: - Internal methods
@@ -79,6 +86,8 @@ public class AddressComponentFieldView: UIView {
             stackView.addArrangedSubview(placeholderLabel)
             stackView.alignment = .leading
         }
+
+        accessibilityLabel = [model.placeholder, model.value ?? model.noValueAccessibilityLabel].compactMap { $0 }.joined(separator: ": ")
     }
 }
 

--- a/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentPostalFieldView.swift
+++ b/FinniversKit/Sources/Components/AddressComponentView/Subviews/AddressComponentPostalFieldView.swift
@@ -36,6 +36,8 @@ public class AddressComponentPostalFieldView: UIView {
     // MARK: - Setup
 
     private func setup() {
+        isAccessibilityElement = true
+
         backgroundColor = .bgTertiary
 
         addSubview(stackView)
@@ -73,6 +75,10 @@ public class AddressComponentPostalFieldView: UIView {
         ])
 
         hairlineView.backgroundColor = showHairline ? .placeholderText : .clear
+
+        accessibilityLabel = [postalCodeModel, postalPlaceModel].map { model in
+            [model.placeholder, model.value ?? model.noValueAccessibilityLabel].compactMap { $0 }.joined(separator: ": ")
+        }.joined(separator: ", ")
     }
 
     // MARK: - Private methods

--- a/FinniversKit/Sources/Components/SearchView/SearchView.swift
+++ b/FinniversKit/Sources/Components/SearchView/SearchView.swift
@@ -34,6 +34,7 @@ public class SearchView: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.textField.returnKeyType = .search
         view.delegate = self
+        view.accessibilityTraits = .searchField
         return view
     }()
 
@@ -75,6 +76,8 @@ public class SearchView: UIView {
     public func configureSearchTextField(placeholder: String, text: String?) {
         searchTextField.textField.placeholder = placeholder
         searchTextField.textField.text = text
+
+        setAccessibilityLabel(searchText: text)
     }
 
     // MARK: - Overrides
@@ -85,6 +88,16 @@ public class SearchView: UIView {
 
     public override func becomeFirstResponder() -> Bool {
         searchTextField.becomeFirstResponder()
+    }
+
+    // MARK: - Private methods
+
+    private func setAccessibilityLabel(searchText: String?) {
+        if let searchText = searchText, !searchText.isEmpty {
+            searchTextField.accessibilityLabel = searchText
+        } else {
+            searchTextField.accessibilityLabel = searchTextField.textField.placeholder
+        }
     }
 }
 
@@ -115,6 +128,7 @@ extension SearchView: UITableViewDataSource {
 
 extension SearchView: TextFieldDelegate {
     public func textFieldDidChange(_ textField: TextField) {
+        setAccessibilityLabel(searchText: textField.text)
         delegate?.searchView(self, didChangeSearchText: textField.text)
     }
 }


### PR DESCRIPTION
# Why?
**Points to my other PR/branch in #1122.**

The view `SearchView` had not been set as accessibility element, and was hard to read using VoiceOver.

# What?
- Add `accessibilityLabel` and set `accessibilityTraits` to `.searchField` for the searchfield within this view.

# Version Change
Patch.

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-06-16 at 13 05 23](https://user-images.githubusercontent.com/1901556/174058069-7f301794-b7ba-48b8-b1df-ebee2cf717fe.png) | ![Screenshot 2022-06-16 at 13 10 29](https://user-images.githubusercontent.com/1901556/174058084-91b675e9-03d5-4cbd-afa1-5038688255d6.png) |