### PR TITLE
Fix APPS-4234: Confirmation View Dark mode appearance

### DIFF
--- a/FinniversKit/Sources/Fullscreen/AdReporter/ConfirmationView.swift
+++ b/FinniversKit/Sources/Fullscreen/AdReporter/ConfirmationView.swift
@@ -12,22 +12,19 @@ public class ConfirmationView: UIView {
     // MARK: - Private properties
 
     private lazy var titleLabel: Label = {
-        let label = Label(style: .title2)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        let label = Label(style: .title2, withAutoLayout: true)
         return label
     }()
 
     private lazy var messageLabel: Label = {
-        let label = Label(style: .body)
+        let label = Label(style: .body, withAutoLayout: true)
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private lazy var closeButton: Button = {
-        let button = Button(style: .flat)
-        button.translatesAutoresizingMaskIntoConstraints = false
+        let button = Button(style: .flat, withAutoLayout: true)
         return button
     }()
 
@@ -54,7 +51,7 @@ public class ConfirmationView: UIView {
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .white
+        backgroundColor = .bgPrimary
 
         let view = UIView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# Why?

Dark mode doesn't apply to ConfirmationView 
https://finn-jira.atlassian.net/browse/APPS-4234

# What?

Added correct background color

# Version Change

patch

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-12 at 10 04 07](https://user-images.githubusercontent.com/7100327/184311893-d5ca01ff-f5b6-4c5d-8b05-923d1b13e5ec.png)![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-12 at 10 04 17](https://user-images.githubusercontent.com/7100327/184311895-7cc8d8d0-2190-40e4-baec-2cfe75c55db7.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-12 at 10 02 06](https://user-images.githubusercontent.com/7100327/184311666-9b58a31d-927b-46cf-a9c8-61e8db601424.png)![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-12 at 10 02 16](https://user-images.githubusercontent.com/7100327/184311673-bc538ddc-7fd4-4f58-9636-df5465112f69.png) |


