### PR TITLE
recommendations-iPad-fix

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldView.swift
@@ -188,7 +188,7 @@ public class FavoriteSoldView: UIView {
         adsRetryView.frame.origin = CGPoint(x: 0, y: headerView.frame.height + Warp.Spacing.spacing800)
         adsRetryView.frame.size = CGSize(width: bounds.width, height: 200)
 
-        adRecommendationsGridView.invalidateLayout()
+//        adRecommendationsGridView.invalidateLayout()
     }
 
     // MARK: - Public methods

--- a/FinniversKit/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldView.swift
@@ -188,7 +188,7 @@ public class FavoriteSoldView: UIView {
         adsRetryView.frame.origin = CGPoint(x: 0, y: headerView.frame.height + Warp.Spacing.spacing800)
         adsRetryView.frame.size = CGSize(width: bounds.width, height: 200)
 
-//        adRecommendationsGridView.invalidateLayout()
+        adRecommendationsGridView.invalidateLayout()
     }
 
     // MARK: - Public methods

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -51,15 +51,20 @@ public class AdRecommendationsGridView: UIView {
 
     private let imageCache = ImageMemoryCache()
 
-    private lazy var collectionViewLayout: AdRecommendationsGridViewLayout = {
-        let layout = AdRecommendationsGridViewLayout()
-        layout.delegate = self
-        return layout
-    }()
+//    private lazy var collectionViewLayout: AdRecommendationsGridViewLayout = {
+//        let layout = AdRecommendationsGridViewLayout()
+//        layout.delegate = self
+//        return layout
+//    }()
 
     // Have the collection view be private so nobody messes with it.
     public private(set) lazy var collectionView: UICollectionView = {
+        let collectionViewLayout = AdRecommendationsGridViewLayout()
+        collectionViewLayout.delegate = self
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+//        let layout = UICollectionViewFlowLayout()
+//        layout.itemSize = CGSize(width: 100, height: 100)
+//        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -112,9 +117,9 @@ public class AdRecommendationsGridView: UIView {
         collectionView.refreshControl = isRefreshEnabled ? refreshControl : nil
     }
 
-    public func invalidateLayout() {
-        collectionView.collectionViewLayout.invalidateLayout()
-    }
+//    public func invalidateLayout() {
+//        collectionView.collectionViewLayout.invalidateLayout()
+//    }
 
     @objc private func handleRefreshBegan() {
         delegate?.adRecommendationsGridViewDidStartRefreshing(self)
@@ -124,13 +129,14 @@ public class AdRecommendationsGridView: UIView {
 
     public func reloadData() {
         collectionView.reloadData()
-        if refreshControl.isRefreshing {
-            collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
-                self?.endRefreshing()
-                UIAccessibility.post(notification: .layoutChanged, argument: nil)
-            })
-        }
-        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+        collectionView.collectionViewLayout.invalidateLayout()
+//        if refreshControl.isRefreshing {
+//            collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
+//                self?.endRefreshing()
+//                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+//            })
+//        }
+//        UIAccessibility.post(notification: .layoutChanged, argument: nil)
     }
 
     public func endRefreshing() {

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -1,7 +1,3 @@
-//
-//  Copyright © FINN.no AS, Inc. All rights reserved.
-//
-
 import UIKit
 
 public protocol AdRecommendationsGridViewDelegate: AnyObject {
@@ -51,20 +47,14 @@ public class AdRecommendationsGridView: UIView {
 
     private let imageCache = ImageMemoryCache()
 
-//    private lazy var collectionViewLayout: AdRecommendationsGridViewLayout = {
-//        let layout = AdRecommendationsGridViewLayout()
-//        layout.delegate = self
-//        return layout
-//    }()
+    private func collectionViewLayout() -> AdRecommendationsGridViewLayout {
+        let layout = AdRecommendationsGridViewLayout()
+        layout.delegate = self
+        return layout
+    }
 
-    // Have the collection view be private so nobody messes with it.
     public private(set) lazy var collectionView: UICollectionView = {
-        let collectionViewLayout = AdRecommendationsGridViewLayout()
-        collectionViewLayout.delegate = self
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
-//        let layout = UICollectionViewFlowLayout()
-//        layout.itemSize = CGSize(width: 100, height: 100)
-//        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -117,9 +107,9 @@ public class AdRecommendationsGridView: UIView {
         collectionView.refreshControl = isRefreshEnabled ? refreshControl : nil
     }
 
-//    public func invalidateLayout() {
-//        collectionView.collectionViewLayout.invalidateLayout()
-//    }
+    public func invalidateLayout() {
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
 
     @objc private func handleRefreshBegan() {
         delegate?.adRecommendationsGridViewDidStartRefreshing(self)
@@ -129,14 +119,13 @@ public class AdRecommendationsGridView: UIView {
 
     public func reloadData() {
         collectionView.reloadData()
-        collectionView.collectionViewLayout.invalidateLayout()
-//        if refreshControl.isRefreshing {
-//            collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
-//                self?.endRefreshing()
-//                UIAccessibility.post(notification: .layoutChanged, argument: nil)
-//            })
-//        }
-//        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+        if refreshControl.isRefreshing {
+            collectionView.performBatchUpdates(nil, completion: { [weak self] _ in
+                self?.endRefreshing()
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            })
+        }
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
     }
 
     public func endRefreshing() {

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridViewLayout.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridViewLayout.swift
@@ -1,7 +1,3 @@
-//
-//  Copyright © FINN.no AS, Inc. All rights reserved.
-//
-
 import UIKit
 
 protocol AdRecommendationsGridViewLayoutDelegate: AnyObject {
@@ -122,7 +118,13 @@ class AdRecommendationsGridViewLayout: UICollectionViewLayout {
     }
 
     override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        return itemAttributes[indexPath.row]
+        guard itemAttributes.indices.contains(indexPath.row)
+        else { return nil }
+        if itemAttributes[indexPath.row].representedElementCategory == .cell {
+            return itemAttributes[indexPath.row]
+        } else {
+            return nil
+        }
     }
 
     override var collectionViewContentSize: CGSize {

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridViewLayout.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridViewLayout.swift
@@ -75,7 +75,7 @@ class AdRecommendationsGridViewLayout: UICollectionViewLayout {
     override func prepare() {
         super.prepare()
 
-        itemAttributes = [UICollectionViewLayoutAttributes]()
+        itemAttributes.removeAll()
 
         guard let collectionView = collectionView else {
             return


### PR DESCRIPTION
# Why?
- there's a crash on iPads when launching the app from background
```
Fatal Exception: NSInternalInconsistencyException
UICollectionView internal bug: Attempting to create a cell with invalid attributes. Collection View: <UICollectionView: 0x108dedc00; frame = (0 0; 1376 888); clipsToBounds = YES; gestureRecognizers = <NSArray: 0x301442940>; backgroundColor = UIExtendedGrayColorSpace 0 0; layer = <CALayer: 0x301a57660>; contentOffset: {0, 30996}; contentSize: {1376, 33730.5}; adjustedContentInset: {0, 0, 0, 0}; layout: <FinniversKit.AdRecommendationsGridViewLayout: 0x11a2f92c0>; dataSource: <FinniversKit.AdRecommendationsGridView: 0x11a28ec00; frame = (0 0; 1376 888); layer = <CALayer: 0x301a57420>>>, Attributes: <UICollectionViewLayoutAttributes: 0x13b4fcc00; index path: (0-0); element kind: (UICollectionElementKindSectionHeader); frame = (0 0; 1376 252)>, Index Path: <NSIndexPath: 0x8c246f538daf20e4> {length = 2, path = 0 - 0}
```

# What?
- improve the lookup in the layout logic for `AdRecommendationsGridViewLayout`

# Version Change
patch

# UI Changes
- none



