### PR TITLE
RefreshControl - hide default icon on first refresh

### DIFF
--- a/FinniversKit/Sources/Components/RefreshControl/RefreshControl.swift
+++ b/FinniversKit/Sources/Components/RefreshControl/RefreshControl.swift
@@ -55,6 +55,8 @@ public class RefreshControl: UIRefreshControl {
 
     private func setup() {
         tintColor = .clear
+        subviews.first?.alpha = 0
+
         addSubview(loadingIndicatorView)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
# Why?

We have a FINN-styled `RefreshControl`. We set the default `UIRefreshControl` icon to `.clear` to hide it and insert our own. This is for some reason not working on the first refresh, so you get duplicate icons (default and FINNs).

# What?

Made a fix where we set the alpha to 0 as well. This hides it on first refresh.

# Version Change

Patch.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-15 at 10 44 53](https://github.com/finn-no/FinniversKit/assets/17450858/3889baba-81aa-496a-a7dc-38dc5a4b5e3c) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-15 at 14 50 56](https://github.com/finn-no/FinniversKit/assets/17450858/eca815e0-dbb8-4e0d-9dd3-386d326f3d32) |