### PR TITLE
Fix: Avoid duplicate labels on maps (from Apple map) when building with Xcode 14

### DIFF
--- a/FinniversKit/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
+++ b/FinniversKit/Sources/Fullscreen/SearchResultMapView/SearchResultMapView.swift
@@ -90,7 +90,7 @@ public final class SearchResultMapView: UIView {
             mapView.removeOverlay(lastOverlay)
         }
 
-        mapView.addOverlay(newOverlay)
+        mapView.addOverlay(newOverlay, level: .aboveLabels)
     }
 
     public func clearMapOverlay(_ overlay: MKTileOverlay) {


### PR DESCRIPTION
# Why?

When building the project with Xcode 14, the Apple map labels suddenly started overlapping our own tiles, thus we ended up with duplicate labels.

# What?

Specifying the tile should be placed `.aboveLabels` fixes the issue.

# Version Change

Patch

# UI Changes

For instance, see extra "Lillestrøm" label. Double "Gjerdrum" label.

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-11-03 at 10 34 53](https://user-images.githubusercontent.com/17450858/199688790-58825e1d-205a-49e9-8049-51cfafb4ab17.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-11-03 at 10 40 13](https://user-images.githubusercontent.com/17450858/199688825-ccd2341f-c3e4-4e69-9725-c751d9e61a07.png) |
