### PR TITLE
Publicly expose separator inset for IconTitleTableViewCell

### DIFF
--- a/FinniversKit/Sources/Cells/IconTitleTableViewCell/IconTitleTableViewCell.swift
+++ b/FinniversKit/Sources/Cells/IconTitleTableViewCell/IconTitleTableViewCell.swift
@@ -20,6 +20,10 @@ open class IconTitleTableViewCell: BasicTableViewCell {
         return imageView
     }()
 
+    public var iconSeparatorInset: CGFloat {
+        .spacingM + iconSize + .spacingM
+    }
+
     // MARK: - Private properties
 
     let iconSize: CGFloat = 24
@@ -67,7 +71,7 @@ open class IconTitleTableViewCell: BasicTableViewCell {
             stackViewToIconConstraint.isActive = true
 
             // align it with the text, considering the size of the icon
-            separatorInset = .leadingInset(.spacingM + iconSize + .spacingM)
+            separatorInset = .leadingInset(iconSeparatorInset)
         } else {
             stackViewToIconConstraint.isActive = false
             stackViewLeadingAnchorConstraint.isActive = true


### PR DESCRIPTION
# Why?

We need it in order to set and reset separators in My Page. (Hide separator on last cell).

# What?

Expose this as a public var.

Merging this into my other dev branch for the same feature.

# Version Change

Minor.

# UI Changes

None.