### PR TITLE
Add no image and description capability to list items

### DIFF
--- a/Demo/Sources/Components/SelectionListView/SelectionListRadiobuttonDemoView.swift
+++ b/Demo/Sources/Components/SelectionListView/SelectionListRadiobuttonDemoView.swift
@@ -18,6 +18,9 @@ class SelectionListRadiobuttonDemoView: UIView, Tweakable {
         .init(title: "5 items", action: { [weak self] in
             self?.checkmarkListView.configure(with: .create(number: 5))
         }),
+        .init(title: "3 items (title only)", action: { [weak self] in
+            self?.checkmarkListView.configure(with: .createTitleOnly(number: 3))
+        }),
     ]
 
     // MARK: - Private properties
@@ -69,6 +72,18 @@ private extension Array where Element == SelectionItemModel {
                 title: "Jeg kan overlevere ved oppmøte",
                 description: .plain("Du og kjøper gjør en egen avtale"),
                 icon: .fixedSize(UIImage(named: .favoriteActive).withRenderingMode(.alwaysTemplate)),
+                isInitiallySelected: $0 == 0
+            )
+        }
+    }
+
+    static func createTitleOnly(number: Int) -> [SelectionItemModel] {
+        (0..<number).map {
+            SelectionItemModel(
+                identifier: "item-\($0)",
+                title: "Jeg kan overlevere ved oppmøte",
+                description: .none,
+                icon: .none,
                 isInitiallySelected: $0 == 0
             )
         }

--- a/FinniversKit/Sources/Components/SelectionListView/Models/SelectionItemModel.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Models/SelectionItemModel.swift
@@ -34,12 +34,15 @@ public struct SelectionItemModel {
     public enum Icon {
         case fixedSize(UIImage)
         case dynamic(UIImage)
+        case none
 
-        var image: UIImage {
+        var image: UIImage? {
             switch self {
             case .fixedSize(let image),
                     .dynamic(let image):
                 return image
+            case .none:
+                return nil
             }
         }
     }

--- a/FinniversKit/Sources/Components/SelectionListView/Models/SelectionItemModel.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Models/SelectionItemModel.swift
@@ -28,6 +28,7 @@ public struct SelectionItemModel {
     public enum Description {
         case plain(String)
         case html(htmlString: String, style: HTMLStyler.StyleMap = [:], accessibilityString: String? = nil)
+        case none
     }
 
     public enum Icon {

--- a/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
@@ -105,7 +105,6 @@ class SelectionListItemView: UIView {
         addSubview(contentView)
         contentView.addSubview(selectionView)
         contentView.addSubview(textStackView)
-        contentView.addSubview(iconImageView)
         contentView.addSubview(detailViewsStackView)
 
         var constraints: [NSLayoutConstraint] = [
@@ -121,14 +120,19 @@ class SelectionListItemView: UIView {
             textStackView.leadingAnchor.constraint(equalTo: selectionView.trailingAnchor, constant: .spacingM),
             textStackView.bottomAnchor.constraint(equalTo: detailViewsStackView.topAnchor, constant: -.spacingM),
 
-            iconImageView.leadingAnchor.constraint(equalTo: textStackView.trailingAnchor, constant: .spacingM),
-            iconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.spacingM),
-            iconImageView.centerYAnchor.constraint(equalTo: textStackView.centerYAnchor),
-
             detailViewsStackView.leadingAnchor.constraint(equalTo: selectionView.trailingAnchor, constant: .spacingM),
             detailViewsStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.spacingM),
             detailViewsStackViewBottomConstraint,
         ]
+
+        if case .none = model.icon {} else {
+            contentView.addSubview(iconImageView)
+            constraints.append(contentsOf: [
+                iconImageView.leadingAnchor.constraint(equalTo: textStackView.trailingAnchor, constant: .spacingM),
+                iconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.spacingM),
+                iconImageView.centerYAnchor.constraint(equalTo: textStackView.centerYAnchor)
+            ])
+        }
 
         if case .fixedSize = model.icon {
             constraints.append(contentsOf: [

--- a/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
@@ -96,10 +96,9 @@ class SelectionListItemView: UIView {
             detailViewsStackViewBottomConstraint.constant = -.spacingM
         }
 
-        if case .none = model.description {
-            textStackView.addArrangedSubviews([titleLabel])
-        } else {
-            textStackView.addArrangedSubviews([titleLabel, descriptionLabel])
+        textStackView.addArrangedSubviews([titleLabel])
+        if case .none = model.description {} else {
+            textStackView.addArrangedSubviews([descriptionLabel])
         }
 
         addSubview(contentView)

--- a/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
+++ b/FinniversKit/Sources/Components/SelectionListView/Subviews/SelectionListItemView.swift
@@ -85,6 +85,8 @@ class SelectionListItemView: UIView {
             descriptionLabel.text = text
         case .html(let htmlString, let style, _):
             descriptionLabel.setHTMLText(htmlString, with: style)
+        case .none:
+            descriptionLabel.text = nil
         }
 
         if let detailItems = model.detailItems, !detailItems.isEmpty {
@@ -94,7 +96,11 @@ class SelectionListItemView: UIView {
             detailViewsStackViewBottomConstraint.constant = -.spacingM
         }
 
-        textStackView.addArrangedSubviews([titleLabel, descriptionLabel])
+        if case .none = model.description {
+            textStackView.addArrangedSubviews([titleLabel])
+        } else {
+            textStackView.addArrangedSubviews([titleLabel, descriptionLabel])
+        }
 
         addSubview(contentView)
         contentView.addSubview(selectionView)
@@ -114,8 +120,6 @@ class SelectionListItemView: UIView {
             textStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: .spacingM),
             textStackView.leadingAnchor.constraint(equalTo: selectionView.trailingAnchor, constant: .spacingM),
             textStackView.bottomAnchor.constraint(equalTo: detailViewsStackView.topAnchor, constant: -.spacingM),
-
-            titleLabel.widthAnchor.constraint(equalTo: descriptionLabel.widthAnchor),
 
             iconImageView.leadingAnchor.constraint(equalTo: textStackView.trailingAnchor, constant: .spacingM),
             iconImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -.spacingM),
@@ -143,12 +147,14 @@ class SelectionListItemView: UIView {
         isAccessibilityElement = true
         accessibilityTraits = .button
 
-        let description = { () -> String in
+        let description = { () -> String? in
             switch model.description {
             case .plain(let text):
                 return text
             case .html(let htmlString, _, let accessibilityString):
                 return accessibilityString ?? htmlString
+            case .none:
+                return nil
             }
         }()
 


### PR DESCRIPTION
# Why?

Not all list elements have an image or a description.

# What?

Make it possible to set image and/or description to .none for a list element.

# Version Change

Minor

# UI Changes

| | Feature A |
| --- | --- |
| **iPhone** |![simulator_screenshot_73DDFD43-9828-4EE6-AA09-F7787215B730](https://user-images.githubusercontent.com/9058089/218061295-4c8e7cd0-7451-49e8-9533-a3a588975674.png)|
| **iPad** |![simulator_screenshot_896B063E-784B-4034-8A24-31C828D81D68](https://user-images.githubusercontent.com/9058089/218066435-1a0b2a35-9c6a-4343-bd59-7b3e725c6405.png)|
