### PR TITLE
Use view model as binding for showing toasts, instead of an extra isShowing bool

### DIFF
--- a/Demo/Sources/SwiftUI/ToastSwiftUIDemoView.swift
+++ b/Demo/Sources/SwiftUI/ToastSwiftUIDemoView.swift
@@ -2,13 +2,17 @@ import SwiftUI
 import FinniversKit
 
 struct ToastSwiftUIDemoView: View {
-    @State var showToastFromBottom: Bool = false
-    @State var showToastFromTop: Bool = false
+    @State var topToastViewModel: Toast.ViewModel? = nil
+    @State var bottomToastViewModel: Toast.ViewModel? = nil
 
     var body: some View {
         VStack(spacing: .spacingM) {
             SwiftUI.Button("Animate from top") {
-                showToastFromTop = true
+                topToastViewModel = .init(
+                    text: "Animated from top",
+                    style: .success,
+                    position: .top
+                )
             }
 
             ToastSwiftUIView(text: "Success", style: .success)
@@ -20,21 +24,15 @@ struct ToastSwiftUIDemoView: View {
             ToastSwiftUIView(text: "Action error", style: .error, actionButton: .init(title: "Undo", buttonStyle: .promoted, action: {}))
 
             SwiftUI.Button("Animate from bottom") {
-                showToastFromBottom = true
+                bottomToastViewModel = .init(
+                    text: "Animated from bottom",
+                    style: .success,
+                    position: .bottom
+                )
             }
         }
-        .toast(
-            text: "Animated from bottom",
-            style: .success,
-            position: .bottom,
-            isShowing: $showToastFromBottom
-        )
-        .toast(
-            text: "Animated from top",
-            style: .success,
-            position: .top,
-            isShowing: $showToastFromTop
-        )
+        .toast(viewModel: $topToastViewModel)
+        .toast(viewModel: $bottomToastViewModel)
     }
 }
 

--- a/FinniversKit/Sources/SwiftUI Components/Toast/Toast.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Toast/Toast.swift
@@ -6,34 +6,10 @@ public enum Toast {} // Empty for namespacing
 
 extension View {
     public func toast(
-        text: String,
-        style: Toast.Style,
-        actionButton: Toast.ActionButton? = nil,
-        timeout: TimeInterval = 5,
-        position: Toast.Position = .bottom,
-        isShowing: Binding<Bool>
-    ) -> some View {
-        self.modifier(
-            ToastViewModifier(
-                toastView: .init(text: text, style: style, actionButton: actionButton),
-                timeout: timeout,
-                position: position,
-                isShowing: isShowing
-            )
-        )
-    }
-
-    public func toast(
-        viewModel: Toast.ViewModel,
-        isShowing: Binding<Bool>
+        viewModel: Binding<Toast.ViewModel?>
     ) -> some View {
         return self.modifier(
-            ToastViewModifier(
-                toastView: .init(text: viewModel.text, style: viewModel.style, actionButton: viewModel.actionButton),
-                timeout: viewModel.timeout,
-                position: viewModel.position,
-                isShowing: isShowing
-            )
+            ToastViewModifier(viewModel: viewModel)
         )
     }
 }

--- a/FinniversKit/Sources/SwiftUI Components/Toast/ToastViewModifier.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Toast/ToastViewModifier.swift
@@ -2,25 +2,37 @@ import Foundation
 import SwiftUI
 
 struct ToastViewModifier: ViewModifier {
-    let toastView: ToastSwiftUIView
-    let timeout: TimeInterval
-    let position: Toast.Position
-    @Binding var isShowing: Bool
+    @Binding var viewModel: Toast.ViewModel?
+
+    private var isPresented: Bool {
+        viewModel != nil
+    }
+
+    @State private var toastTimeoutWorkItem: DispatchWorkItem? {
+        didSet {
+            oldValue?.cancel()
+        }
+    }
 
     func body(content: Content) -> some View {
         ZStack {
             content
             VStack {
-                if position == .bottom {
-                    Spacer()
-                }
-                if isShowing {
-                    toastView
+                if let viewModel {
+                    let position = viewModel.position
+
+                    if position == .bottom {
+                        Spacer()
+                    }
+
+                    ToastSwiftUIView(text: viewModel.text, style: viewModel.style, actionButton: viewModel.actionButton)
                         .transition(.move(edge: position == .top ? .top : .bottom))
                         .onAppear {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
-                                isShowing = false
+                            let dismissToastWorkItem = DispatchWorkItem {
+                                self.viewModel = nil
                             }
+                            toastTimeoutWorkItem = dismissToastWorkItem
+                            DispatchQueue.main.asyncAfter(deadline: .now() + viewModel.timeout, execute: dismissToastWorkItem)
                         }
                         .gesture(
                             DragGesture(minimumDistance: 20, coordinateSpace: .local)
@@ -30,16 +42,17 @@ struct ToastViewModifier: ViewModifier {
                                     let swipedDown = value.translation.height > 0
                                     let swipedUp = !swipedDown
                                     if position == .bottom && swipedDown || position == .top && swipedUp {
-                                        isShowing = false
+                                        self.viewModel = nil
                                     }
                                 }
                         )
-                }
-                if position == .top {
-                    Spacer()
+
+                    if position == .top {
+                        Spacer()
+                    }
                 }
             }
-            .animation(.easeInOut(duration: 0.3), value: isShowing)
+            .animation(.easeInOut(duration: 0.3), value: isPresented)
         }
     }
 }


### PR DESCRIPTION
# Why?

Made an improvement to the toast view modifier, where we use a binding for the view model instead of an extra boolean indicating whether the toast should be shown.

# What?

When you set a `Toast.ViewModel` on the view, the toast will show up, when it's set to nil, it will disappear. It gives us much more flexibility than adding a bunch of required view models where we control whether they're shown with booleans. 
Remove `isShowing` boolean.

# Version Change

Merging this into #1194 