### PR TITLE
Get rid of code related to years old migration of loading indicators

### DIFF
--- a/FinniversKit/Sources/Fullscreen/LoadingView/LoadingView.swift
+++ b/FinniversKit/Sources/Fullscreen/LoadingView/LoadingView.swift
@@ -21,11 +21,6 @@ import UIKit
         case boxed
     }
 
-    /// Allows the loading view to use a plain UIActivityIndicatorView,
-    /// useful for a smooth transition between the old indicator and the new one,
-    /// by using this flag we can avoid having multiple styles of showing progress in our app.
-    @objc public static var shouldUseOldIndicator: Bool = false
-
     private let animationDuration: TimeInterval = 0.3
     private let loadingIndicatorSize: CGFloat = 40
     private let boxedSize: CGFloat = 120
@@ -56,7 +51,7 @@ import UIKit
         let view = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.image = UIImage(named: .checkmarkBig).withRenderingMode(.alwaysTemplate)
-        view.tintColor = LoadingView.shouldUseOldIndicator ? .nmpBrandDecoration : .accentSecondaryBlue
+        view.tintColor = .nmpBrandDecoration
         view.alpha = 0
         view.transform = loadingIndicatorInitialTransform
         return view


### PR DESCRIPTION
# Why?

We found this var which is a remainder from a migration like 5 years ago.

# What?

Get rid of `shouldUseOldIndicator`. We can default to `.nmpBrandDecoration` which is just another shade of blue than we used to have.

# Version Change

Breaking.

# UI Changes

There's actually no UI change, due to the loading view always being updated before display, while we only changed the initial/default value.