### PR TITLE
feat: Adds support for anchor tags in HTMLText

### DIFF
--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -306,6 +306,8 @@
 		B26B582E2B4BD695000E0245 /* NMPInfoboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B582C2B4BD695000E0245 /* NMPInfoboxView.swift */; };
 		B26B582F2B4BD695000E0245 /* NMPInfoboxView+InformationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B582D2B4BD695000E0245 /* NMPInfoboxView+InformationType.swift */; };
 		B26B58312B4BDD15000E0245 /* InfoboxSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B58302B4BDD15000E0245 /* InfoboxSwiftUIView.swift */; };
+		B2829E2D2C7F054F0032BDFA /* HTMLAttributeStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2829E2C2C7F054F0032BDFA /* HTMLAttributeStack.swift */; };
+		B2829E2F2C7F05D20032BDFA /* LocalizedStringKey+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2829E2E2C7F05D20032BDFA /* LocalizedStringKey+Extensions.swift */; };
 		B6801C1C2982ECCA004A0F4F /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6801C1B2982ECCA004A0F4F /* SettingsHeaderView.swift */; };
 		CBD2F08D20615990002AA385 /* TextField+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD2F08C20615990002AA385 /* TextField+State.swift */; };
 		CF05B7E023325968003A7F1C /* FavoriteFolderActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05B7DF23325968003A7F1C /* FavoriteFolderActionButton.swift */; };
@@ -759,6 +761,8 @@
 		B26B582C2B4BD695000E0245 /* NMPInfoboxView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NMPInfoboxView.swift; sourceTree = "<group>"; };
 		B26B582D2B4BD695000E0245 /* NMPInfoboxView+InformationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NMPInfoboxView+InformationType.swift"; sourceTree = "<group>"; };
 		B26B58302B4BDD15000E0245 /* InfoboxSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoboxSwiftUIView.swift; sourceTree = "<group>"; };
+		B2829E2C2C7F054F0032BDFA /* HTMLAttributeStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLAttributeStack.swift; sourceTree = "<group>"; };
+		B2829E2E2C7F05D20032BDFA /* LocalizedStringKey+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizedStringKey+Extensions.swift"; sourceTree = "<group>"; };
 		B6801C1B2982ECCA004A0F4F /* SettingsHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		CB3CF1561F73E5870041EF20 /* FinniversKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FinniversKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBD2F08C20615990002AA385 /* TextField+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+State.swift"; sourceTree = "<group>"; };
@@ -1092,6 +1096,7 @@
 				17538722291ABC1B00DA57D2 /* HTMLElement.swift */,
 				179D06A72906A39D00A65E3A /* HTMLStringParser.swift */,
 				175385AF29146A4000DA57D2 /* HTMLStringStyleStack.swift */,
+				B2829E2C2C7F054F0032BDFA /* HTMLAttributeStack.swift */,
 				1753871B291AA4F900DA57D2 /* Translators */,
 			);
 			path = HTMLStringParser;
@@ -2274,6 +2279,7 @@
 				DA5A858B24617DF000AC0DFE /* ImageExtensions.swift */,
 				5DA190C625A4A7E0002305A8 /* Transition+Extensions.swift */,
 				9BB680312462F7AC001ADACF /* View+Extensions.swift */,
+				B2829E2E2C7F05D20032BDFA /* LocalizedStringKey+Extensions.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -3308,6 +3314,7 @@
 				CFCED8E122CF3A690049A3A0 /* AddFavoriteFolderViewCell.swift in Sources */,
 				CFF9727221C3BA1D00C85238 /* BannerTransparencyView.swift in Sources */,
 				44A557B522E72187001667AE /* HeartTableViewCell.swift in Sources */,
+				B2829E2D2C7F054F0032BDFA /* HTMLAttributeStack.swift in Sources */,
 				573B3FF82ACC1B75005096EC /* SettingsViewIconCellModel.swift in Sources */,
 				4447F6D11FDB2B110033DBC1 /* Label+Style.swift in Sources */,
 				441FE431209A24E500B04EF1 /* AdRecommendationsGridHeaderView.swift in Sources */,
@@ -3354,6 +3361,7 @@
 				DAD6EB2A2369916100968497 /* SettingsView.swift in Sources */,
 				4408A6A32027AC41008C0BD9 /* UIColor+FinniversKit.swift in Sources */,
 				446EE15C2345A6AA00010818 /* SelectorTitleView.swift in Sources */,
+				B2829E2F2C7F05D20032BDFA /* LocalizedStringKey+Extensions.swift in Sources */,
 				DAD6EB292369916100968497 /* SettingsViewConsentCellModel.swift in Sources */,
 				CF3F85BF229C29B3003A6748 /* IconCollectionViewFlowLayout.swift in Sources */,
 				4DD3AA7C27B56592007B107E /* DetailCalloutView.swift in Sources */,

--- a/FinniversKit/FinniversKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FinniversKit/FinniversKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "0d9eedf11daca64801572add0a3be5102458060bc23ba186e10954aa4fcceb89",
   "pins" : [
     {
       "identity" : "warp-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "7d24900acc6225655038c7ea5e3e9f9249631d58",
-        "version" : "0.0.3"
+        "revision" : "aeb72c43f2918a290d00d9fe93035723accb876b",
+        "version" : "0.0.25"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/FinniversKit/Sources/Components/HTMLText/HTMLText.swift
+++ b/FinniversKit/Sources/Components/HTMLText/HTMLText.swift
@@ -30,7 +30,14 @@ public struct HTMLText: View {
             return styledTexts.reduce(
                 into: Text("").applyStyle(translator.styleStack.defaultStyle)
             ) { textView, styledText in
-                textView = textView + Text(styledText.text).applyStyle(styledText.style)
+                let newText: Text
+                if let url = styledText.url {
+                    newText = Text("\(styledText.text, link: url)")
+                } else {
+                    newText = Text(styledText.text)
+                }
+                textView = textView + newText
+                    .applyStyle(styledText.style)
             }
         } catch {
             return Text(html)
@@ -87,6 +94,8 @@ struct HTMLText_Previews: PreviewProvider {
             HTMLText("Shipping costs <span style=\"color:tjt-price-highlight\">60 NOK</span>")
 
             HTMLText("Old price is <del>80 NOK</del>")
+
+            HTMLText("A <a href=\"https://google.com\">link</a>")
         }
         .previewLayout(.sizeThatFits)
     }

--- a/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
+++ b/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
@@ -27,7 +27,7 @@ extension HTMLStringSwiftUIStyleTranslator {
                 spanMapper(attributes, &style)
             case .u:
                 style.underline = true
-           default:
+            default:
                 break
             }
             return style

--- a/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
+++ b/FinniversKit/Sources/Components/HTMLText/HTMLTextFinnStyle.swift
@@ -27,7 +27,7 @@ extension HTMLStringSwiftUIStyleTranslator {
                 spanMapper(attributes, &style)
             case .u:
                 style.underline = true
-            default:
+           default:
                 break
             }
             return style

--- a/FinniversKit/Sources/Extensions/SwiftUI/LocalizedStringKey+Extensions.swift
+++ b/FinniversKit/Sources/Extensions/SwiftUI/LocalizedStringKey+Extensions.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/*
+ Credit where credit is due, thanks Ole!:
+
+ https://gist.github.com/ole/8d1ef1cab4bbd387c3bdc8c69e29eae3
+ */
+extension LocalizedStringKey.StringInterpolation {
+    /// Appends a link with a title to a string interpolation.
+    ///
+    /// Usage:
+    ///
+    ///     let url: URL = …
+    ///     Text("\("Link title", url: url)")
+    mutating func appendInterpolation(_ linkTitle: String, link url: URL) {
+        var linkString = AttributedString(linkTitle)
+        linkString.link = url
+        self.appendInterpolation(linkString)
+    }
+}

--- a/FinniversKit/Sources/Util/HTMLStringParser/HTMLAttributeStack.swift
+++ b/FinniversKit/Sources/Util/HTMLStringParser/HTMLAttributeStack.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct HTMLAttributeStack<Attribute> {
+    private struct AttributeInfo {
+        let elementName: String
+        let attribute: Attribute
+    }
+
+    private var stack: [AttributeInfo] = []
+
+    mutating func pushAttribute(_ attribute: Attribute, elementName: String) {
+        stack.append(.init(elementName: elementName, attribute: attribute))
+    }
+
+    mutating func popAttribute(elementName: String) {
+        if let lastElementIndex = stack.lastIndex(where: { $0.elementName == elementName}) {
+            stack.remove(at: lastElementIndex)
+        }
+    }
+
+    func peek() -> Attribute? {
+        stack.last?.attribute
+    }
+}

--- a/FinniversKit/Sources/Util/HTMLStringParser/HTMLElement.swift
+++ b/FinniversKit/Sources/Util/HTMLStringParser/HTMLElement.swift
@@ -31,5 +31,6 @@ extension HTMLElement {
     public static var span: Self { .init("span") }
     public static var strong: Self { .init("strong") }
     public static var u: Self { .init("u") }
+    public static var a: Self { .init("a") }
     // swiftlint:enable identifier_name
 }

--- a/FinniversKit/UnitTests/Util/HTMLStringParser/HTMLStringSwiftUIStyleTranslatorTests.swift
+++ b/FinniversKit/UnitTests/Util/HTMLStringParser/HTMLStringSwiftUIStyleTranslatorTests.swift
@@ -26,4 +26,44 @@ final class HTMLStringSwiftUIStyleTranslatorTests: XCTestCase {
         ]
         XCTAssertEqual(styleElements, reference)
     }
+
+    func testSingleLink() throws {
+        let urlString = "https://example.com"
+        guard let url = URL(string: urlString) else {
+            XCTFail("Foundation has forgotten how to create URLs apparently")
+            return
+        }
+
+        let linkText = "Here we have <a href=\"\(urlString)\">a link</a>"
+        let styleElements = try HTMLStringParser.parse(html: linkText, translator: translator)
+        let reference: [HTMLStringSwiftUIStyleTranslator.StyledText] = [
+            .init(text: "Here we have ", style: .init(font: .body)),
+            .init(text: "a link", style: .init(font: .body, underline: true), attributes: [.url(value: url)]),
+        ]
+        XCTAssertEqual(styleElements, reference)
+    }
+
+    func testMultipleLinks() throws {
+        let firstURLString = "https://example.com"
+        guard let firstURL = URL(string: firstURLString) else {
+            XCTFail("Foundation has forgotten how to create URLs apparently")
+            return
+        }
+
+        let secondURLString = "https://another-example.com"
+        guard let secondURL = URL(string: secondURLString) else {
+            XCTFail("Foundation has forgotten how to create URLs apparently")
+            return
+        }
+
+        let linkText = "Here we have <a href=\"\(firstURLString)\">a link</a> and here is <a href=\"\(secondURLString)\">another one</a>"
+        let styleElements = try HTMLStringParser.parse(html: linkText, translator: translator)
+        let reference: [HTMLStringSwiftUIStyleTranslator.StyledText] = [
+            .init(text: "Here we have ", style: .init(font: .body)),
+            .init(text: "a link", style: .init(font: .body, underline: true), attributes: [.url(value: firstURL)]),
+            .init(text: " and here is ", style: .init(font: .body)),
+            .init(text: "another one", style: .init(font: .body, underline: true), attributes: [.url(value: secondURL)]),
+        ]
+        XCTAssertEqual(styleElements, reference)
+    }
 }


### PR DESCRIPTION
# Why?

Because I needed it 🤷 

OK then...in an error screen we need to present a localized text with a link to our help center, dependent on country. When you click that link you are taken to the correct help center in a browser.

The easiest would be if we could use HTML for this and then use an anchor tag to control where to go. That way we don't need to have two separate keys in our localization and do all kinds of combining, tap gestures and so on.

Sadly our `HTMLText` SwiftUI view does not support HTML attributes...till now 😅 

# What?

## Reading Order 👀 
I managed to extend the existing `HTMLStringSwiftUIStyleTranslator` class with a new capability to also read and store attributes so that would be a good place to start.

You will notice that the internal `StyledText` has been extended with a new array of `Attribute` elements like so:

```swift
public let attributes: [Attribute]?
```

And `Attribute` is defined like so:

```swift
extension HTMLStringSwiftUIStyleTranslator {
    public enum Attribute: Equatable {
        /*
         For now we just have a URL attribute here (which is read from the href attribute of an anchor tag)
         but this could be extended if so needed
         */
        case url(value: URL)
    }
}
```

So...at the moment we only support URL's but that can be extended if so needed later on.

### OK so...
We are now able to send potential `Attribute`s as part of the parsing, how do we do that? 

Still in `HTMLStringSwiftUIStyleTranslator` take a look at `translate(tokens: )` where there are the following changes to the `switch`:
- the `.tagStart` arm has been extended to now also handle `a` tags. All we do here is store a URL for the current href value on a new `attributeStack` which is somewhat similar to the existing `styleStack` (and yet different...basically it is a simple Stack datastructure used to hold the current Attribute)
- the `.text` arm has been extended to look for attributes, and if any are present, they are added as part of the `StyledText` element we create. Note that we don't pop the attributes here...we just `peek` them
- in the `.tagEnd` arm we clean up any lingering attributes...we do that here because here we have a name for them, which makes it easier when querying

Here's how that looks in code:

```swift
public func translate(tokens: [HTMLToken]) throws -> [StyledText] {
    var styledText: [StyledText] = []
    for token in tokens {
        switch token {
        case .tagStart(let name, let attributes, _):
            switch name.lowercased() {
            case "br":
                styledText.append(StyledText(text: "\n", style: styleStack.currentStyle))
                continue
            case "a":
                if let urlString = attributes.first(where: { $0.name.lowercased() == "href"})?.value,
                   let url = URL(string: urlString) {
                    attributeStack.pushAttribute(.url(value: url), elementName: name)
                }
            default:
                break
            }
            let styleMapper = self.styleMapper ?? defaultStyleMapper
            if let style = styleMapper(name, attributes) {
                styleStack.pushStyle(style, elementName: name)
            }
        case .tagEnd(let name):
            attributeStack.popAttribute(elementName: name)
            styleStack.popStyle(elementName: name)
        case .text(let text):
            if let lastAttribute = attributeStack.peek() {
                styledText.append(.init(text: text, style: styleStack.currentStyle, attributes: [lastAttribute]))
            } else {
                styledText.append(.init(text: text, style: styleStack.currentStyle, attributes: nil))
            }
        default:
            break
        }
    }
    return styledText
}
```

If you are curious about the `attributeStack`, you can find it in the `HTMLAttributeStack` file.

### OK so...
Now we have parsed the HTML and built a structure for each token. Next we want to actually use that to build our `Text` items.

That takes place in `HTMLText` where we now check if we have a URL or not. If we do not have a URL it is business as usual, and if we have a URL we can generate a `Text` element with that URL, using a new extension to `StringInterpolation`

First, here's how the `reduce` from styledTexts into a combined `Text` looks.

```swift
return styledTexts.reduce(
    into: Text("").applyStyle(translator.styleStack.defaultStyle)
) { textView, styledText in
    let newText: Text
    if let url = styledText.url {
        newText = Text("\(styledText.text, link: url)")
    } else {
        newText = Text(styledText.text)
    }
    textView = textView + newText
        .applyStyle(styledText.style)
}
```

And then the linchpin that ties all this together in `LocalizedStringKey+Extensions`!

```swift
mutating func appendInterpolation(_ linkTitle: String, link url: URL) {
    var linkString = AttributedString(linkTitle)
    linkString.link = url
    self.appendInterpolation(linkString)
}
```

With this extension we are able to actually create `Text` elements from `URL`s...and with that we can stay in a "pure Text" environment...thereby allowing us to use the + operator overload for `Text` 😅  

### Other Elements
- There are a couple of new unit tests in `HTMLStringSwiftUIStyleTranslatorTests.swift`
 
# Version Change

This is a minor change...we have a new option that doesn't break the existing usage.

# UI Changes

_If the change concerns UI, a transition or an animation, providing an image, a gif, or a video is encouraged to help us reviewing your PR._

| Code | Output |
| --- | --- |
|![Screenshot 2024-08-28 at 14 58 15](https://github.com/user-attachments/assets/ec8a29f1-66b7-4a71-b3d8-5390db18389f) | ![Simulator Screen Recording - iPhone 15 - 2024-08-28 at 14 59 09](https://github.com/user-attachments/assets/cf3c7cb6-3710-4bfe-9bf6-3fba81f3d552) |