### PR TITLE
Accessibility fix for ObjectPageTitleView 

### DIFF
--- a/FinniversKit/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
+++ b/FinniversKit/Sources/Components/ObjectPageTitleView/ObjectPageTitleView.swift
@@ -23,7 +23,11 @@ public class ObjectPageTitleView: UIView {
     private let titleStyle: Label.Style
     private let subtitleStyle: Label.Style
     private let captionStyle: Label.Style
-    private lazy var ribbonView = RibbonView(withAutoLayout: true)
+    private lazy var ribbonView: RibbonView = {
+        let ribbonView = RibbonView(withAutoLayout: true)
+        ribbonView.accessibilityTraits = .staticText
+        return ribbonView
+    }()
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [ribbonView, titleLabel, subtitleLabel, captionLabel])
@@ -37,18 +41,21 @@ public class ObjectPageTitleView: UIView {
     private lazy var titleLabel: Label = {
         let label = Label(style: titleStyle, withAutoLayout: true)
         label.numberOfLines = 0
+        label.accessibilityTraits = .header
         return label
     }()
 
     private lazy var subtitleLabel: Label = {
         let label = Label(style: subtitleStyle, withAutoLayout: true)
         label.numberOfLines = 0
+        label.accessibilityTraits = .staticText
         return label
     }()
 
     private lazy var captionLabel: Label = {
         let label = Label(style: captionStyle, withAutoLayout: true)
         label.numberOfLines = 0
+        label.accessibilityTraits = .staticText
         return label
     }()
 
@@ -71,22 +78,6 @@ public class ObjectPageTitleView: UIView {
     private func setup() {
         addSubview(stackView)
         stackView.fillInSuperview()
-        setupAccessibility()
-    }
-
-    private func setupAccessibility() {
-        isAccessibilityElement = false
-        let accessibilityElements = [titleLabel, subtitleLabel, captionLabel, ribbonView]
-
-        accessibilityElements.forEach {
-            if $0 == titleLabel {
-                $0.accessibilityTraits = .header
-            } else {
-                $0.accessibilityTraits = .staticText
-            }
-        }
-
-        self.accessibilityElements = accessibilityElements
     }
 
     // MARK: - Public methods
@@ -115,5 +106,11 @@ public class ObjectPageTitleView: UIView {
 
         stackView.setCustomSpacing(spacingAfterTitle, after: titleLabel)
         stackView.setCustomSpacing(spacingAfterSubtitle, after: subtitleLabel)
+
+        isAccessibilityElement = false
+        let accessibilityElements = [titleLabel, subtitleLabel, captionLabel, ribbonView]
+        // On iOS 15 the hidden elements are still accessible for screen readers (and causes issues navigating further)
+        // so need to filter them out, this is not needed on iOS 16
+        self.accessibilityElements = accessibilityElements.filter({ !$0.isHidden })
     }
 }


### PR DESCRIPTION
# Why?
Screen readers on iOS 15 would get stuck on object page, not being able to read everything.

Since it works on iOS 16 I think we can say that the base for this is actually a bug in iOS, but we can still help our users on iOS 15 😄 

# What?
Filtering hidden views from accessibilityElements, this doesn't seem to be needed on iOS 16 but is still "safe" to include there as well.

# Version Change
Patch

# UI Changes
Noticeable with accessibility inspector, see below. In the app the screen reader gets so confused it goes back to the beginning after being on the hidden views.

| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 13 Pro - 2022-11-15 at 14 39 00](https://user-images.githubusercontent.com/3169203/201934376-28a4be65-bf7d-4e59-8c59-a50ceefde4a4.gif) | ![Simulator Screen Recording - iPhone 13 Pro - 2022-11-15 at 14 52 00](https://user-images.githubusercontent.com/3169203/201936426-16f8ea94-6c0d-4673-93dd-28a0d8f64ec5.gif) |
