### PR TITLE
JobApplyBoxView: Pass viewmodel on click

### DIFF
--- a/Demo/Sources/Components/JobApplyBox/JobApplyBoxDemoView.swift
+++ b/Demo/Sources/Components/JobApplyBox/JobApplyBoxDemoView.swift
@@ -47,7 +47,8 @@ extension JobApplyBoxDemoView: JobApplyBoxViewDelegate {
     func jobApplyBoxView(
         _ view: JobApplyBoxView,
         didSelectButton selectedButton: JobApplyBoxView.SelectedButton,
-        withURL url: URL
+        withURL url: URL,
+        viewModel: JobApplyBoxViewModel
     ) {
         print("👉 Did select button: \(selectedButton)")
     }

--- a/FinniversKit/Sources/Components/JobApplyBoxView/JobApplyBoxView.swift
+++ b/FinniversKit/Sources/Components/JobApplyBoxView/JobApplyBoxView.swift
@@ -1,7 +1,12 @@
 import UIKit
 
 public protocol JobApplyBoxViewDelegate: AnyObject {
-    func jobApplyBoxView(_ view: JobApplyBoxView, didSelectButton selectedButton: JobApplyBoxView.SelectedButton, withURL url: URL)
+    func jobApplyBoxView(
+        _ view: JobApplyBoxView,
+        didSelectButton selectedButton: JobApplyBoxView.SelectedButton,
+        withURL url: URL,
+        viewModel: JobApplyBoxViewModel
+    )
 }
 
 public class JobApplyBoxView: UIView {
@@ -69,7 +74,7 @@ public class JobApplyBoxView: UIView {
     // MARK: - Actions
 
     @objc private func primaryButtonTapped() {
-        delegate?.jobApplyBoxView(self, didSelectButton: .primary, withURL: viewModel.primaryButton.url)
+        delegate?.jobApplyBoxView(self, didSelectButton: .primary, withURL: viewModel.primaryButton.url, viewModel: viewModel)
     }
 }
 
@@ -77,7 +82,7 @@ public class JobApplyBoxView: UIView {
 
 extension JobApplyBoxView: LinkButtonViewDelegate {
     func linkButton(withIdentifier identifier: String?, wasTappedWithUrl url: URL) {
-        delegate?.jobApplyBoxView(self, didSelectButton: .secondary, withURL: url)
+        delegate?.jobApplyBoxView(self, didSelectButton: .secondary, withURL: url, viewModel: viewModel)
     }
 }
 


### PR DESCRIPTION
# Why?
In order to perform the correct tracking when the user clicks a button we need to know more about the buttons this view presents.

# What?
- Pass the viewmodel through the delegate on click.

# Version Change
Breaking. Changing a delegate method.

# UI Changes
_No UI._