### PR TITLE
Fix: `FooterButtonView` button init issue

### DIFF
--- a/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
+++ b/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
@@ -26,7 +26,7 @@ public final class FooterButtonView: TopShadowView {
 
     // MARK: - Private properties
 
-    private let button: UIButton = {
+    private lazy var button: UIButton = {
         let button = Button(style: .callToAction, size: .normal, withAutoLayout: true)
         button.addTarget(self, action: #selector(handleButtonTap), for: .touchUpInside)
         return button


### PR DESCRIPTION
# Why?
Thanks to @MarenZR who, unfortunately, experienced the issue of being stuck on the shipping page we managed to track down the root issue.

The button within `FooterButtonView` was initialized as a `let` and not as a `lazy var`. Not sure how this was missed earlier, and why Xcode doesn't provide a warning, but AppCode managed to provide it.

![Screenshot 2022-07-05 at 11 52 40](https://user-images.githubusercontent.com/1901556/177301882-2de3e000-062f-4852-8119-a39a6183267d.png)

# What?
- Replace `let` with `lazy var`, since we use a reference to `self` for adding a target.

# Version Change
Patch.
