### PR TITLE
FavoriteFolderActionView fix

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/FavoriteFolderActionView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteFolderActions/FavoriteFolderActionView.swift
@@ -64,6 +64,7 @@ public final class FavoriteFolderActionView: UIView {
             description: viewModel.shareLinkButtonDescription
         )
         view.delegate = self
+        view.isHidden = !isShared
         return view
     }()
 


### PR DESCRIPTION
# Why?

Overlapping label when opening the `FavoriteActionView`.

# What?

* Avoid overlap of the label by setting the isHidden property when creating it

# Version Change

Minor

# UI Changes

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7df35de3-839d-482a-ad25-6e48d08821f1" width=320>| <img src="https://github.com/user-attachments/assets/f17a5861-0bff-4317-966a-77cf39ca9f23" width=320> |
