### PR TITLE
Use span mapper for HTMLText in SwiftUI similar to UIKit

### DIFF
--- a/Demo/Sources/SwiftUI/HTMLTextDemoViewController.swift
+++ b/Demo/Sources/SwiftUI/HTMLTextDemoViewController.swift
@@ -3,6 +3,7 @@ import Foundation
 import SwiftUI
 import UIKit
 import DemoKit
+import Warp
 
 final class HTMLTextDemoViewController: UIViewController {
     let hostingController: UIHostingController<HTMLText>
@@ -50,17 +51,34 @@ extension HTMLTextDemoViewController: TweakableDemo {
     }
 
     func configure(forTweakAt index: Int) {
+        let spanMapper: HTMLStringSwiftUIStyleTranslator.SpanMapper = { attributes, currentStyle in
+            for attribute in attributes {
+                guard attribute.name == "style",
+                      attribute.value == "color:tjt-price-highlight" else {
+                    return
+                }
+
+                currentStyle.foregroundColor = Warp.Token.textNegative
+            }
+        }
+
         switch Tweaks.allCases[index] {
         case .default:
             htmlView = HTMLText("This is <b>HTML</b>")
         case .linebreak:
             htmlView = HTMLText("This is <b>HTML</b><br>over two lines")
         case .priceHighlight:
-            htmlView = HTMLText("Shipping costs <span style=\"color:tjt-price-highlight\">60 NOK</span>")
+            htmlView = HTMLText(
+                "Shipping costs <span style=\"color:tjt-price-highlight\">60 NOK</span>",
+                spanMapper: spanMapper
+            )
         case .strikethrough:
             htmlView = HTMLText("Old price is <del>80 NOK</del>")
         case .mix:
-            htmlView = HTMLText("New price is <b>60 kr</b>, old price is <del>80 kr</del><br>Shipping is <span style=\"color:tjt-price-highlight\">60 kr</span>")
+            htmlView = HTMLText(
+                "New price is <b>60 kr</b>, old price is <del>80 kr</del><br>Shipping is <span style=\"color:tjt-price-highlight\">60 kr</span>",
+                spanMapper: spanMapper
+            )
         }
     }
 }

--- a/FinniversKit/Sources/Components/HTMLText/HTMLText.swift
+++ b/FinniversKit/Sources/Components/HTMLText/HTMLText.swift
@@ -2,12 +2,17 @@ import SwiftUI
 
 public struct HTMLText: View {
     public let html: String
+    public let spanMapper: HTMLStringSwiftUIStyleTranslator.SpanMapper
 
     private var font: Font?
     private var foregroundColor: Color?
 
-    public init(_ html: String) {
+    public init(
+        _ html: String,
+        spanMapper: @escaping HTMLStringSwiftUIStyleTranslator.SpanMapper = { _, _ in }
+    ) {
         self.html = html
+        self.spanMapper = spanMapper
     }
 
     public var body: some View {
@@ -18,7 +23,8 @@ public struct HTMLText: View {
         do {
             let translator = HTMLStringSwiftUIStyleTranslator.finnStyle(
                 font: font,
-                foregroundColor: foregroundColor
+                foregroundColor: foregroundColor,
+                spanMapper: spanMapper
             )
             let styledTexts = try HTMLStringParser.parse(html: html, translator: translator)
             return styledTexts.reduce(

--- a/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
+++ b/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
@@ -3,9 +3,12 @@ import SwiftUI
 import UIKit
 
 extension HTMLStringSwiftUIStyleTranslator {
+    public typealias SpanMapper = (_ attributes: [HTMLToken.TagAttribute], _ currentStyle: inout Style) -> Void
+
     static func finnStyle(
         font: Font?,
-        foregroundColor: Color?
+        foregroundColor: Color?,
+        spanMapper: @escaping SpanMapper
     ) -> HTMLStringSwiftUIStyleTranslator {
         return .init(defaultStyle: .init(
             font: font,
@@ -21,16 +24,7 @@ extension HTMLStringSwiftUIStyleTranslator {
             case .i:
                 style.italic = true
             case .span:
-                for attribute in attributes {
-                    switch attribute.name {
-                    case "style":
-                        if attribute.value == "color:tjt-price-highlight" {
-                            style.foregroundColor = .textNegative
-                        }
-                    default:
-                        break
-                    }
-                }
+                spanMapper(attributes, &style)
             case .u:
                 style.underline = true
             default:


### PR DESCRIPTION
# Why?

The class `HTMLText` had a hard coded colour specific to TJT and since we changed that colour recently it was impossible to get it to the view.

# What?

A new span mapper parameter is added to the class enabling configuring the specific section colours from the "outside"

# Version Change

Breaking: Make it possible to configure span colours in HTMLText.
