### PR TITLE
I os] render the (market) label in two lines

### DIFF
--- a/FinniversKit/Sources/Components/Label/Label.swift
+++ b/FinniversKit/Sources/Components/Label/Label.swift
@@ -15,7 +15,7 @@ public class Label: UILabel {
 
     public init(
         style: Style,
-        numberOfLines: Int = 1,
+        numberOfLines: Int = 2,
         textColor: UIColor = .textPrimary,
         withAutoLayout: Bool = false
     ) {

--- a/FinniversKit/Sources/Components/Label/Label.swift
+++ b/FinniversKit/Sources/Components/Label/Label.swift
@@ -15,7 +15,7 @@ public class Label: UILabel {
 
     public init(
         style: Style,
-        numberOfLines: Int = 2,
+        numberOfLines: Int = 1,
         textColor: UIColor = .textPrimary,
         withAutoLayout: Bool = false
     ) {

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
@@ -8,6 +8,8 @@ class MarketsGridViewCell: UICollectionViewCell {
     // MARK: - Internal properties
 
     private let cornerRadius: CGFloat = 16
+    
+    var isFinn: Bool = true
 
     private lazy var sharpShadowView: UIView = {
         let view = UIView(withAutoLayout: true)
@@ -95,12 +97,14 @@ class MarketsGridViewCell: UICollectionViewCell {
         smoothShadowView.fillInSuperview()
         containerView.fillInSuperview()
 
+        contentStackView.spacing = 8
+        
         NSLayoutConstraint.activate([
             iconImageView.heightAnchor.constraint(equalToConstant: 28),
             iconImageView.widthAnchor.constraint(equalToConstant: 42),
 
-            contentStackView.widthAnchor.constraint(equalTo: widthAnchor),
-            contentStackView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor),
+            contentStackView.widthAnchor.constraint(equalTo: widthAnchor - 8),
+            contentStackView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor - 20),
             contentStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             externalLinkImageView.topAnchor.constraint(equalTo: topAnchor, constant: 8),

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
@@ -103,8 +103,8 @@ class MarketsGridViewCell: UICollectionViewCell {
             iconImageView.heightAnchor.constraint(equalToConstant: 28),
             iconImageView.widthAnchor.constraint(equalToConstant: 42),
 
-            contentStackView.widthAnchor.constraint(equalTo: widthAnchor - 8),
-            contentStackView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor - 20),
+            contentStackView.widthAnchor.constraint(equalTo: widthAnchor, constant: -8),
+            contentStackView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor, constant: -20),
             contentStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             externalLinkImageView.topAnchor.constraint(equalTo: topAnchor, constant: 8),

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
@@ -71,7 +71,6 @@ class MarketsGridViewCell: UICollectionViewCell {
     }()
 
     // MARK: - Setup
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -101,11 +100,11 @@ class MarketsGridViewCell: UICollectionViewCell {
         
         NSLayoutConstraint.activate([
             iconImageView.heightAnchor.constraint(equalToConstant: 28),
-            iconImageView.widthAnchor.constraint(equalToConstant: 42),
 
             contentStackView.widthAnchor.constraint(equalTo: widthAnchor, constant: -8),
             contentStackView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor, constant: -20),
             contentStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            contentStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
 
             externalLinkImageView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             externalLinkImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
@@ -30,7 +30,8 @@ public class MarketsGridView: UIView, MarketsView {
     private weak var delegate: MarketsViewDelegate?
     private weak var dataSource: MarketsViewDataSource?
     
-    public var isFinn: Bool = true //how to tell is the user is in finn?
+    //how to tell is the user is in finn?
+    public var isFinn: Bool = true
 
     private var itemSize = CGSize(width: 92, height: 72)
     private let itemSpacing: CGFloat = .spacingS

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
@@ -29,8 +29,10 @@ public class MarketsGridView: UIView, MarketsView {
 
     private weak var delegate: MarketsViewDelegate?
     private weak var dataSource: MarketsViewDataSource?
+    
+    public var isFinn: Bool = true //how to tell is the user is in finn?
 
-    private let itemSize = CGSize(width: 92, height: 72)
+    private var itemSize = CGSize(width: 92, height: 72)
     private let itemSpacing: CGFloat = .spacingS
     private let sideMargin: CGFloat = .spacingM
     private let rowSpacing: CGFloat = .spacingS
@@ -83,6 +85,13 @@ public class MarketsGridView: UIView, MarketsView {
         backgroundColor = .clear
         collectionView.register(MarketsGridViewCell.self)
         addSubview(collectionView)
+        
+        if isFinn {
+            itemSize = CGSize(width: 92, height: 72)
+        }
+        else {
+            itemSize = CGSize(width: 96, height: 88)
+        }
 
         collectionView.fillInSuperview()
 
@@ -119,7 +128,7 @@ public class MarketsGridView: UIView, MarketsView {
         let gridInsets = insets(for: width)
         let rows = numberOfRows(for: width)
 
-        let height = (itemSize.height * CGFloat(rows)) + (rowSpacing * CGFloat(rows - 1)) + gridInsets.top + gridInsets.bottom
+        var height = (itemSize.height * CGFloat(rows)) + (rowSpacing * CGFloat(rows - 1)) + gridInsets.top + gridInsets.bottom
 
         return CGSize(width: width, height: height)
     }
@@ -249,6 +258,8 @@ extension MarketsGridView: UICollectionViewDataSource {
         if let model = dataSource?.marketsView(self, modelAtIndex: indexPath.row) {
             cell.model = model
         }
+        
+        cell.isFinn = isFinn
 
         return cell
     }

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
@@ -30,7 +30,6 @@ public class MarketsGridView: UIView, MarketsView {
     private weak var delegate: MarketsViewDelegate?
     private weak var dataSource: MarketsViewDataSource?
     
-    //how to tell is the user is in finn?
     public var isFinn: Bool = true
 
     private var itemSize = CGSize(width: 92, height: 72)
@@ -128,7 +127,7 @@ public class MarketsGridView: UIView, MarketsView {
         let gridInsets = insets(for: width)
         let rows = numberOfRows(for: width)
 
-        var height = (itemSize.height * CGFloat(rows)) + (rowSpacing * CGFloat(rows - 1)) + gridInsets.top + gridInsets.bottom
+        let height = (itemSize.height * CGFloat(rows)) + (rowSpacing * CGFloat(rows - 1)) + gridInsets.top + gridInsets.bottom
 
         return CGSize(width: width, height: height)
     }

--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/MarketsGridView.swift
@@ -88,8 +88,7 @@ public class MarketsGridView: UIView, MarketsView {
         
         if isFinn {
             itemSize = CGSize(width: 92, height: 72)
-        }
-        else {
+        } else {
             itemSize = CGSize(width: 96, height: 88)
         }
 


### PR DESCRIPTION
# Why?

 Finn Legendary has a small issue with the rendering i.e “Feriehus..” label renders too close to the edges,

# What?

The markets-grid cell is updated to render their labels correctly according to what version of the app it is.

# Version Change

minor patch to render the labels correctly in the MarketsGridViewCell

# UI Changes



