### PR TITLE
Update icon color for favorite icon button

### DIFF
--- a/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
+++ b/FinniversKit/Sources/SwiftUI Components/Button/SwiftUIIconButton.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 public struct SwiftUIIconButton: View {
     public struct Style {
+        let color: Color
+        let colorToggled: Color
         let icon: UIImage
         let iconToggled: UIImage
     }
@@ -17,7 +19,7 @@ public struct SwiftUIIconButton: View {
     public var body: some View {
         Image.init(uiImage: isToggled ? style.iconToggled : style.icon)
             .renderingMode(.template)
-            .foregroundColor(isToggled ? .backgroundPrimary : .icon)
+            .foregroundColor(isToggled ? style.colorToggled : style.color)
             .accessibilityRemoveTraits(.isImage)
             .accessibilityAddTraits(isToggled ? [.isButton, .isSelected] : [.isButton])
     }
@@ -25,6 +27,8 @@ public struct SwiftUIIconButton: View {
 
 public extension SwiftUIIconButton.Style {
     static let favorite = SwiftUIIconButton.Style(
+        color: .iconSubtle,
+        colorToggled: .backgroundPrimary,
         icon: UIImage(named: .favoriteDefault),
         iconToggled: UIImage(named: .favoriteActive)
     )


### PR DESCRIPTION
# Why?

Icon color that was set when changing to Warp colors was not correct.

# What?

Update to iconSubtle for untoggled state.

# Version Change

Breaking because of changes to `Style` struct.

# UI Changes

| Before | After |
| --- | --- |
|<img width="56" alt="Screenshot 2024-08-06 at 17 23 39" src="https://github.com/user-attachments/assets/aa49072a-2ad8-424a-938e-613ceaa01675">|<img width="56" alt="Screenshot 2024-08-06 at 17 22 05" src="https://github.com/user-attachments/assets/145c27de-44f7-43b0-9ac9-c85a89a5bede">|
|<img width="56" alt="Screenshot 2024-08-06 at 17 23 25" src="https://github.com/user-attachments/assets/d1436d18-3383-4b63-8936-0849f01d3b4d">|<img width="56" alt="Screenshot 2024-08-06 at 17 23 00" src="https://github.com/user-attachments/assets/dabd7e73-f835-492c-a943-deda52d080c9">|