### PR TITLE
Fix: Size bug with image gallery

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
+++ b/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
@@ -109,7 +109,7 @@ public class FullscreenGalleryViewController: UIPageViewController {
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        currentImageViewController()?.updateLayout(withPreviewViewVisible: overlayView.previewViewVisible)
+        currentImageViewController()?.updateLayout(containerSize: view.bounds.size, withPreviewViewVisible: overlayView.previewViewVisible)
 
         if !hasPerformedInitialPreviewScroll {
             if let currentIndex = currentImageViewController()?.imageIndex {
@@ -150,11 +150,11 @@ public class FullscreenGalleryViewController: UIPageViewController {
 
         UIView.animate(withDuration: 0.5, delay: 0.0, usingSpringWithDamping: 0.6, initialSpringVelocity: 0.0, options: [], animations: {
             self.overlayView.setThumbnailPreviewsVisible(visible)
-            self.viewControllers?.forEach({ vc in
+            self.viewControllers?.forEach({ [weak self] vc in
                 guard let imageVc = vc as? FullscreenImageViewController else {
                     return
                 }
-                imageVc.updateLayout(withPreviewViewVisible: visible)
+                imageVc.updateLayout(containerSize: self?.view.bounds.size, withPreviewViewVisible: visible)
             })
         })
     }
@@ -188,9 +188,9 @@ public class FullscreenGalleryViewController: UIPageViewController {
 
         view.layoutIfNeeded()
         overlayView.setThumbnailPreviewsVisible(visible)
-        viewControllers?.forEach({ vc in
+        viewControllers?.forEach({ [weak self] vc in
             guard let imageVc = vc as? FullscreenImageViewController else { return }
-            imageVc.updateLayout(withPreviewViewVisible: visible)
+            imageVc.updateLayout(containerSize: self?.view.bounds.size, withPreviewViewVisible: visible)
         })
     }
 
@@ -234,7 +234,7 @@ extension FullscreenGalleryViewController: UIPageViewControllerDataSource {
         let vc = FullscreenImageViewController(imageIndex: translatedindex)
         vc.delegate = self
         vc.dataSource = self
-        vc.updateLayout(withPreviewViewVisible: overlayView.previewViewVisible)
+        vc.updateLayout(containerSize: view.bounds.size, withPreviewViewVisible: overlayView.previewViewVisible)
         return vc
     }
 }
@@ -252,9 +252,9 @@ extension FullscreenGalleryViewController: UIPageViewControllerDelegate {
     }
 
     public func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
-        pendingViewControllers.forEach({ vc in
+        pendingViewControllers.forEach({ [weak self] vc in
             guard let imageVc = vc as? FullscreenImageViewController else { return }
-            imageVc.updateLayout(withPreviewViewVisible: overlayView.previewViewVisible)
+            imageVc.updateLayout(containerSize: self?.view.bounds.size, withPreviewViewVisible: overlayView.previewViewVisible)
         })
     }
 }

--- a/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
+++ b/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenImageViewController.swift
@@ -109,16 +109,16 @@ class FullscreenImageViewController: UIViewController {
 
     // MARK: - Public methods
 
-    func updateLayout(withPreviewViewVisible previewViewVisible: Bool) {
+    func updateLayout(containerSize: CGSize? = nil, withPreviewViewVisible previewViewVisible: Bool) {
         self.previewViewVisible = previewViewVisible
-        fullscreenImageView.frame = calculateImageFrame()
+        fullscreenImageView.frame = calculateImageFrame(containerSize: containerSize)
         fullscreenImageView.recalculateLimitsAndBounds()
     }
 
     // MARK: - Private methods
 
-    private func calculateImageFrame() -> CGRect {
-        return calculateImageFrame(fromSize: view.bounds.size)
+    private func calculateImageFrame(containerSize: CGSize? = nil) -> CGRect {
+        calculateImageFrame(fromSize: containerSize ?? view.bounds.size)
     }
 
     private func calculateImageFrame(fromSize size: CGSize) -> CGRect {


### PR DESCRIPTION
# Why?
The full screen image gallery had an issue where the image you're swiping to would "jump" into the correct size when the swipe is finished. This is mostly visible on iPad, especially when multitasking.

The issue seems to be that the size calculation of the view happens before it's frame is set properly, so it takes the whole width of the screen before "jumping" into the correct size once the frame is set and the size of the view is recalculated.

# What?
- Pass the size of the container to the VC handling each full screen image.

# Version Change
Patch. No API changes.

# UI Changes
Sorry for the 2 FPS gifs 😅 The issue is still visible, even though it hurts to watch.

| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPad Air (5th generation) - 2022-07-01 at 14 33 48](https://user-images.githubusercontent.com/1901556/176895609-740babb4-6e7d-401d-90c3-db679fb1c6ee.gif) | ![Simulator Screen Recording - iPad Air (5th generation) - 2022-07-01 at 14 32 57](https://user-images.githubusercontent.com/1901556/176895618-9b6084b5-44d9-4392-946a-322665f8c8e3.gif) |