### PR TITLE
Make UIColor extensions internal

### DIFF
--- a/Demo/Sources/Components/LoanCalculator/LoanCalculatorDemoView.swift
+++ b/Demo/Sources/Components/LoanCalculator/LoanCalculatorDemoView.swift
@@ -169,16 +169,16 @@ extension LoanCalculatorDemoViewModel {
         var accentColor: UIColor? {
             switch self {
             case .dnb: return UIColor.dynamicColor(
-                defaultColor: UIColor(r: 55, g: 122, b: 130),
-                darkModeColor: UIColor(r: 58, g: 168, b: 180)
+                defaultColor: UIColor(hex: "#377A82"),
+                darkModeColor: UIColor(hex: "#3AA8B4")
             )
             case .nordea: return UIColor.dynamicColor(
-                defaultColor: UIColor(r: 0, g: 0, b: 160),
-                darkModeColor: UIColor(r: 49, g: 49, b: 211)
+                defaultColor: UIColor(hex: "#0000A0"),
+                darkModeColor: UIColor(hex: "#3131D3")
             )
             case .danskeBank: return UIColor.dynamicColor(
-                defaultColor: UIColor(r: 0, g: 55, b: 85),
-                darkModeColor: UIColor(r: 22, g: 92, b: 129)
+                defaultColor: UIColor(hex: "#003755"),
+                darkModeColor: UIColor(hex: "#165C81")
             )
             }
         }

--- a/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "a7558552e9242afff6f18f9c9f67f6e8f723be39",
-        "version" : "0.0.11"
+        "revision" : "a9fbc5677c8efeeba6d946faa9892121da1339be",
+        "version" : "0.0.12"
       }
     }
   ],

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -487,7 +487,7 @@ public extension UIColor {
     /// Base initializer, it creates an instance of `UIColor` using an HEX string.
     ///
     /// - Parameter hex: The base HEX string to create the color.
-    convenience init(hex: String) {
+    internal convenience init(hex: String) {
         let noHashString = hex.replacingOccurrences(of: "#", with: "")
         let scanner = Scanner(string: noHashString)
         scanner.charactersToBeSkipped = CharacterSet.symbols

--- a/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
+++ b/FinniversKit/Sources/DNA/Color/UIColor+FinniversKit.swift
@@ -480,7 +480,7 @@ public extension UIColor {
     ///   - g: green (0-255)
     ///   - b: blue (0-255)
     ///   - a: alpla (0-1)
-    convenience init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) { // swiftlint:disable:this identifier_name
+    internal convenience init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1.0) { // swiftlint:disable:this identifier_name
         self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: a)
     }
 


### PR DESCRIPTION
# Why?

I'm facing this nice error: `Ambiguous use of 'init(hex:)'` which is available both in `FinniversKit` and in `Warp`. 
So let's start removing the use of this extensions outside `FinniversKit`.

# What?

Make `init(hex:) and init(r:g:b:)` internal.

# Version Change

Major change, since it could break codebases 🙈 

# UI Changes

No UI changes