### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import FinniversKit
 - Install dependencies listed in Gemfile with `bundle install` (dependencies will be installed in `./bundler`)
 - Fastlane will use the GitHub API, so make sure to create a personal access token [here](https://github.com/settings/tokens) and place it within an environment variable called **`FINNIVERSKIT_GITHUB_ACCESS_TOKEN`**.
   - When creating a token, you only need to give access to the scope `repo`.
-  - There are multiple ways to make an environment variable, for example by using a `.env` file or adding it to `.bashrc`/`.bash_profile`). Don't forget to run `source .env` (for whichever file you set the environment variables in) if you don't want to restart your shell.
+  - There are multiple ways to make an environment variable, for example by using a `.env` file or adding the following line to `.zshrc`/`.bashrc`/`.bash_profile`):<br/> `export FINNIVERSKIT_GITHUB_ACCESS_TOKEN="[Your access token]"`<br/> Don't forget to run `source .env` (for whichever file you set the environment variables in) if you don't want to restart your shell.
   - Run `bundle exec fastlane verify_environment_variable` to see if it is configured correctly.
 - Run `bundle exec fastlane verify_ssh_to_github` to see if ssh to GitHub is working.
 


### PR DESCRIPTION
Clarify how to add variable to `.zshrc` during setup.

# Why?

The readme does not include information on how to setup the environment variable for ZSH

# What?

Clarification is added on how to add the environment variable for ZSH

# Version Change

Minor

# UI Changes

None
