### PR TITLE
Fix a crash where fonts randomly become unavailable

### DIFF
--- a/FinniversKit/Sources/DNA/Font/FontProvider.swift
+++ b/FinniversKit/Sources/DNA/Font/FontProvider.swift
@@ -235,28 +235,17 @@ private extension UIFont {
         }
     }
 
-    private static func registerFontFor(bundle: Bundle, forResource: String) {
-        guard let pathForResourceString = bundle.path(forResource: forResource, ofType: "ttf") else {
-            print("UIFont+: Failed to register font - path for resource not found.")
-            return
-        }
-
-        guard let fontData = NSData(contentsOfFile: pathForResourceString) else {
-            print("UIFont+: Failed to register font - font data could not be loaded.")
-            return
-        }
-
-        guard let dataProvider = CGDataProvider(data: fontData) else {
-            print("UIFont+: Failed to register font - data provider could not be loaded.")
-            return
-        }
-
-        guard let fontRef = CGFont(dataProvider) else {
-            print("UIFont+: Failed to register font - font could not be loaded.")
+    private static func registerFontFor(bundle: Bundle, forResource resource: String) {
+        guard let fontUrl = bundle.url(forResource: resource, withExtension: "ttf") else {
+            print("UIFont+: Failed to register font - URL for resource not found.")
             return
         }
 
         var errorRef: Unmanaged<CFError>?
-        CTFontManagerRegisterGraphicsFont(fontRef, &errorRef)
+        let registeredFont = CTFontManagerRegisterFontsForURL(fontUrl as CFURL, .process, &errorRef)
+
+        if !registeredFont {
+            print("UIFont+: Failed to register font \(resource)")
+        }
     }
 }


### PR DESCRIPTION
# Why?

We have a crash in Tori and FINN NMP related to fonts. The problem is that some fonts suddenly "disappear" from memory a while after having been successfully loaded on app startup, so our force unwrap of the FINN font will crash the app.

# What?

We found a consistent way to reproduce this:
1. Open a real-estate ad
2. Open the map
3. Move the app to the background
4. Open the app again. Navigate back from map to ad and scroll. CRASH! 💣 

I found [this thread](https://forums.developer.apple.com/forums/thread/741720) of others experiencing the same issue. The last post includes a fix, where you use another method for registering fonts based on URL. Currently we are using this method to register fonts: `CTFontManagerRegisterGraphicsFont`, but the fix is to switch to `CTFontManagerRegisterFontsForURL`, where you are able to specify a scope.
There's a scope called `.process` which means the font will be available for the lifetime of "the process" which registered it, e.g. it needs to be registered once after every restart of the app, as we already do.

After having changed to `CTFontManagerRegisterFontsForURL`, the app does not crash anymore when following the steps above, so it seems to fix it. 🤞

# Version Change

Minor.
