### PR TITLE
Bugfix: Make recommendations accessible with VoiceOver

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Cell/StandardAdRecommendationCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Cell/StandardAdRecommendationCell.swift
@@ -170,7 +170,6 @@ public class StandardAdRecommendationCell: UICollectionViewCell, AdRecommendatio
     }
 
     private func setup() {
-        isAccessibilityElement = true
         var accessibilityMultiplier: CGFloat = 1.0
         if Config.isDynamicTypeEnabled {
             accessibilityMultiplier = {


### PR DESCRIPTION
# Why?

Recommendations aren't accessible with VoiceOver anymore. 

# What?

In https://github.com/finn-no/FinniversKit/pull/1183 we set `StandardAdRecommendationCell` to be accessible, with
`isAccessibilityElement = true`

That caused problems, since accessibility labels are set in the subviews `containerView` and `favoriteButton`, and they are accessibility elements
`accessibilityElements = [containerView, favoriteButton]
`

When we set their parent to be accessible, VoiceOver didn't read up the accessibility labels of the subviews anymore.

Reverted this, so parent isn't accessible anymore.
This might cause issues to dynamic font sizes, which https://github.com/finn-no/FinniversKit/pull/1183 was supposed to improve, but reverting it won't affect our production app since dynamic font sizes is not enabled in production anyways. 

# Version Change

Patch.