### PR TITLE
Missing dark bgcolor

### DIFF
--- a/FinniversKit/Sources/Components/BrazePromotionView/BrazePromotionView.swift
+++ b/FinniversKit/Sources/Components/BrazePromotionView/BrazePromotionView.swift
@@ -232,7 +232,7 @@ private extension UIColor {
     }
 
     static var bgColor: UIColor {
-        return .dynamicColor(defaultColor: .milk, darkModeColor: .blueGray700)
+        return .dynamicColor(defaultColor: .white, darkModeColor: .darkBgPrimaryProminent)
     }
 }
 

--- a/FinniversKit/Sources/Components/FrontPageTransactionView/FrontPageTransactionView.swift
+++ b/FinniversKit/Sources/Components/FrontPageTransactionView/FrontPageTransactionView.swift
@@ -195,7 +195,7 @@ private extension UIColor {
     }
 
     static var bgColor: UIColor {
-        return .dynamicColor(defaultColor: .milk, darkModeColor: .blueGray700)
+        return .dynamicColor(defaultColor: .white, darkModeColor: .darkBgPrimaryProminent)
     }
 }
 

--- a/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
+++ b/FinniversKit/Sources/Components/PromotionView/PromotionView.swift
@@ -258,7 +258,7 @@ private extension UIColor {
     }
 
     static var bgColor: UIColor {
-        return .dynamicColor(defaultColor: .milk, darkModeColor: .blueGray700)
+        return .dynamicColor(defaultColor: .white, darkModeColor: .darkBgPrimaryProminent)
     }
 }
 

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -116,6 +116,7 @@ extension CGColor {
 // These colors are in use but are not part of the Fabric color palette
 extension UIColor {
     public class var coolGray100: UIColor { .init(hex: "#F3F4F6") }
+    public class var darkBgPrimaryProminent: UIColor { .init(hex: "#323241") }
     public class var darkCallToAction: UIColor { .init(hex: "#006DFB") }
     public class var darkIce: UIColor { .init(hex: "#262633") }
     public class var darkLicorice: UIColor { .init(hex: "#828699") }
@@ -131,6 +132,7 @@ extension UIColor {
 
 extension CGColor {
     public class var coolGray100: CGColor { UIColor.coolGray100.cgColor }
+    public class var darkBgPrimaryProminent: CGColor { UIColor.darkBgPrimaryProminent.cgColor }
     public class var darkCallToAction: CGColor { UIColor.darkCallToAction.cgColor }
     public class var darkIce: CGColor { UIColor.darkIce.cgColor }
     public class var darkLicorice: CGColor { UIColor.darkLicorice.cgColor }

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/CompactView/CompactMarketsViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/CompactView/CompactMarketsViewCell.swift
@@ -213,7 +213,7 @@ private extension UIColor {
     }
 
     class var tileBackgroundColor: UIColor {
-        return .dynamicColor(defaultColor: .milk, darkModeColor: .blueGray700)
+        return .dynamicColor(defaultColor: .white, darkModeColor: .darkBgPrimaryProminent)
     }
 }
 

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
@@ -204,6 +204,6 @@ private extension UIColor {
     }
 
     class var tileBackgroundColor: UIColor {
-        return .dynamicColor(defaultColor: .milk, darkModeColor: .blueGray700)
+        return .dynamicColor(defaultColor: .white, darkModeColor: .darkBgPrimaryProminent)
     }
 }


### PR DESCRIPTION
# Why?

Some components were using Bluegray700 as dark background color, but it was defined as a custom color with a different value than the one in Fabric. When colors were updated to match Fabric these components got a slightly lighter background. After disussion with the design team it was decided to use the original color which corresponds with `darkBgPrimaryProminent` on Android.

# What?

Changed instances of `blueGray700` to `darkBgPrimaryProminent` in custom dark colors in components.

# Version Change

Patch.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-05 at 13 40 31](https://user-images.githubusercontent.com/844977/210782646-cbb449c0-3353-4777-a74c-d649a73f67eb.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-05 at 13 39 42](https://user-images.githubusercontent.com/844977/210782655-172d9924-fa0c-4ce8-b472-ee4e2bd3bbfa.png) |
