### PR TITLE
Allow HTML in SwiftUI selection list item description.

### DIFF
--- a/FinniversKit/Sources/SwiftUI Components/SwiftUISelectionListItem.swift
+++ b/FinniversKit/Sources/SwiftUI Components/SwiftUISelectionListItem.swift
@@ -30,7 +30,7 @@ struct SwiftUISelectionListItem<ItemType>: View {
                     .foregroundColor(.textPrimary)
 
                 if let description = itemModel.description {
-                    Text(description)
+                    HTMLText(description)
                         .finnFont(.caption)
                         .foregroundColor(.textSecondary)
                 }


### PR DESCRIPTION
# Why?

The description needs to support HTML for future flexibility (all `text` fields in TJT backend can support a subset of HTML going forward).

# What?

Replace `Text` with `HTMLText`.

# Version Change

Patch.
