### PR TITLE
Add borderSecondary semantic color - to use on map overlays

### DIFF
--- a/FinniversKit/Sources/DNA/Color/ColorProvider.swift
+++ b/FinniversKit/Sources/DNA/Color/ColorProvider.swift
@@ -29,6 +29,7 @@ public protocol ColorProvider {
     var borderNegativeSubtle: UIColor { get }
     var borderPositiveSubtle: UIColor { get }
     var borderWarningSubtle: UIColor { get }
+    var borderSecondary: UIColor { get }
     var btnPrimary: UIColor { get }
     var btnDisabled: UIColor { get }
     var btnCritical: UIColor { get }
@@ -162,6 +163,10 @@ public struct DefaultColorProvider: ColorProvider {
 
     public var borderWarningSubtle: UIColor {
         .dynamicColor(defaultColor: .yellow300, darkModeColor: .yellow700)
+    }
+
+    public var borderSecondary: UIColor {
+        .aqua400
     }
 
     public var btnPrimary: UIColor {

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -35,6 +35,7 @@ import UIKit
     public class var borderPositive: UIColor { Config.colorProvider.borderPositive }
     public class var borderWarning: UIColor { Config.colorProvider.borderWarning }
     public class var borderCallout: UIColor { Config.colorProvider.borderCallout }
+    public class var borderSecondary: UIColor { Config.colorProvider.borderSecondary }
     public class var btnCritical: UIColor { Config.colorProvider.btnCritical }
     public class var btnDisabled: UIColor { Config.colorProvider.btnDisabled }
     public class var btnPrimary: UIColor { Config.colorProvider.btnPrimary }


### PR DESCRIPTION
# Why?

We need a new semantic color to use on map overlays. 

# What?

- Add `borderSecondary` which is `aqua400` in FINN.

# Version Change

Breaking, another color needs to be injected in Tori.

# UI Changes

No UI change in this repo.