### PR TITLE
ObjectPageTitleView: Set accessibility elements

### DIFF
--- a/FinniversKit/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
+++ b/FinniversKit/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
@@ -71,6 +71,22 @@ public class ObjectPageTitleView: UIView {
     private func setup() {
         addSubview(stackView)
         stackView.fillInSuperview()
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = false
+        let accessibilityElements = [titleLabel, subtitleLabel, captionLabel, ribbonView]
+
+        accessibilityElements.forEach {
+            if $0 == titleLabel {
+                $0.accessibilityTraits = .header
+            } else {
+                $0.accessibilityTraits = .staticText
+            }
+        }
+
+        self.accessibilityElements = accessibilityElements
     }
 
     // MARK: - Public methods


### PR DESCRIPTION
# Why?
This view has a bunch of labels, but it's not as easy as it should be to find this view when using VoiceOver.

# What?
- Define the list/order of `accessibilityElements`, having the `titleLabel` first and giving it the `header` trait.
  - I placed `ribbonView` last in this list, I think this makes sense.
- Set all other labels to `staticText`.

# Version Change
Patch. No API changes.

# UI Changes
| Before | After |
| --- | --- |
| ![Screenshot 2022-07-11 at 12 12 06](https://user-images.githubusercontent.com/1901556/178246339-45d1e5c5-b86e-47f3-afab-8c22ef3833a6.png) | ![Screenshot 2022-07-11 at 12 11 15](https://user-images.githubusercontent.com/1901556/178246350-f5be52ca-3684-4790-9a77-922fe60912be.png) |