### PR TITLE
Wishlist - Matvii Support files

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,9 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "location" : "https://github.com/pimms/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "f29e2014f6230cf7d5138fc899da51c7f513d467",
-        "version" : "1.10.0"
+        "revision" : "0efeef44df913fe60ea868f037f271ac927a8e8c"
       }
     }
   ],

--- a/FinniversKit/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdViewModel.swift
+++ b/FinniversKit/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdViewModel.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public struct FavoriteAdViewModel {
+public struct FavoriteAdViewModel: Hashable {
     public let addressText: String?
     public let titleText: String
     public let titleColor: UIColor

--- a/FinniversKit/Sources/Components/EarthHour/Views/EarthHourHeaderView.swift
+++ b/FinniversKit/Sources/Components/EarthHour/Views/EarthHourHeaderView.swift
@@ -61,7 +61,7 @@ final class EarthHourHeaderView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     // MARK: - Overrides
 
     override func layoutSubviews() {

--- a/FinniversKit/Sources/Components/Ribbon/Models/RibbonViewModel.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Models/RibbonViewModel.swift
@@ -4,12 +4,29 @@
 
 import UIKit
 
-public struct RibbonViewModel: Hashable {
+public struct RibbonViewModel: Hashable, Codable {
     public let style: RibbonView.Style
     public let title: String
-
+    
     public init(style: RibbonView.Style, title: String) {
         self.style = style
         self.title = title
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case style
+        case title
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        style = try container.decode(RibbonView.Style.self, forKey: .style)
+        title = try container.decode(String.self, forKey: .title)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(style, forKey: .style)
+        try container.encode(title, forKey: .title)
     }
 }

--- a/FinniversKit/Sources/Components/Ribbon/Models/RibbonViewModel.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Models/RibbonViewModel.swift
@@ -4,29 +4,12 @@
 
 import UIKit
 
-public struct RibbonViewModel: Hashable, Codable {
+public struct RibbonViewModel: Hashable {
     public let style: RibbonView.Style
     public let title: String
     
     public init(style: RibbonView.Style, title: String) {
         self.style = style
         self.title = title
-    }
-    
-    private enum CodingKeys: String, CodingKey {
-        case style
-        case title
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        style = try container.decode(RibbonView.Style.self, forKey: .style)
-        title = try container.decode(String.self, forKey: .title)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(style, forKey: .style)
-        try container.encode(title, forKey: .title)
     }
 }

--- a/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public extension RibbonView {
-    enum Style: Hashable {
+    enum Style: Hashable, Codable {
         case `default`
         case success
         case warning

--- a/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public extension RibbonView {
-    enum Style: Hashable, Codable {
+    enum Style: Hashable {
         case `default`
         case success
         case warning

--- a/FinniversKit/Sources/Components/Ribbon/RibbonView.swift
+++ b/FinniversKit/Sources/Components/Ribbon/RibbonView.swift
@@ -26,8 +26,13 @@ public class RibbonView: UIView {
         label.setContentHuggingPriority(.required, for: .vertical)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.textAlignment = .center
+        label.numberOfLines = 0
         return label
     }()
+    
+    public override var intrinsicContentSize: CGSize {
+        return titleLabel.intrinsicContentSize
+    }
 
     // MARK: - Init
 

--- a/FinniversKit/Sources/Components/Ribbon/RibbonViewRepresentable.swift
+++ b/FinniversKit/Sources/Components/Ribbon/RibbonViewRepresentable.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+public struct RibbonViewRepresentable: UIViewRepresentable {
+    let ribbonViewModel: RibbonViewModel
+    
+    public init?(ribbonViewModel: RibbonViewModel?) {
+        guard let ribbonViewModel else { return nil }
+        self.ribbonViewModel = ribbonViewModel
+    }
+    
+    public func makeUIView(context: Context) -> RibbonView {
+        let view = RibbonView(viewModel: ribbonViewModel)
+        return view
+    }
+    
+    public func updateUIView(_ uiView: RibbonView, context: Context) {
+    }
+}

--- a/FinniversKit/Sources/Components/Ribbon/RibbonViewRepresentable.swift
+++ b/FinniversKit/Sources/Components/Ribbon/RibbonViewRepresentable.swift
@@ -10,6 +10,9 @@ public struct RibbonViewRepresentable: UIViewRepresentable {
     
     public func makeUIView(context: Context) -> RibbonView {
         let view = RibbonView(viewModel: ribbonViewModel)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        view.clipsToBounds = true
         return view
     }
     

--- a/FinniversKit/Sources/SwiftUI Components/Extensions/Text + Extensions.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Extensions/Text + Extensions.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+public extension Text {
+    public static func optional(_ str: (any StringProtocol)?) -> some View {
+        guard let str = str else { return AnyView(Text("").isHidden(true, remove: true)) }
+        return AnyView(Text(str))
+    }
+}

--- a/FinniversKit/Sources/SwiftUI Components/Extensions/View + Extension.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Extensions/View + Extension.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+public extension View {
+    /// Hide or show the view based on a boolean value.
+    ///
+    /// Example for visibility:
+    ///
+    ///     Text("Label")
+    ///         .isHidden(true)
+    ///
+    /// Example for complete removal:
+    ///
+    ///     Text("Label")
+    ///         .isHidden(true, remove: true)
+    ///
+    /// - Parameters:
+    ///   - hidden: Set to `false` to show the view. Set to `true` to hide the view.
+    ///   - remove: Boolean value indicating whether or not to remove the view.
+    @ViewBuilder public func isHidden(_ hidden: Bool, remove: Bool = false) -> some View {
+        if hidden {
+            if !remove {
+                self.hidden()
+            }
+        } else {
+            self
+        }
+    }
+}

--- a/FinniversKit/Sources/SwiftUI Components/GenericAsyncImageView.swift
+++ b/FinniversKit/Sources/SwiftUI Components/GenericAsyncImageView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+public struct GenericAsyncImageView: View {
+    let imageURL: URL?
+    let fallbackImage: Image = Image(uiImage: UIImage(named: .noImage))
+    let backgroundColor: Color = .bgSecondary
+    
+    @State private var state: ImageState = .loading
+    
+    public init(imageURL: URL?) {
+        self.imageURL = imageURL
+    }
+    
+    public init(imageURLString: String?) {
+        self.imageURL = URL(string: imageURLString ?? "")
+    }
+    
+    public var body: some View {
+        Group {
+            switch state {
+            case .loading:
+                ZStack {
+                    Rectangle()
+                        .fill(backgroundColor)
+                    
+                    ProgressView()
+                }
+                
+            case .fetched(let image):
+                image.resizable()
+                
+            case .notFound:
+                fallbackImage.resizable()
+            }
+        }
+        .onAppear {
+            Task {
+                await fetchImage()
+            }
+        }
+    }
+    
+    private func fetchImage() async {
+        guard let imageURL else {
+            state = .notFound
+            return
+        }
+        
+        if
+            let (data, _) = try? await URLSession.shared.data(from: imageURL),
+            let uiImage = UIImage(data: data)
+        {
+            let image = Image(uiImage: uiImage)
+            self.state = .fetched(image)
+            
+        } else {
+            self.state = .notFound
+        }
+    }
+}
+
+extension GenericAsyncImageView {
+    enum ImageState {
+        case loading
+        case fetched(Image)
+        case notFound
+    }
+}
+
+struct AsyncImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        GenericAsyncImageView(imageURL: URL(string: ""))
+    }
+}
+


### PR DESCRIPTION
# Why?

In order to mark all necessary support files files available in the main application for the **onboarding Wishlist task**

# What?

- added generic **AsyncImageView** built with SwiftUI 
- added **RibbonViewRepresentable** view to use with SwiftUI
- added some needed for the main application **protocol conformances** to some of the types

# Version Change

Minor

# Should not be merged