### PR TITLE
Use lowercase year in date formatter

### DIFF
--- a/Demo/Sources/Fullscreen/FavoriteAdsListView/FavoriteAdsDemoDataSource.swift
+++ b/Demo/Sources/Fullscreen/FavoriteAdsListView/FavoriteAdsDemoDataSource.swift
@@ -73,7 +73,7 @@ class FavoriteAdsDemoDataSource {
         if year == currentYear {
             FavoriteAdsDemoDataSource.dateFormatter.dateFormat = "MMMM"
         } else {
-            FavoriteAdsDemoDataSource.dateFormatter.dateFormat = "MMMM YYYY"
+            FavoriteAdsDemoDataSource.dateFormatter.dateFormat = "MMMM yyyy"
         }
 
         return FavoriteAdsDemoDataSource.dateFormatter.string(from: date)


### PR DESCRIPTION
# Why?

Change year formatting (YY and YYYY) into lowercase to get the actual year instead of year of the week 🤯

In short, a date like 31 Dec 2024 would be 2024 using `yyyy` but 2025 using `YYYY`. See [this article](https://www.swiftwithvincent.com/blog/bad-practice-using-yyyy-to-format-a-date), among many.

# Version Change

Patch