### PR TITLE
Crash fix: Register custom fonts before creating instance of one

### DIFF
--- a/FinniversKit/Sources/DNA/Font/FontProvider.swift
+++ b/FinniversKit/Sources/DNA/Font/FontProvider.swift
@@ -176,6 +176,8 @@ public struct DefaultFontProvider: FontProvider {
     }
 
     public func font(ofSize size: CGFloat, weight: FontWeight) -> UIFont {
+        registerCustomFonts()
+
         switch weight {
         case .light:
             return UIFont(name: FontType.light.rawValue, size: size)!


### PR DESCRIPTION
# Why?

The NMP app crashed when I added a FinniversKit view due to force unwrapping fonts which weren't registered yet.
 
# What?

Call `registerCustomFonts()` before force unwrapping fonts below. 

# Version Change

Patch. 

# UI Changes

No UI.