### PR TITLE
Fiks ferdig promo redesign

### DIFF
--- a/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
@@ -95,15 +95,15 @@ public class PromotionView: UIView {
         imageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor, constant: -.spacingXXL),
         imageView.topAnchor.constraint(equalTo: imageContainer.topAnchor),
         imageView.leadingAnchor.constraint(equalTo: backgroundImageContainer.leadingAnchor, constant: .spacingM),
-        imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: imageRatio ?? 1),
-        ]
+        imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: viewModel.imageRatio),
+    ]
     private lazy var regularDynamicConstraint: [NSLayoutConstraint] = [
         imageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
         imageView.topAnchor.constraint(equalTo: imageContainer.topAnchor),
         imageView.leadingAnchor.constraint(equalTo: backgroundImageContainer.leadingAnchor, constant: .spacingM),
-        imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: imageRatio ?? 1),
-        ]
-    private var imageRatio: CGFloat?
+        imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: viewModel.imageRatio),
+    ]
+    private var viewModel: PromotionViewModel
 
     // MARK: - Public properties
 
@@ -117,6 +117,7 @@ public class PromotionView: UIView {
     // MARK: - Init
 
     public init(viewModel: PromotionViewModel) {
+        self.viewModel = viewModel
         super.init(frame: .zero)
         setup()
         configure(with: viewModel)
@@ -130,7 +131,6 @@ public class PromotionView: UIView {
         titleLabel.text = viewModel.title
         primaryButton.configure(withTitle: viewModel.primaryButtonTitle)
         secondaryButton.configure(withTitle: viewModel.secondaryButtonTitle)
-        imageRatio = viewModel.image.size.width / viewModel.image.size.height
 
         if let text = viewModel.text {
             textLabel.text = text
@@ -151,7 +151,7 @@ public class PromotionView: UIView {
         case .fullWidth:
             imageView.fillInSuperview(insets: UIEdgeInsets(top: .spacingM, leading: .spacingS, bottom: -.spacingM, trailing: -.spacingS))
         case .trailing:
-            guard let imageRatio = imageRatio else { return }
+            let imageRatio = viewModel.imageRatio
             NSLayoutConstraint.activate([
                 imageView.topAnchor.constraint(equalTo: imageContainer.topAnchor),
                 imageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
@@ -159,10 +159,10 @@ public class PromotionView: UIView {
                 imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: imageRatio),
             ])
         case .dynamic:
-            if isCompactScreen() {
-                activateCompactConstraints()
-            } else {
+            if UITraitCollection.isHorizontalSizeClassRegular {
                 activateRegularConstraints()
+            } else {
+                activateCompactConstraints()
             }
         }
 
@@ -185,10 +185,10 @@ public class PromotionView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass {
-            if isCompactScreen() {
-                activateCompactConstraints()
-            } else {
+            if UITraitCollection.isHorizontalSizeClassRegular {
                 activateRegularConstraints()
+            } else {
+                activateCompactConstraints()
             }
         }
     }

--- a/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
@@ -158,7 +158,7 @@ public class PromotionView: UIView {
                 imageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
                 imageView.widthAnchor.constraint(lessThanOrEqualTo: imageView.heightAnchor, multiplier: imageRatio),
             ])
-        case .fullWidthDynamic:
+        case .dynamic:
             if isCompactScreen() {
                 activateCompactConstraints()
             } else {

--- a/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
@@ -6,6 +6,7 @@ public struct PromotionViewModel {
     let image: UIImage
     let imageAlignment: ImageAlignment
     let imageBackgroundColor: UIColor?
+    let backgroundImage: UIImage?
     let primaryButtonTitle: String?
     let secondaryButtonTitle: String?
 
@@ -13,6 +14,7 @@ public struct PromotionViewModel {
     public enum ImageAlignment {
         case trailing
         case fullWidth
+        case fullWidthDynamic
     }
 
     public init(
@@ -21,6 +23,7 @@ public struct PromotionViewModel {
         image: UIImage,
         imageAlignment: ImageAlignment,
         imageBackgroundColor: UIColor? = nil,
+        backgroundImage: UIImage? = nil,
         primaryButtonTitle: String? = nil,
         secondaryButtonTitle: String? = nil
     ) {
@@ -29,6 +32,7 @@ public struct PromotionViewModel {
         self.image = image
         self.imageAlignment = imageAlignment
         self.imageBackgroundColor = imageBackgroundColor
+        self.backgroundImage = backgroundImage
         self.primaryButtonTitle = primaryButtonTitle
         self.secondaryButtonTitle = secondaryButtonTitle
     }

--- a/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
@@ -14,7 +14,7 @@ public struct PromotionViewModel {
     public enum ImageAlignment {
         case trailing
         case fullWidth
-        case fullWidthDynamic
+        case dynamic
     }
 
     public init(

--- a/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionViewModel.swift
@@ -37,3 +37,9 @@ public struct PromotionViewModel {
         self.secondaryButtonTitle = secondaryButtonTitle
     }
 }
+
+extension PromotionViewModel {
+     var imageRatio: CGFloat {
+          image.size.width / image.size.height
+     }
+}


### PR DESCRIPTION
# Why?

There is a new design for the frontpage promotion banner with a background image and different constraints for the top-image (Fiks ferdig logo) depending on screen width. 

# What?

Added option for a background image to PromotionViewModel and PromotionView. Also added a case for image placement called dynamic, that changes according to screen width available. 

# Version Change

Minor.

# UI Changes

![QuickTime movie](https://user-images.githubusercontent.com/49304658/175239572-f2bd8c5e-0856-4a21-aa41-1e9222d641d8.gif)

