### PR TITLE
Recommendation image mixup fix 🤞 

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Cell/StandardAdRecommendationCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/Cell/StandardAdRecommendationCell.swift
@@ -377,12 +377,10 @@ public class StandardAdRecommendationCell: UICollectionViewCell, AdRecommendatio
     }
 
     public func loadImage() {
-        if imageView.image == nil {
-            if let imagePath = model?.imagePath {
-                imageView.loadImage(for: imagePath, imageWidth: frame.size.width, fallbackImage: defaultImage)
-            } else {
-                setDefaultImage()
-            }
+        if let imagePath = model?.imagePath {
+            imageView.loadImage(for: imagePath, imageWidth: frame.size.width, fallbackImage: defaultImage)
+        } else {
+            setDefaultImage()
         }
 
         if logoImageView.image == nil {


### PR DESCRIPTION
We suspect this is causing the image to sometimes be the incorrect due some cancellation of imageloadings not functioning as intended.

# Why?

We have had a long-living bug where some images get mixed up in the recommendation-feed, this may be the reason for it. If the imageLoading didn't cancel loading properly, it may have been inserted after prepareForReuse has been called, and the imageView.image would not be nil.

# What?

Remove check for imageView.image == nil in StandardAdRecommendationCell.

# Version Change

Patch