### PR TITLE
Fixing the SwiftUIIConButton images that switched by accident

### DIFF
--- a/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
@@ -15,7 +15,7 @@ public struct SwiftUIIconButton: View {
     }
 
     public var body: some View {
-        Image.init(uiImage: isToggled ? style.icon : style.iconToggled)
+        Image.init(uiImage: isToggled ? style.iconToggled : style.icon)
             .accessibilityRemoveTraits(.isImage)
             .accessibilityAddTraits(isToggled ? [.isButton, .isSelected] : [.isButton])
             .opacity(isToggled ? 0.8 : 1)


### PR DESCRIPTION
# Why?

A previous PR have accidentally switched around the bool statement for these icons  

# What?

Fixing the isToggled image use for SwiftUIIconButton

# Version Change

A patch change