### PR TITLE
FeedbackView: Refactor state handling

### DIFF
--- a/Demo/Sources/Components/Feedback/FeedbackDemoView.swift
+++ b/Demo/Sources/Components/Feedback/FeedbackDemoView.swift
@@ -101,37 +101,43 @@ class FeedbackDemoView: UIView, Demoable {
 
 // MARK: - SingleQuestionFeedback
 
-class SingleQuestionFeedback: FeedbackViewDelegate {
-    let viewModels: [FeedbackView.State: FeedbackViewModel] = [
-        .initial: FeedbackViewModel(title: "Tjohei! Hvordan var det å bruke det nye filteret?", positiveButtonTitle: "Gi tilbakemelding"),
-        .finished: FeedbackViewModel(title: "Takk!\nVi setter pris på din tilbakemelding - det hjelper oss med å bli bedre")
-    ]
-
-    func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forState state: FeedbackView.State) {
-        feedbackView.setState(.finished, withViewModel: viewModels[.finished]!) // swiftlint:disable:this force_unwrapping
+private class SingleQuestionFeedback: FeedbackViewDelegate {
+    func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forStep stepIdentifier: String) {
+        let step = FeedbackStep.finished
+        feedbackView.configure(stepIdentifier: step, viewModel: step.viewModel)
     }
 
     func createFeedbackView() -> FeedbackView {
         let feedbackView = FeedbackView(withAutoLayout: true)
         feedbackView.delegate = self
-        feedbackView.setState(.initial, withViewModel: viewModels[.initial]!) // swiftlint:disable:this force_unwrapping
+
+        let initialStep = FeedbackStep.initial
+        feedbackView.configure(stepIdentifier: initialStep, viewModel: initialStep.viewModel)
         return feedbackView
+    }
+
+    enum FeedbackStep: String {
+        case initial
+        case finished
+
+        var viewModel: FeedbackViewModel {
+            switch self {
+            case .initial:
+                FeedbackViewModel(title: "Tjohei! Hvordan var det å bruke det nye filteret?", positiveButtonTitle: "Gi tilbakemelding")
+            case .finished:
+                FeedbackViewModel(title: "Takk!\nVi setter pris på din tilbakemelding - det hjelper oss med å bli bedre")
+            }
+        }
     }
 }
 
 // MARK: - MultiQuestionFeedback
 
-class MultiQuestionFeedback: FeedbackViewDelegate {
-    let viewModels: [FeedbackView.State: FeedbackViewModel] = [
-        .initial: FeedbackViewModel(title: "Liker du FINN appen?", positiveButtonTitle: "Ja!", negativeButtonTitle: "Niks."),
-        .accept: FeedbackViewModel(title: "Hurra! Hva med å gi oss noen stjerner i App Store?", positiveButtonTitle: "Klart!", negativeButtonTitle: "Nei"),
-        .decline: FeedbackViewModel(title: "Å nei! Lyst til å hjelpe oss med å bli bedre?", positiveButtonTitle: "Klart!", negativeButtonTitle: "Nei"),
-        .finished: FeedbackViewModel(title: "Takk!\nVi setter pris på din tilbakemelding - det hjelper oss med å bli bedre")
-    ]
+private class MultiQuestionFeedback: FeedbackViewDelegate {
+    func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forStep stepIdentifier: String) {
+        let newState: FeedbackStep
 
-    public func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forState state: FeedbackView.State) {
-        let newState: FeedbackView.State
-        switch (state, buttonType) {
+        switch (FeedbackStep(rawValue: stepIdentifier), buttonType) {
         case (.initial, .positive):
             newState = .accept
         case (.initial, .negative):
@@ -140,14 +146,35 @@ class MultiQuestionFeedback: FeedbackViewDelegate {
             newState = .finished
         }
 
-        guard let viewModel = viewModels[newState] else { return }
-        feedbackView.setState(newState, withViewModel: viewModel)
+        feedbackView.configure(stepIdentifier: newState, viewModel: newState.viewModel)
     }
 
     func createFeedbackView() -> FeedbackView {
         let feedbackView = FeedbackView(withAutoLayout: true)
         feedbackView.delegate = self
-        feedbackView.setState(.initial, withViewModel: viewModels[.initial]!) // swiftlint:disable:this force_unwrapping
+
+        let initialStep = FeedbackStep.initial
+        feedbackView.configure(stepIdentifier: initialStep, viewModel: initialStep.viewModel)
         return feedbackView
+    }
+
+    enum FeedbackStep: String {
+        case initial
+        case accept
+        case decline
+        case finished
+
+        var viewModel: FeedbackViewModel {
+            switch self {
+            case .initial:
+                FeedbackViewModel(title: "Liker du FINN appen?", positiveButtonTitle: "Ja!", negativeButtonTitle: "Niks.")
+            case .accept:
+                FeedbackViewModel(title: "Hurra! Hva med å gi oss noen stjerner i App Store?", positiveButtonTitle: "Klart!", negativeButtonTitle: "Nei")
+            case .decline:
+                FeedbackViewModel(title: "Å nei! Lyst til å hjelpe oss med å bli bedre?", positiveButtonTitle: "Klart!", negativeButtonTitle: "Nei")
+            case .finished:
+                FeedbackViewModel(title: "Takk!\nVi setter pris på din tilbakemelding - det hjelper oss med å bli bedre")
+            }
+        }
     }
 }

--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -7,7 +7,11 @@ import UIKit
 // MARK: - FeedbackViewDelegate
 
 public protocol FeedbackViewDelegate: AnyObject {
-    func feedbackView(_ feedbackView: FeedbackView, didSelectButtonOfType buttonType: FeedbackView.ButtonType, forState state: FeedbackView.State)
+    func feedbackView(
+        _ feedbackView: FeedbackView,
+        didSelectButtonOfType buttonType: FeedbackView.ButtonType,
+        forStep stepIdentifier: String
+    )
 }
 
 // MARK: - FeedbackView
@@ -18,13 +22,6 @@ public class FeedbackView: UIView {
         case negative
     }
 
-    public enum State: Int {
-        case initial = 0
-        case accept
-        case decline
-        case finished
-    }
-
     // MARK: - Public properties
 
     public weak var delegate: FeedbackViewDelegate?
@@ -32,7 +29,7 @@ public class FeedbackView: UIView {
     // MARK: - Private properties
 
     private var hasBeenPresented = false
-    private var state: State = .initial
+    private var stepIdentifier: String = ""
     private var presentation: FeedbackViewPresentation?
     private var allowAutomaticPresentationSwitch: Bool = true
 
@@ -120,8 +117,12 @@ public class FeedbackView: UIView {
         configure(forPresentation: presentation)
     }
 
-    public func setState(_ state: State, withViewModel viewModel: FeedbackViewModel) {
-        self.state = state
+    public func configure<T: RawRepresentable<String>>(stepIdentifier: T, viewModel: FeedbackViewModel) {
+        configure(stepIdentifier: stepIdentifier.rawValue, viewModel: viewModel)
+    }
+
+    public func configure(stepIdentifier: String, viewModel: FeedbackViewModel) {
+        self.stepIdentifier = stepIdentifier
         configure(withViewModel: viewModel)
     }
 
@@ -170,12 +171,12 @@ public class FeedbackView: UIView {
 
     @objc private func positiveButtonTapped() {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        delegate?.feedbackView(self, didSelectButtonOfType: .positive, forState: state)
+        delegate?.feedbackView(self, didSelectButtonOfType: .positive, forStep: stepIdentifier)
     }
 
     @objc private func negativeButtonTapped() {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        delegate?.feedbackView(self, didSelectButtonOfType: .negative, forState: state)
+        delegate?.feedbackView(self, didSelectButtonOfType: .negative, forStep: stepIdentifier)
     }
 
     // MARK: - Overrides
@@ -315,6 +316,8 @@ private class ButtonView: UIView {
     // MARK: - Setup
 
     private func setup() {
+        setButtonTitles(positive: nil, negative: nil)
+
         addSubview(stackView)
         stackView.fillInSuperview()
     }


### PR DESCRIPTION
# Why?
Currently we only support a set of known steps/states for `FeedbackView`, through `FeedbackView.State`. This has worked well, but now we want to make it easier for verticals to implement their own "flow" when adding new RateMyApp campaigns.

In order to do this we need to make the step identifiers generic and move the ownership of these away from `FeedbackView` and into the implementations. 

# What?
- Remove `FeedbackView.State` – use instead `String` as identifier for a state/step.
- Update demo to own the step identifiers.

# Version Change
Breaking.

# UI Changes
None.