### PR TITLE
New semantic color for sponsored ribbons

### DIFF
--- a/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -26,7 +26,7 @@ public extension RibbonView {
 
         var textColor: UIColor {
             switch self {
-            case .default, .disabled: return .textPrimary
+            case .default, .disabled, .sponsored: return .textPrimary
             default: return .textToast
             }
         }

--- a/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -20,7 +20,7 @@ public extension RibbonView {
             case .warning: return .bgAlert
             case .error: return .bgCritical
             case .disabled: return .decorationSubtle
-            case .sponsored: return .accentToothpaste
+            case .sponsored: return .bgSponsored
             }
         }
 

--- a/FinniversKit/Sources/DNA/Color/ColorProvider.swift
+++ b/FinniversKit/Sources/DNA/Color/ColorProvider.swift
@@ -124,7 +124,7 @@ public struct DefaultColorProvider: ColorProvider {
     }
 
     public var bgSponsored: UIColor {
-        .aqua200
+        .dynamicColor(defaultColor: .aqua200, darkModeColor: .aqua600)
     }
 
     public var borderInfo: UIColor {

--- a/FinniversKit/Sources/DNA/Color/ColorProvider.swift
+++ b/FinniversKit/Sources/DNA/Color/ColorProvider.swift
@@ -19,6 +19,7 @@ public protocol ColorProvider {
     var bgInfoHeader: UIColor { get }
     var bgSuccess: UIColor { get }
     var bgCritical: UIColor { get }
+    var bgSponsored: UIColor { get }
     var borderInfo: UIColor { get }
     var borderNegative: UIColor { get }
     var borderPositive: UIColor { get }
@@ -120,6 +121,10 @@ public struct DefaultColorProvider: ColorProvider {
 
     public var bgWarningSubtle: UIColor {
         .dynamicColor(defaultColor: .yellow50, darkModeColor: .yellow900)
+    }
+
+    public var bgSponsored: UIColor {
+        .aqua200
     }
 
     public var borderInfo: UIColor {

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -24,6 +24,7 @@ import UIKit
     public class var bgSecondary: UIColor { Config.colorProvider.bgSecondary }
     public class var bgSuccess: UIColor { Config.colorProvider.bgSuccess }
     public class var bgTertiary: UIColor { Config.colorProvider.bgTertiary }
+    public class var bgSponsored: UIColor { Config.colorProvider.bgSponsored }
     public class var borderDefault: UIColor { Config.colorProvider.borderDefault }
     public class var borderInfoSubtle: UIColor { Config.colorProvider.borderInfoSubtle }
     public class var borderNegativeSubtle: UIColor { Config.colorProvider.borderNegativeSubtle }


### PR DESCRIPTION
# Why?

We currently use accentToothpaste color for sponsored ribbons. This semantic color is watermelon in Tori, but sponsored ribbons shouldn't be watermelon. 

# What?

We can't just change accentToothpaste to be something else in Tori, since it's used many other places as well. So to fix this I added a new semantic color which is a part of Warp. It's called `bgSponsored`. To avoid introducing any new changes in FINN, I have kept the static `aqua200` color, even though this one will be dark mode compatible in Warp at a later point.

# Version Change

Breaking change.

# UI Changes

No UI changes in FinniversKit, as we don't have Tori colors here.