### PR TITLE
Small fix

### DIFF
--- a/FinniversKit/Sources/Fullscreen/EmptyView/GenericErrorSwiftUIView.swift
+++ b/FinniversKit/Sources/Fullscreen/EmptyView/GenericErrorSwiftUIView.swift
@@ -10,7 +10,7 @@ public final class GenericErrorViewModel {
         title: String,
         description: String? = nil,
         buttonTitle: String? = nil,
-        action: @escaping (() -> Void)
+        action: (() -> Void)? = nil
     ) {
         self.title = title
         self.description = description


### PR DESCRIPTION
# Why?

Not possible to use GenericErrorSwiftUIView without button action

# What?

Make action as nil by default in init

# Version Change

Patch
