### PR TITLE
Clear external icon image before reuse

### DIFF
--- a/FinniversKit/Sources/Cells/IconTitleTableViewCell/IconTitleTableViewCell.swift
+++ b/FinniversKit/Sources/Cells/IconTitleTableViewCell/IconTitleTableViewCell.swift
@@ -51,6 +51,7 @@ open class IconTitleTableViewCell: BasicTableViewCell {
         super.prepareForReuse()
         iconImageView.image = nil
         iconImageView.tintColor = UIImageView.appearance().tintColor
+        externalIconImageView.image = nil
     }
 
     open func configure(with viewModel: IconTitleTableViewCellViewModel) {


### PR DESCRIPTION
# Why?

The external icon isn't cleared before reuse, so it sometimes shows up in cells where it doesn't belong when the table view is reloaded.

# What?

Set the external icon image to nil before cell reuse.

# UI Changes

Before
https://user-images.githubusercontent.com/9058089/195339908-d71e3398-50ff-4b96-90b0-73ff9dc4980a.mp4

After
https://user-images.githubusercontent.com/9058089/195340142-5dc8e548-95f2-4bde-b912-1adace4be962.mp4

