### PR TITLE
Change ArReporterView configuration

### DIFF
--- a/Demo/Sources/Fullscreen/AdReporter/AdReporterDemoView.swift
+++ b/Demo/Sources/Fullscreen/AdReporter/AdReporterDemoView.swift
@@ -7,7 +7,6 @@ import DemoKit
 
 struct AdReporterViewData: AdReporterViewModel {
     var radioButtonTitle = "Hva gjelder det?"
-    var radioButtonFields = ["Mistanke om svindel", "Regelbrudd", "Forhandler opptrer som privat"]
     var descriptionViewTitle = "Beskrivelse"
     var descriptionViewPlaceholderText = "Beskriv kort hva problemet er"
     var helpButtonText = "Trenger du hjelp?"
@@ -20,6 +19,7 @@ class AdReporterDemoView: UIView, Demoable {
     private lazy var adReporterView: AdReporterView = {
         let view = AdReporterView(frame: .zero)
         view.model = AdReporterViewData()
+        view.setRadioButtonFields(["Mistanke om svindel", "Regelbrudd", "Forhandler opptrer som privat"])
         view.reporterDelegate = self
         view.alwaysBounceVertical = true
         view.keyboardDismissMode = .interactive

--- a/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterView.swift
+++ b/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterView.swift
@@ -53,11 +53,14 @@ public class AdReporterView: UIScrollView {
         didSet {
             guard let model = model else { return }
             radioButton.title = model.radioButtonTitle
-            radioButton.fields = model.radioButtonFields
             descriptionView.titleLabel.text = model.descriptionViewTitle
             descriptionView.textView.placeholderText = model.descriptionViewPlaceholderText
             helpButton.setTitle(model.helpButtonText, for: .normal)
         }
+    }
+
+    public func setRadioButtonFields(_ fields: [String]) {
+        radioButton.fields = fields
     }
 
     public var message: String {

--- a/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterViewModel.swift
+++ b/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterViewModel.swift
@@ -1,12 +1,7 @@
-//
-//  Copyright © FINN.no AS, Inc. All rights reserved.
-//
-
 import UIKit
 
 public protocol AdReporterViewModel {
     var radioButtonTitle: String { get }
-    var radioButtonFields: [String] { get }
     var descriptionViewTitle: String { get }
     var descriptionViewPlaceholderText: String { get }
     var helpButtonText: String { get }


### PR DESCRIPTION
# Why?

Previously AdReportView could be configured without waiting a network request, but now we receive report types so it should be configured apart of all localized stuff 

# What?

Change way of configuring AdReportView 

# Version Change

Major

# UI Changes

![new](https://media.github.schibsted.io/user/7250/files/e050a986-9e0b-40fd-b3d4-325206973a1b)

