### PR TITLE
Bump Warp to 0.0.11 and deprecate spacing

### DIFF
--- a/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "f3b3c78db4d9cac6ad4aa20a33d11f9d80cb1e6e",
-        "version" : "0.0.9"
+        "revision" : "a7558552e9242afff6f18f9c9f67f6e8f723be39",
+        "version" : "0.0.11"
       }
     }
   ],

--- a/FinniversKit/Sources/DNA/Spacing/Spacing.swift
+++ b/FinniversKit/Sources/DNA/Spacing/Spacing.swift
@@ -7,34 +7,6 @@ import Foundation
 public extension CGFloat {
     /// Separation of 2 points.
     @available(*, deprecated, message: "Use Warp.Spacing.spacing25 instead.")
-    static let verySmallSpacing: CGFloat = 2
-
-    /// Separation of 4 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing50 instead.")
-    static let smallSpacing: CGFloat = 4
-
-    /// Separation of 8 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing100 instead.")
-    static let mediumSpacing: CGFloat = 8
-
-    /// Separation of 16 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing200 instead.")
-    static let mediumLargeSpacing: CGFloat = 16
-
-    /// Separation of 24 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing300 instead.")
-    static let mediumPlusSpacing: CGFloat = 24
-
-    /// Separation of 32 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing400 instead.")
-    static let largeSpacing: CGFloat = 32
-
-    /// Separation of 64 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing800 instead.")
-    static let veryLargeSpacing: CGFloat = 64
-
-    /// Separation of 2 points.
-    @available(*, deprecated, message: "Use Warp.Spacing.spacing25 instead.")
     static let spacingXXS: CGFloat = 2
 
     /// Separation of 4 points.

--- a/FinniversKit/Sources/DNA/Spacing/Spacing.swift
+++ b/FinniversKit/Sources/DNA/Spacing/Spacing.swift
@@ -6,51 +6,58 @@ import Foundation
 
 public extension CGFloat {
     /// Separation of 2 points.
-    @available(*, deprecated, message: "Use spacingXXS instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing25 instead.")
     static let verySmallSpacing: CGFloat = 2
 
     /// Separation of 4 points.
-    @available(*, deprecated, message: "Use spacingXS instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing50 instead.")
     static let smallSpacing: CGFloat = 4
 
     /// Separation of 8 points.
-    @available(*, deprecated, message: "Use spacingS instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing100 instead.")
     static let mediumSpacing: CGFloat = 8
 
     /// Separation of 16 points.
-    @available(*, deprecated, message: "Use spacingM instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing200 instead.")
     static let mediumLargeSpacing: CGFloat = 16
 
     /// Separation of 24 points.
-    @available(*, deprecated, message: "Use spacingL instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing300 instead.")
     static let mediumPlusSpacing: CGFloat = 24
 
     /// Separation of 32 points.
-    @available(*, deprecated, message: "Use spacingXL instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing400 instead.")
     static let largeSpacing: CGFloat = 32
 
     /// Separation of 64 points.
-    @available(*, deprecated, message: "Use spacingXXL instead.")
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing800 instead.")
     static let veryLargeSpacing: CGFloat = 64
 
     /// Separation of 2 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing25 instead.")
     static let spacingXXS: CGFloat = 2
 
     /// Separation of 4 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing50 instead.")
     static let spacingXS: CGFloat = 4
 
     /// Separation of 8 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing100 instead.")
     static let spacingS: CGFloat = 8
 
     /// Separation of 16 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing200 instead.")
     static let spacingM: CGFloat = 16
 
     /// Separation of 24 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing300 instead.")
     static let spacingL: CGFloat = 24
 
     /// Separation of 32 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing400 instead.")
     static let spacingXL: CGFloat = 32
 
     /// Separation of 64 points.
+    @available(*, deprecated, message: "Use Warp.Spacing.spacing800 instead.")
     static let spacingXXL: CGFloat = 64
 }


### PR DESCRIPTION
# Why?

`Warp` now include spacing. 

# What?

Bumped `Warp` to `0.0.11` and added deprecated warning to spacing in favor for using `Warp.Spacing`.

# Version Change

Minor change.

# UI Changes

No changes