### PR TITLE
actually force remove the callout from the view

### DIFF
--- a/FinniversKit/Sources/Components/Callout/CalloutView.swift
+++ b/FinniversKit/Sources/Components/Callout/CalloutView.swift
@@ -107,7 +107,10 @@ public final class CalloutView: UIView {
             animations: { [weak self] in
                 self?.alpha = 0
             },
-            completion: completion
+            completion: { [weak self] finished in
+                self?.removeFromSuperview()
+                completion?(finished)
+            }
         )
     }
 


### PR DESCRIPTION
# Why?
The CalloutView is not actually removed from the view on hide, only the alpha value is set to zero. This is creating problems for callouts when they are opened via notifications.

# What?
After the fade-out animation is complete, the `removeFromSuperview()` method is called as a completion. This ensures that the view is not only hidden but also removed from the view hierarchy. 