### PR TITLE
Add full width parameter for default style buttons

### DIFF
--- a/FinniversKit/Sources/Base Components/ButtonStyle.swift
+++ b/FinniversKit/Sources/Base Components/ButtonStyle.swift
@@ -53,27 +53,34 @@ public struct DefaultStyle: ButtonStyle {
     private let size: Button.Size
     private let font: Font
     private let textColor: Color
+    private let fullWidth: Bool
     private let padding: EdgeInsets
 
     public init(
         size: Button.Size = .normal,
         textColor: Color = .btnPrimary,
+        fullWidth: Bool = true,
         padding: EdgeInsets = .init(top: .spacingS, leading: .spacingM, bottom: .spacingS, trailing: .spacingM)
     ) {
         self.size = size
         self.font = size == .normal ? .finnFont(.bodyStrong) : .finnFont(.detailStrong)
         self.textColor = textColor
+        self.fullWidth = fullWidth
         self.padding = padding
     }
 
     public func makeBody(configuration: Configuration) -> some View {
         HStack {
-            Spacer()
+            if fullWidth {
+                Spacer()
+            }
             configuration
                 .label
                 .font(font)
                 .foregroundColor(textColor)
-            Spacer()
+            if fullWidth {
+                Spacer()
+            }
         }
         .padding(padding)
         .background(

--- a/FinniversKit/Sources/Base Components/ButtonStyle.swift
+++ b/FinniversKit/Sources/Base Components/ButtonStyle.swift
@@ -140,3 +140,26 @@ public struct CallToAction: ButtonStyle {
         configuration.isPressed ? background.opacity(0.8) : background
     }
 }
+
+#Preview {
+    VStack {
+        HStack(spacing: 0) {
+            Text("Example ")
+                .finnFont(.body)
+            SwiftUI.Button("inline style", action: {})
+                .buttonStyle(InlineFlatStyle())
+            Text(" with some text")
+                .finnFont(.body)
+        }
+        SwiftUI.Button("Flat", action: {})
+            .buttonStyle(FlatStyle())
+        SwiftUI.Button("Default (full width)", action: {})
+            .buttonStyle(DefaultStyle())
+        SwiftUI.Button("Default", action: {})
+            .buttonStyle(DefaultStyle(fullWidth: false))
+        SwiftUI.Button("Call to action (full width)", action: {})
+            .buttonStyle(CallToAction())
+        SwiftUI.Button("Call to action", action: {})
+            .buttonStyle(CallToAction(fullWidth: false))
+    }
+}


### PR DESCRIPTION
# Why?

Missing option that we already have for CTA style. 

# What?

Add a parameter for turning off full width on default style buttons.

# Version Change

Minor

# UI Changes

<img width="300" alt="Screenshot 2023-11-13 at 12 32 02" src="https://github.com/finn-no/FinniversKit/assets/9058089/1d71e4ea-2732-40b6-82cf-b2465d69c013">
