### PR TITLE
Fix bug where broadcast would be placed below tab bar view

### DIFF
--- a/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
+++ b/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
@@ -44,6 +44,7 @@ public final class Broadcast: UIStackView {
             let newMessages = messages.subtracting(self.messages)
             self.messages.formUnion(messages)
             add(newMessages, animated: animated)
+            superview?.bringSubviewToFront(self)
             return
         }
 


### PR DESCRIPTION
# Why?

We had an edge case bug which was reproducible like this:
1. Log in, see there's a broadcast placed correctly in each tab
2. Log out
3. Log in again, the broadcast is now placed below the tab bar view for my page and notifications tab

# What?

We had no trouble with the initial setup of broadcasts, but this appeared when displaying broadcasts where there was already a superview. So I added a call to send it to front there.

# Version Change

Minor

# UI Changes

## My page

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-08-23 at 15 28 53](https://github.com/user-attachments/assets/9ada7cd0-83d2-4a8d-ad55-c08e9523c81d) | ![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-08-23 at 15 47 02](https://github.com/user-attachments/assets/98917a89-3999-46df-a852-52606fc5f9ab) |

## Notifications

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-08-23 at 15 28 47](https://github.com/user-attachments/assets/df280fe8-b604-4a50-b95a-f82b38b80b1e) | ![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-08-23 at 15 47 17](https://github.com/user-attachments/assets/7e5f8a9c-ef8c-4455-96a6-45d0186895c9) |


