### PR TITLE
Nmp branding adjustments

### DIFF
--- a/FinniversKit/Sources/DNA/Color/ColorProvider.swift
+++ b/FinniversKit/Sources/DNA/Color/ColorProvider.swift
@@ -39,6 +39,7 @@ public protocol ColorProvider {
     var iconTertiary: UIColor { get }
     var borderDefault: UIColor { get }
     var marketplaceNavigationBarIcon: UIColor { get }
+    var nmpBrandTabBarIconSelected: UIColor { get }
     var nmpBrandColorPrimary: UIColor { get }
     var nmpBrandColorSecondary: UIColor { get }
     var nmpBrandControlSelected: UIColor { get }
@@ -188,6 +189,10 @@ public struct DefaultColorProvider: ColorProvider {
     }
 
     // NMP brand colors
+    public var nmpBrandTabBarIconSelected: UIColor {
+        .dynamicColor(defaultColor: .blue600, darkModeColor: .darkCallToAction)
+    }
+
     public var nmpBrandControlSelected: UIColor {
         .blue600
     }

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -40,6 +40,8 @@ import UIKit
     public class var textTertiary: UIColor { Config.colorProvider.textTertiary }
     public class var textToast: UIColor { Config.colorProvider.textToast }
     public class var marketplaceNavigationBarIcon: UIColor { Config.colorProvider.marketplaceNavigationBarIcon }
+    public class var nmpBrandTabBarIcon: UIColor {
+        Config.colorProvider.nmpBrandTabBarIconSelected }
     public class var nmpBrandColorPrimary: UIColor { Config.colorProvider.nmpBrandColorPrimary }
     public class var nmpBrandColorSecondary: UIColor { Config.colorProvider.nmpBrandColorSecondary }
     public class var nmpBrandControlSelected: UIColor { Config.colorProvider.nmpBrandControlSelected }
@@ -81,6 +83,8 @@ extension CGColor {
     public class var textTertiary: CGColor { UIColor.textTertiary.cgColor }
     public class var textToast: CGColor { UIColor.textToast.cgColor }
     public class var marketplaceNavigationBarIcon: CGColor { Config.colorProvider.marketplaceNavigationBarIcon.cgColor }
+    public class var nmpBrandTabBarIcon: CGColor {
+        Config.colorProvider.nmpBrandTabBarIconSelected.cgColor }
     public class var nmpBrandColorPrimary: CGColor { Config.colorProvider.nmpBrandColorPrimary.cgColor }
     public class var nmpBrandColorSecondary: CGColor { Config.colorProvider.nmpBrandColorSecondary.cgColor }
     public class var nmpBrandControlSelected: CGColor { Config.colorProvider.nmpBrandControlSelected.cgColor }

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -40,7 +40,7 @@ import UIKit
     public class var textTertiary: UIColor { Config.colorProvider.textTertiary }
     public class var textToast: UIColor { Config.colorProvider.textToast }
     public class var marketplaceNavigationBarIcon: UIColor { Config.colorProvider.marketplaceNavigationBarIcon }
-    public class var nmpBrandTabBarIcon: UIColor {
+    public class var nmpBrandTabBarIconSelected: UIColor {
         Config.colorProvider.nmpBrandTabBarIconSelected }
     public class var nmpBrandColorPrimary: UIColor { Config.colorProvider.nmpBrandColorPrimary }
     public class var nmpBrandColorSecondary: UIColor { Config.colorProvider.nmpBrandColorSecondary }
@@ -83,7 +83,7 @@ extension CGColor {
     public class var textTertiary: CGColor { UIColor.textTertiary.cgColor }
     public class var textToast: CGColor { UIColor.textToast.cgColor }
     public class var marketplaceNavigationBarIcon: CGColor { Config.colorProvider.marketplaceNavigationBarIcon.cgColor }
-    public class var nmpBrandTabBarIcon: CGColor {
+    public class var nmpBrandTabBarIconSelected: CGColor {
         Config.colorProvider.nmpBrandTabBarIconSelected.cgColor }
     public class var nmpBrandColorPrimary: CGColor { Config.colorProvider.nmpBrandColorPrimary.cgColor }
     public class var nmpBrandColorSecondary: CGColor { Config.colorProvider.nmpBrandColorSecondary.cgColor }


### PR DESCRIPTION
# Why?

Enable branding for NMP apps

# What?

A new colour is added here to enable the correct colours for the NMP apps and keep the same for FINN legendary. After a workshop preparing apps for internal verification its clear that we needed more granularity in the colours to meet the design we would like. 

In this specific case its for the tabBar where we want to (keep) use the primaryColor for FINN legendary but the secondaryColor (watermelon) for Tori. This is not a colour pattern we have seen before and is an odd one out. This was the quickest solution without impacting any other places we apply colour schemes

# Version Change

Breaking change as its a new addition to the protocol

# UI Changes

No visible changes in FinniversKit