### PR TITLE
Fix favorite icon being opposite of toggle state

### DIFF
--- a/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
@@ -15,7 +15,7 @@ public struct SwiftUIIconButton: View {
     }
 
     public var body: some View {
-        Image.init(uiImage: isToggled ? style.icon : style.iconToggled)
+        Image.init(uiImage: isToggled ? style.iconToggled : style.icon)
             .accessibilityRemoveTraits(.isImage)
             .accessibilityAddTraits(isToggled ? [.isButton, .isSelected] : [.isButton])
             .opacity(isToggled ? 0.8 : 1)


### PR DESCRIPTION
# Why?

There was a regression where the logic was flipped.

# What?

Flip it back.

# Version Change

Patch