### PR TITLE
added dynamic textcolor for transaction feed

### DIFF
--- a/FinniversKit/Sources/Components/FrontPageTransactionView/FrontPageTransactionView.swift
+++ b/FinniversKit/Sources/Components/FrontPageTransactionView/FrontPageTransactionView.swift
@@ -13,18 +13,14 @@ public class FrontPageTransactionView: UIView {
     private let cornerRadius: CGFloat = 8
     
     private lazy var titleLabel: UILabel = {
-        let label = Label(withAutoLayout: true)
-        label.font = .bodyStrong
-        label.textColor = .licorice
+        let label = Label(style: .bodyStrong,withAutoLayout: true)
         label.numberOfLines = 1
         label.textAlignment = .left
         return label
     }()
     
     private lazy var subtitleLabel: UILabel = {
-        let label = Label(withAutoLayout: true)
-        label.font = .body
-        label.textColor = .licorice
+        let label = Label(style: .body, withAutoLayout: true)
         label.numberOfLines = 1
         label.textAlignment = .left
 


### PR DESCRIPTION
# Why?

Transaction Feed on front page did not have dynamic text color

# What?

Added Dynamic text color for Transaction Feed View

# Version Change
minor

# UI Changes

![Dark mode](https://user-images.githubusercontent.com/11430094/185102719-2fdd5ef4-a2b3-4694-bf2c-dfc02a17d614.png)

![Light mode](https://user-images.githubusercontent.com/11430094/185103007-89091538-c0ad-4399-9507-bfcad8e68a0e.png)

