### PR TITLE
New color variable for the Tori loading indicator

### DIFF
--- a/FinniversKit/Sources/Components/LoadingIndicator/LoadingIndicatorView.swift
+++ b/FinniversKit/Sources/Components/LoadingIndicator/LoadingIndicatorView.swift
@@ -98,7 +98,7 @@ extension LoadingIndicatorView {
         backgroundLayer.lineCap = .round
 
         animatedLayer.fillColor = UIColor.clear.cgColor
-        animatedLayer.strokeColor = UIColor.accentSecondaryBlue.cgColor
+        animatedLayer.strokeColor = UIColor.loadingIndicator.cgColor
         animatedLayer.strokeStart = 0
         animatedLayer.strokeEnd = 1
         animatedLayer.lineWidth = lineWidth

--- a/FinniversKit/Sources/DNA/Color/ColorProvider.swift
+++ b/FinniversKit/Sources/DNA/Color/ColorProvider.swift
@@ -44,6 +44,7 @@ public protocol ColorProvider {
     var nmpBrandColorSecondary: UIColor { get }
     var nmpBrandControlSelected: UIColor { get }
     var nmpBrandDecoration: UIColor { get }
+    var loadingIndicator: UIColor { get }
 }
 
 // MARK: - Default FINN colors
@@ -206,6 +207,10 @@ public struct DefaultColorProvider: ColorProvider {
     }
 
     public var nmpBrandColorSecondary: UIColor {
+        .aqua400
+    }
+
+    public var loadingIndicator: UIColor {
         .aqua400
     }
 }

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -30,6 +30,7 @@ import UIKit
     public class var iconSecondary: UIColor { Config.colorProvider.iconSecondary }
     public class var iconTertiary: UIColor { Config.colorProvider.iconTertiary }
     public class var imageBorder: UIColor { Config.colorProvider.imageBorder }
+    public class var loadingIndicator: UIColor { Config.colorProvider.loadingIndicator }
     public class var tableViewSeparator: UIColor { Config.colorProvider.tableViewSeparator }
     public class var textAction: UIColor { Config.colorProvider.textAction }
     public class var textCritical: UIColor { Config.colorProvider.textCritical }


### PR DESCRIPTION
# Why?
The Loading icon is gray without animation for Tori.

# What?
In conversation with @christian-therkelsen, a new color is introduced to match the Android loading indicator, as we did not have any brand-specific colors that matched the criteria of the spinner. @mohsen-schibsted have a separate branch that is a work in progress to use Warp colors instead of Fabric colors, and therefore no more work is done on this for now (ex. file content in alphabetical order). Finn loading color is not changed. Related commit: https://github.schibsted.io/finn/ios-app/commit/3a3e88a3ab2b8a313b9d79bb0bf37488e0b29e83 

# Version Change
The change is breaking since the ToriColorProvider holds the variable for Tori.

# UI Changes
| Before | After |
| --- | --- |
| _![loadingBefore](https://github.com/finn-no/FinniversKit/assets/1043747/94430daf-c73f-43ac-80b3-5cfbbd8f8e44)_ | _![after](https://github.com/finn-no/FinniversKit/assets/1043747/4062221f-4f52-4a61-9a82-42602a89018a)_ |
