### PR TITLE
Using brand colors for StoryBoarderView

### DIFF
--- a/FinniversKit/Sources/Cells/SavedSearchShelfCell/StoryBorderView.swift
+++ b/FinniversKit/Sources/Cells/SavedSearchShelfCell/StoryBorderView.swift
@@ -53,10 +53,10 @@ class StoryBorderView: UIView {
 
 private extension UIColor {
     static var unreadStoryTopGradientColor: CGColor {
-        UIColor(hex: "#0063FB").cgColor
+        UIColor.nmpBrandColorPrimary.cgColor
     }
 
     static var unreadStoryBottomGradientColor: CGColor {
-        UIColor(hex: "#06BEFB").cgColor
+        UIColor.nmpBrandColorSecondary.cgColor
     }
 }


### PR DESCRIPTION
# Why?

Enabling for Tori branding for all components 

# What?

The StoryBorderView had hardcoded colors for the gradient border

# Version Change

This is a patch version

# UI Changes

FINN has a primary and secondary blue creating the gradient effect. Tori only has one brand color. For now this means that the .nmpBrandColorSecondary returns the same as the .nmpBrandColorPrimary which results in no gradient for Tori. Should we introduce a secondary color for Tori this would take effect automatically however.

Finn is unchanged as the hardcoded hex colors was the primary and secondary blue colors

Tori Before: 

![Simulator Screenshot - iPhone 14 Plus - 2023-09-07 at 08 38 06](https://github.com/finn-no/FinniversKit/assets/134999755/75353d27-195e-4f66-be49-4006817f7482)

Tori after:

![Simulator Screenshot - iPhone 14 Plus - 2023-09-07 at 08 42 19](https://github.com/finn-no/FinniversKit/assets/134999755/cea67bb5-e402-43bd-983a-759a06894a03)

FINN legendary before/after:

![Simulator Screenshot - iPhone 14 Plus - 2023-09-07 at 09 18 10](https://github.com/finn-no/FinniversKit/assets/134999755/2759010e-2e8b-4e07-a241-72b6a3507a50)
