### PR TITLE
Using ColorProvider color for marketgrid icons

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/Markets/GridView/Cell/MarketsGridViewCell.swift
@@ -40,6 +40,7 @@ class MarketsGridViewCell: UICollectionViewCell {
 
     private lazy var iconImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.tintColor = .marketplaceNavigationBarIcon
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         imageView.setContentHuggingPriority(.defaultHigh, for: .vertical)


### PR DESCRIPTION
# Why?

Enable NMP brand styling for apps

# What?

The MarketGridViewCell images seemed to inherit their tintColor from the `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME`. 

This colour is now being deleted and instead we are parsing the Window when setting up different Appearances. See this branch for more context: https://github.schibsted.io/finn/ios-app/compare/fix/nmp-accent-color?expand=1

For Tori the primary colour has also changed changed to .petrolium so the marketgrid icons would now inherit this colour as their tintColor which is the wrong branding.

We need to change it to .watermelon but still keep the secondaryBlue (aqua400) for FINN legendary. 

This PR resolves this by setting the: `.marketplaceNavigationBarIcon` as tintColor on the MarketGridViewCell icon images

# Version Change

Patch version with a small change.

# UI Changes

FINN legendary has no UI changes 

NMP Tori will have wrong tint when we merged the branch mentioned above: 

Before this fix:
![Simulator Screenshot - iPhone 14 Pro - 2023-11-21 at 13 58 14](https://github.com/finn-no/FinniversKit/assets/134999755/a69d03e8-9b36-4820-95ee-3108736179cd)

After this fix:
![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 20 27 46](https://github.com/finn-no/FinniversKit/assets/134999755/e12ac9a4-ce96-4eb2-aeac-d19b56df0072)

