### PR TITLE
A11y: StatisticsItemView

### DIFF
--- a/FinniversKit/Sources/Components/StatisticsView/StatisticsItemModel.swift
+++ b/FinniversKit/Sources/Components/StatisticsView/StatisticsItemModel.swift
@@ -21,6 +21,6 @@ public struct StatisticsItemModel {
         self.type = type
         self.value = value
         self.text = text
-        self.accessibilityLabel = "\(value)" + text
+        accessibilityLabel = "\(value) \(text)"
     }
 }

--- a/FinniversKit/Sources/Components/StatisticsView/StatisticsItemView.swift
+++ b/FinniversKit/Sources/Components/StatisticsView/StatisticsItemView.swift
@@ -8,6 +8,8 @@ public class StatisticsItemView: UIView {
 
     // MARK: - Private
 
+    private let model: StatisticsItemModel
+
     private lazy var imageView: UIImageView = {
         let view = UIImageView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -62,6 +64,7 @@ public class StatisticsItemView: UIView {
     // MARK: - Initalization
 
     init(model: StatisticsItemModel) {
+        self.model = model
         super.init(frame: .zero)
 
         let formatter = NumberFormatter()
@@ -98,6 +101,9 @@ public class StatisticsItemView: UIView {
     // MARK: - Private methods
 
     private func setup() {
+        isAccessibilityElement = true
+        accessibilityLabel = model.accessibilityLabel
+
         addSubview(imageView)
         addSubview(valueLabel)
         addSubview(textLabel)

--- a/FinniversKit/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementStatisticsCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/AdManagement/Cells/UserAdManagementStatisticsCell.swift
@@ -24,6 +24,7 @@ public class UserAdManagementStatisticsCell: UITableViewCell {
     private lazy var titleLabel: Label = {
         let label = Label(style: .bodyStrong, withAutoLayout: true)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.accessibilityTraits = .header
         return label
     }()
 


### PR DESCRIPTION
# Why?
The view `StatisticsItemView` were hard to read using VoiceOver, since the element wasn't an accessibility element.

# What?
- Define title label as header.
- Set accessibility label on each item view.

# Version Change
Patch.

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-07-04 at 08 47 20](https://user-images.githubusercontent.com/1901556/177098497-cfb1cfbd-e69f-41ab-9657-5d45b6dee5b5.png) | ![Screenshot 2022-07-04 at 08 52 42](https://user-images.githubusercontent.com/1901556/177098509-0b55ee82-7f4f-43ed-af04-d34019d24c77.png) |