### PR TITLE
Primary text color on disabled map button

### DIFF
--- a/FinniversKit/Sources/Components/MapAddressButton/MapAddressButton.swift
+++ b/FinniversKit/Sources/Components/MapAddressButton/MapAddressButton.swift
@@ -60,7 +60,7 @@ public class MapAddressButton: UIView {
     }
 
     public func setButton(isEnabled: Bool) {
-        let titleColor: UIColor = isEnabled ? buttonStyle.textColor : buttonStyle.disabledTextColor ?? .textDisabled
+        let titleColor: UIColor = isEnabled ? buttonStyle.textColor : .textPrimary
         buttonStyle = buttonStyle.overrideStyle(textColor: titleColor)
         button.isUserInteractionEnabled = isEnabled
 


### PR DESCRIPTION
# Why?

We have been using `textDisabled` on disabled map button. This will make the component blend in a bit with the background. 

# What?

When it comes to addresses, it doesn't make sense to use this color if it's not clickable. Then the address is a piece of useful information that can have a `textPrimary` color, to look like any other text on the page.

# Version Change

Minor.

# UI Changes

## Light mode 

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-21 at 16 02 57](https://github.com/finn-no/FinniversKit/assets/17450858/5253d1c2-b3a8-45e0-bff4-426050a0d919) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-21 at 16 04 08](https://github.com/finn-no/FinniversKit/assets/17450858/52b4b602-0e34-4dac-bbfa-f7069904659c) |

## Dark mode

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-21 at 16 03 03](https://github.com/finn-no/FinniversKit/assets/17450858/51f14d3d-f7c8-4f82-8640-6967fb883a60) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-21 at 16 03 53](https://github.com/finn-no/FinniversKit/assets/17450858/49a04507-ac0d-4614-8e35-995ef5b758ea) |
