### PR TITLE
A11y: Ad lifecycle

### DIFF
--- a/FinniversKit/Sources/Components/LinkButton/LinkButtonView.swift
+++ b/FinniversKit/Sources/Components/LinkButton/LinkButtonView.swift
@@ -92,6 +92,7 @@ class LinkButtonView: UIView {
         externalImageView.isHidden = !isExternal
         externalImageView.tintColor = externalIconColor ?? .borderDefault
         linkButton.setTitle(buttonTitle, for: .normal)
+        linkButton.accessibilityTraits = isExternal ? .link : .button
         subtitleLabel.text = subtitle
         subtitleLabel.isHidden = subtitle?.isEmpty ?? true
         setup()

--- a/FinniversKit/Sources/Components/MyAdsList/Subviews/MyAdCollectionViewCell.swift
+++ b/FinniversKit/Sources/Components/MyAdsList/Subviews/MyAdCollectionViewCell.swift
@@ -50,6 +50,7 @@ class MyAdCollectionViewCell: UICollectionViewCell {
     // MARK: - Setup
 
     private func setup() {
+        titleLabel.accessibilityTraits = .header
         textStackView.addArrangedSubviews([titleLabel, subtitleLabel])
 
         contentView.addSubview(remoteImageView)

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/ObjectPagePriceView.swift
@@ -154,6 +154,7 @@ private class PriceView: UIView {
 
     private func setup() {
         isAccessibilityElement = true
+        accessibilityTraits = .staticText
         if let accessibilityLabel = viewModel.accessibilityLabel {
             self.accessibilityLabel = accessibilityLabel
         } else {

--- a/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
+++ b/FinniversKit/Sources/Components/ObjectPagePriceView/Subviews/PriceLinkButtonView.swift
@@ -88,6 +88,7 @@ class PriceLinkButtonView: UIView {
 
         externalImageView.isHidden = !viewModel.isExternal
         linkButton.setTitle(viewModel.buttonTitle, for: .normal)
+        linkButton.accessibilityTraits = viewModel.isExternal ? .link : .button
 
         subtitleLabel.text = viewModel.subtitle
         subtitleLabel.isHidden = viewModel.subtitle?.isEmpty ?? true

--- a/FinniversKit/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsSortingView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsSortingView.swift
@@ -9,7 +9,10 @@ class FavoriteAdsSortingView: UIView {
     // MARK: - Internal properties
 
     var title: String = "" {
-        didSet { sortingLabel.text = title.uppercased() }
+        didSet {
+            sortingLabel.text = title.uppercased()
+            accessibilityLabel = title
+        }
     }
 
     // MARK: - Private properties
@@ -42,6 +45,9 @@ class FavoriteAdsSortingView: UIView {
     // MARK: - Setup
 
     private func setup() {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+
         addSubview(sortingLabel)
         addSubview(arrowImage)
 

--- a/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/FavoriteFolderActionView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/FavoriteFolderActionView.swift
@@ -21,6 +21,7 @@ public final class FavoriteFolderActionView: UIView {
     public var isShared: Bool {
         didSet {
             updateSeparators()
+            shareLinkView.isHidden = !isShared
         }
     }
 

--- a/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/Views/FavoriteFolderShareLinkView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/Views/FavoriteFolderShareLinkView.swift
@@ -63,7 +63,6 @@ final class FavoriteFolderShareLinkView: UIView {
     }
 
     private func setup() {
-        isAccessibilityElement = true
         backgroundColor = .bgSecondary
 
         addSubview(iconImageView)

--- a/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/Views/FavoriteFolderShareToggleView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/Views/FavoriteFolderShareToggleView.swift
@@ -69,7 +69,6 @@ final class FavoriteFolderShareToggleView: UIView {
     }
 
     private func setup() {
-        isAccessibilityElement = true
         backgroundColor = .bgPrimary
 
         addSubview(iconImageView)

--- a/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileInfoViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileInfoViewCell.swift
@@ -12,14 +12,21 @@ final class NeighborhoodProfileInfoViewCell: NeighborhoodProfileViewCell {
     typealias Content = NeighborhoodProfileViewModel.Content
     typealias Row = NeighborhoodProfileViewModel.Row
 
+    // MARK: - Internal properties
+
     weak var delegate: NeighborhoodProfileInfoViewCellDelegate?
     private(set) var linkButtonUrl: URL?
 
+    // MARK: - Private properties
+
     private lazy var titleLabel: UILabel = makeTitleLabel()
+    private lazy var stackView = UIStackView(axis: .vertical, spacing: .spacingXS, alignment: .fill, distribution: .fillEqually, withAutoLayout: true)
+    private lazy var stackViewTopConstraint = stackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: .spacingM)
+    private lazy var linkButtonToStackViewConstraint = linkButton.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: .spacingS)
+    private lazy var linkButtonToTitleLabelConstraint = linkButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: .spacingS)
 
     private lazy var linkButton: Button = {
-        let button = Button(style: .link)
-        button.translatesAutoresizingMaskIntoConstraints = false
+        let button = Button(style: .link, withAutoLayout: true)
         button.titleLabel?.font = NeighborhoodProfileInfoViewCell.linkButtonFont
         button.titleLabel?.numberOfLines = 0
         button.contentHorizontalAlignment = .left
@@ -27,31 +34,10 @@ final class NeighborhoodProfileInfoViewCell: NeighborhoodProfileViewCell {
         return button
     }()
 
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(withAutoLayout: true)
-        stackView.axis = .vertical
-        stackView.spacing = .spacingXS
-        stackView.distribution = .fillEqually
-        stackView.alignment = .fill
-        return stackView
-    }()
-
     private lazy var iconImageView: UIImageView = {
         let imageView = UIImageView(withAutoLayout: true)
         imageView.contentMode = .scaleAspectFit
         return imageView
-    }()
-
-    private lazy var stackViewTopConstraint: NSLayoutConstraint = {
-        return stackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: .spacingM)
-    }()
-
-    private lazy var linkButtonToStackViewConstraint: NSLayoutConstraint = {
-        return linkButton.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: .spacingS)
-    }()
-
-    private lazy var linkButtonToTitleLabelConstraint: NSLayoutConstraint = {
-        return linkButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: .spacingS)
     }()
 
     // MARK: - Init

--- a/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileInfoViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/Cells/NeighborhoodProfileInfoViewCell.swift
@@ -83,11 +83,8 @@ final class NeighborhoodProfileInfoViewCell: NeighborhoodProfileViewCell {
         stackView.isHidden = rows.isEmpty
         stackViewTopConstraint.constant = rows.isEmpty ? 0 : .spacingM
 
-        for row in rows {
-            let rowView = InfoRowView()
-            rowView.configure(withTitle: row.title, detailText: row.detailText, icon: row.icon)
-            stackView.addArrangedSubview(rowView)
-        }
+        let rowViews = rows.map(InfoRowView.init(row:))
+        stackView.addArrangedSubviews(rowViews)
     }
 
     private func setup() {
@@ -175,9 +172,10 @@ private final class InfoRowView: UIView {
         return imageView
     }()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(row: NeighborhoodProfileViewModel.Row) {
+        super.init(frame: .zero)
         setup()
+        configure(with: row)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -185,13 +183,18 @@ private final class InfoRowView: UIView {
         setup()
     }
 
-    func configure(withTitle title: String, detailText: String?, icon: UIImage?) {
-        titleLabel.text = title
-        detailTextLabel.text = detailText
-        iconImageView.image = icon?.withRenderingMode(.alwaysTemplate)
+    private func configure(with row: NeighborhoodProfileViewModel.Row) {
+        titleLabel.text = row.title
+        detailTextLabel.text = row.detailText
+        iconImageView.image = row.icon?.withRenderingMode(.alwaysTemplate)
+
+        accessibilityLabel = row.accessibilityLabel ?? [row.title, row.detailText].compactMap { $0 }.joined(separator: ". ")
     }
 
     private func setup() {
+        isAccessibilityElement = true
+        accessibilityTraits = .staticText
+
         addSubview(titleLabel)
         addSubview(iconImageView)
         addSubview(detailTextLabel)

--- a/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileHeaderView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileHeaderView.swift
@@ -29,6 +29,8 @@ final class NeighborhoodProfileHeaderView: UIView {
 
     // MARK: - Private properties
 
+    private lazy var stackView = UIStackView(axis: .horizontal, spacing: .spacingM, alignment: .center, distribution: .fill, withAutoLayout: true)
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel(withAutoLayout: true)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -58,18 +60,9 @@ final class NeighborhoodProfileHeaderView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        addSubview(titleLabel)
-        addSubview(button)
-
-        NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: button.leadingAnchor, constant: -.spacingM),
-            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            button.centerYAnchor.constraint(equalTo: centerYAnchor),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
+        stackView.addArrangedSubviews([titleLabel, UIView(), button])
+        addSubview(stackView)
+        stackView.fillInSuperview()
     }
 
     // MARK: - Actions

--- a/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileViewModel.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/NeighborhoodProfile/NeighborhoodProfileViewModel.swift
@@ -52,11 +52,13 @@ extension NeighborhoodProfileViewModel {
         public let title: String
         public let detailText: String?
         public let icon: UIImage?
+        public let accessibilityLabel: String?
 
-        public init(title: String, detailText: String? = nil, icon: UIImage? = nil) {
+        public init(title: String, detailText: String? = nil, icon: UIImage? = nil, accessibilityLabel: String? = nil) {
             self.title = title
             self.detailText = detailText
             self.icon = icon
+            self.accessibilityLabel = accessibilityLabel
         }
     }
 

--- a/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
@@ -24,29 +24,15 @@ public class FavoritesListViewCell: UITableViewCell {
     private static let imageSize: CGFloat = 74.0
 
     private lazy var adImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        let imageView = UIImageView(withAutoLayout: true)
         imageView.layer.cornerRadius = FavoritesListViewCell.cornerRadius
         imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()
 
-    private lazy var detailLabel: Label = {
-        let label = Label(style: .detail)
-        label.textColor = .textSecondary
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = .clear
-        return label
-    }()
-
-    private lazy var titleLabel: Label = {
-        let label = Label(style: .body)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = .clear
-        label.numberOfLines = 2
-        return label
-    }()
+    private lazy var titleLabel = Label(style: .body, numberOfLines: 2, withAutoLayout: true)
+    private lazy var detailLabel = Label(style: .detail, textColor: .textSecondary, withAutoLayout: true)
 
     // MARK: - Setup
 

--- a/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
@@ -61,6 +61,7 @@ public class FavoritesListViewCell: UITableViewCell {
     }
 
     private func setup() {
+        accessibilityTraits = .header
         isAccessibilityElement = true
 
         addSubview(adImageView)

--- a/FinniversKit/Sources/Recycling/ListViews/Favorites/Model/FavoritesListViewModel.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Favorites/Model/FavoritesListViewModel.swift
@@ -14,8 +14,8 @@ public protocol FavoritesListViewModel {
 
 public extension FavoritesListViewModel {
     var accessibilityLabel: String {
-        var message = detail
-        message += ". " + title
+        var message = title
+        message += ". " + detail
         return message
     }
 }


### PR DESCRIPTION
# Why?
Accessibility fixes for ad lifecycle.

# What?
- Give title labels in my ads cell trait `header`.
- Favorites
  - Give title label trait `header`.
  - Give sorting button trait `button`.
  - Make favorite cells clickable (folders + folder contents).
- Neighborhood profile
  - Group title label + distance.
  - Add property for accesibilityLabel to view model.
  - Hide share link view, if sharing is turned off.
  - Reorder title label and "Read more" button.
- Price view (object page)
  - Give trait `staticText`.
  - Give buttons opening Safari trait `link`.

# Version Change
Minor. Optional argument added to view model.
