### PR TITLE
Maximise the image quality in the fullscreen view

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
+++ b/FinniversKit/Sources/Fullscreen/FullscreenGallery/FullscreenGalleryViewController.swift
@@ -268,7 +268,7 @@ extension FullscreenGalleryViewController: FullscreenImageViewControllerDataSour
         }
 
         let url = viewModel.imageUrls[vc.imageIndex]
-        let imageWidth = min(view.bounds.width, view.bounds.height)
+        let imageWidth = CGFloat(3840)
 
         galleryDataSource.fullscreenGalleryViewController(self, imageForUrlString: url, width: imageWidth, completionHandler: { (_, image, _) in
             dataCallback(image)


### PR DESCRIPTION
# Why?

Previously the fullscreen view images only loaded to fill the screen. But the users might want to zoom into the image and take a closer look. So therefore we here bump the image resolution in fullscreen gallery view to get the maximum available.

# What?

Here the image width is set to 3840, aka 4k, instead of the screens width. However the maximum image width in the backend is 1600 so this is then fetched.

# Version Change

minor

# UI Changes

| Before | After |
| --- | --- |
| <img width="484" alt="Screenshot 2023-03-07 at 13 29 58" src="https://user-images.githubusercontent.com/17337441/223423279-7f880204-8268-4f63-bf3c-3ff49f14ed0f.png"> | <img width="485" alt="Screenshot 2023-03-07 at 13 26 09" src="https://user-images.githubusercontent.com/17337441/223422855-31c08269-d194-4e64-a622-7c7fd1a40231.png"> |
| <img width="478" alt="Screenshot 2023-03-07 at 13 29 19" src="https://user-images.githubusercontent.com/17337441/223423052-e1b644a4-e02c-402c-81cf-aeb91f03d4df.png"> | <img width="495" alt="Screenshot 2023-03-07 at 13 25 43" src="https://user-images.githubusercontent.com/17337441/223422920-57afb278-e011-4232-ba06-f3f2f66919e9.png"> |