### PR TITLE
Fix: ContractActionView properties

### DIFF
--- a/FinniversKit/Sources/Components/ContractActionView/ContractActionView.swift
+++ b/FinniversKit/Sources/Components/ContractActionView/ContractActionView.swift
@@ -13,9 +13,9 @@ public class ContractActionView: UIView {
     // MARK: - Public properties
 
     public weak var delegate: ContractActionViewDelegate?
-    private(set) var identifier: String?
-    private(set) var buttonUrl: URL?
-    private(set) var videoUrl: URL?
+    public private(set) var identifier: String?
+    public private(set) var buttonUrl: URL?
+    public private(set) var videoUrl: URL?
 
     // MARK: - Private properties
 


### PR DESCRIPTION
# Why?
We need to get hold of a few of the properties from `ContractActionView, but they're currently only internal.

# What?
- Make properties public.

# Version Change
Patch.

# UI Changes
_No UI._