### PR TITLE
A11y: Price view

### DIFF
--- a/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
+++ b/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
@@ -108,6 +108,13 @@ public class KeyValueGridView: UIView {
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(valueLabel)
 
+        stackView.isAccessibilityElement = true
+        if let accessibilityLabel = pair.accessibilityLabel {
+            stackView.accessibilityLabel = accessibilityLabel
+        } else {
+            stackView.accessibilityLabel = "\(pair.title): \(pair.value)"
+        }
+
         return stackView
     }
 

--- a/FinniversKit/Sources/Components/KeyValueGridView/KeyValuePair.swift
+++ b/FinniversKit/Sources/Components/KeyValueGridView/KeyValuePair.swift
@@ -1,9 +1,11 @@
 public struct KeyValuePair: Hashable {
     let title: String
     let value: String
+    let accessibilityLabel: String?
 
-    public init(title: String, value: String) {
+    public init(title: String, value: String, accessibilityLabel: String? = nil) {
         self.title = title
         self.value = value
+        self.accessibilityLabel = accessibilityLabel
     }
 }

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -154,7 +154,20 @@ private class PriceView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
-        accessibilityLabel = viewModel.accessibilityLabel
+        if let accessibilityLabel = viewModel.accessibilityLabel {
+            self.accessibilityLabel = accessibilityLabel
+        } else {
+            var accessibilityLabel = viewModel.totalPrice
+
+            if let title = viewModel.title {
+                accessibilityLabel = "\(title): \(accessibilityLabel)"
+            }
+
+            if let subtitle = viewModel.subtitle {
+                accessibilityLabel = "\(accessibilityLabel). \(subtitle)"
+            }
+            self.accessibilityLabel = accessibilityLabel
+        }
 
         titleLabel.text = viewModel.title
         titleLabel.isHidden = viewModel.title?.isEmpty ?? true


### PR DESCRIPTION
# Why?
We've had some accessibility issues on `PriceView`, where we would present no accessibility label if none were provided.

The same goes for `priceDetails`, which is a `KeyValueGrid`. I've added an optional `accessibilityLabel` property to the struct `KeyValuePair`. If none is provided there it'll concatenate the title and the value.

# What?
- Add optional property `accessibilityLabel` to `KeyValuePair`.
- Use 👆 or concatenate title/value in `KeyValueGridView`.
- Use values in `title`, `totalPrice` and `subtitle` to create the accessibilityLabel, if none is provided.

# Version Change
Patch. No API changes.

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-07-04 at 10 57 58](https://user-images.githubusercontent.com/1901556/177121095-02b16c2e-0d47-45a5-88f1-5c849e15be9d.png) | ![Screenshot 2022-07-04 at 10 57 20](https://user-images.githubusercontent.com/1901556/177121108-916a75a2-d371-452d-ba41-e4d8eb304819.png) |
| ![Screenshot 2022-07-04 at 10 57 53](https://user-images.githubusercontent.com/1901556/177121154-f7b65ea6-e836-4da0-869f-7cb26b7a5210.png) | ![Screenshot 2022-07-04 at 10 56 53](https://user-images.githubusercontent.com/1901556/177121178-5bdebd4f-cf4e-4ac9-97c3-6029d7893906.png) |
| ![Screenshot 2022-07-04 at 10 58 18](https://user-images.githubusercontent.com/1901556/177121208-264dd75c-f22b-43a8-b01c-94b0aecc0e9e.png) | ![Screenshot 2022-07-04 at 10 57 06](https://user-images.githubusercontent.com/1901556/177121242-49fd6ade-670e-4878-964c-1ec9094b9113.png) |