### PR TITLE
Fix: Width calculation in OverflowCollectionView

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/OverflowCollectionView/OverflowCollectionView.swift
@@ -141,7 +141,7 @@ private extension OverflowCollectionView {
                 let previousCellMaxX = attributes[index - 1].frame.maxX
 
                 // Make sure the new cell is not exceeding the width of the collectionView.
-                if previousCellMaxX + cellSpacing.horizontal + attribute.frame.size.width < collectionViewContentSize.width {
+                if previousCellMaxX + cellSpacing.horizontal + attribute.frame.size.width <= collectionViewContentSize.width {
                     var newFrame = attribute.frame
                     newFrame.origin.x = previousCellMaxX + cellSpacing.horizontal
                     attribute.frame = newFrame


### PR DESCRIPTION
# Why?
There was a small typo in the width calculation in `OverflowCollectionView` that caused cells that would fill the width entirely to have their `x` offset set to 0.

# What?
- Use `<=` rather than just `<` when comparing the calculated size against the width of the UICV.

# Version Change
Patch

# UI Changes
| Before | After |
| --- | --- |
|  ![Screenshot 2023-01-16 at 11 01 38](https://user-images.githubusercontent.com/1901556/212651925-bfa7461b-7cd8-49f3-86c9-6bf86fd75801.png) | ![Screenshot 2023-01-16 at 11 01 08](https://user-images.githubusercontent.com/1901556/212651938-42dc0e37-9f21-4fd6-aff8-47f096fcd42a.png) |