### PR TITLE
Update SwiftUI icon button accessibility traits

### DIFF
--- a/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
@@ -16,7 +16,8 @@ public struct SwiftUIIconButton: View {
 
     public var body: some View {
         Image.init(isToggled ? style.iconToggled : style.icon)
-            .accessibility(addTraits: isToggled ? [.isSelected] : [])
+            .accessibilityRemoveTraits(.isImage)
+            .accessibility(addTraits: isToggled ? [.isButton, .isSelected] : [.isButton])
             .opacity(isToggled ? 0.8 : 1)
     }
 }

--- a/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
@@ -17,7 +17,7 @@ public struct SwiftUIIconButton: View {
     public var body: some View {
         Image.init(isToggled ? style.iconToggled : style.icon)
             .accessibilityRemoveTraits(.isImage)
-            .accessibility(addTraits: isToggled ? [.isButton, .isSelected] : [.isButton])
+            .accessibilityAddTraits(isToggled ? [.isButton, .isSelected] : [.isButton])
             .opacity(isToggled ? 0.8 : 1)
     }
 }


### PR DESCRIPTION
# Why?

The button is being read as an image.

# What?

Remove the image trait and add the button trait.

# Version Change

Patch
