### PR TITLE
Add support for  messagesReceived

### DIFF
--- a/Demo/Sources/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Sources/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -60,7 +60,8 @@ class AdManagementDemoView: UIView {
     private static var exampleStatisticsCellModels: [StatisticsItemModel] = [
         .init(type: .seen, value: 968, text: "har sett annonsen"),
         .init(type: .favourited, value: 16, text: "har lagret annonsen"),
-        .init(type: .email, value: 1337, text: "har fått e-post om annonsen")
+        .init(type: .email, value: 1337, text: "har fått e-post om annonsen"),
+        .init(type: .messagesReceived, value: 500, text: "messages received")
     ]
 
     private var statisticsCellModels: [StatisticsItemModel] = exampleStatisticsCellModels {

--- a/Demo/Sources/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
+++ b/Demo/Sources/Recycling/ListViews/AdManagement/AdManagementDemoView.swift
@@ -60,8 +60,7 @@ class AdManagementDemoView: UIView {
     private static var exampleStatisticsCellModels: [StatisticsItemModel] = [
         .init(type: .seen, value: 968, text: "har sett annonsen"),
         .init(type: .favourited, value: 16, text: "har lagret annonsen"),
-        .init(type: .email, value: 1337, text: "har fått e-post om annonsen"),
-        .init(type: .messagesReceived, value: 500, text: "messages received")
+        .init(type: .email, value: 1337, text: "har fått e-post om annonsen")
     ]
 
     private var statisticsCellModels: [StatisticsItemModel] = exampleStatisticsCellModels {

--- a/FinniversKit/Sources/Components/StatisticsView/StatisticsItemModel.swift
+++ b/FinniversKit/Sources/Components/StatisticsView/StatisticsItemModel.swift
@@ -8,6 +8,7 @@ public struct StatisticsItemModel {
     public enum StatisticsItemType {
         case seen
         case favourited
+        case messagesReceived
         case email
     }
 

--- a/FinniversKit/Sources/Components/StatisticsView/StatisticsItemView.swift
+++ b/FinniversKit/Sources/Components/StatisticsView/StatisticsItemView.swift
@@ -74,6 +74,8 @@ final class StatisticsItemView: UIView {
                 return UIImage(named: .statsClick).withRenderingMode(.alwaysTemplate)
             case .favourited:
                 return UIImage(named: .statsHeart).withRenderingMode(.alwaysTemplate)
+            case .messagesReceived:
+                return UIImage(named: .statsEnvelope).withRenderingMode(.alwaysTemplate)
             }
         }
 


### PR DESCRIPTION
# Why?
FinniversKit didn't support the `messagesReceived` case for statistics.

# What?

Add support for the `messagesReceived` case.

# Version Change

Minor change