### PR TITLE
Fix keyboard intersection height with Prefer Cross-Fade Transitions

### DIFF
--- a/FinniversKit/Sources/Util/KeyboardNotificationInfo.swift
+++ b/FinniversKit/Sources/Util/KeyboardNotificationInfo.swift
@@ -31,7 +31,9 @@ public struct KeyboardNotificationInfo {
     /// will be between 0 and whatever intersection occurs. This is in case the user has
     /// an iPad with an external keyboard connected, which would've returned a negative value.
     public func keyboardFrameEndIntersectHeight(inView view: UIView) -> CGFloat {
-        guard let frameEnd = frameEnd else { return 0 }
+        // The Prefer Cross-Fade Transitions setting causes empty frameEnd,
+        // so we need to check for this to support the setting.
+        guard let frameEnd = frameEnd, !frameEnd.isEmpty else { return 0 }
         let frameInWindow = view.convert(view.bounds, to: nil)
         let intersection = frameEnd.intersection(frameInWindow)
         let safeInsetBottom: CGFloat = view.safeAreaInsets.bottom


### PR DESCRIPTION
# Why?

When Reduce Motion and Prefer Cross-Fade Transition are enabled, the keyboard notification returns an empty end frame. This causes us to calculate an incorrect intersection height, which can break views that depend on this value.

# What?

Return 0 if keyboard notification end frame is empty

# Version Change

Patch