### PR TITLE
Fix breaking changes in warp colors

### DIFF
--- a/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "revision" : "debbf05cf26bc89f7d0f1755f4f817a398a06865",
-        "version" : "0.0.27"
+        "branch" : "main",
+        "revision" : "5d3ade820e33c9c76f5775fd59165e1645600793"
       }
     }
   ],

--- a/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FinniversKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/warp-ds/warp-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "5d3ade820e33c9c76f5775fd59165e1645600793"
+        "revision" : "037ef2a2ee8be35f37a1d245fd72b6cfc468e177",
+        "version" : "0.0.32"
       }
     }
   ],

--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -3836,9 +3836,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/warp-ds/warp-ios.git";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 999.0.0;
-				minimumVersion = 0.0.27;
+				branch = main;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -3836,8 +3836,9 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/warp-ds/warp-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = versionRange;
+				maximumVersion = 999.0.0;
+				minimumVersion = 0.0.32;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
+++ b/FinniversKit/Sources/Components/Ribbon/Ribbon+Style.swift
@@ -20,7 +20,7 @@ public extension RibbonView {
             case .success: return Warp.UIColor.badgePositiveBackground
             case .warning: return Warp.UIColor.badgeWarningBackground
             case .error: return Warp.UIColor.badgeNegativeBackground
-            case .disabled: return Warp.UIColor.badgeDisabledBackground
+            case .disabled: return Warp.UIToken.backgroundDisabled
             case .sponsored: return Warp.UIColor.badgeSponsoredBackground
             }
         }

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/warp-ds/warp-ios.git", "0.0.27"..."999.0.0")
+        .package(url: "https://github.com/warp-ds/warp-ios.git", branch: "main")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/warp-ds/warp-ios.git", branch: "main")
+        .package(url: "https://github.com/warp-ds/warp-ios.git", "0.0.32"..."999.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Why?

We have removed many colors from Warp.

# What?

Previously we have had 429 colors in Warp.Color which mostly were mapped to Warp.Token
Now that we are using Style Dictionary to sync Colors and Tokens on Warp-iOS we are only getting 25 Colors which are only the ones that are specific for brands and can't be mapped to a specific Token.
[This](https://github.com/warp-ds/warp-ios/pull/84) is a breaking change which is released on [Warp](https://github.com/warp-ds/warp-ios/releases/tag/0.0.32) then some dependency repos and then on NMP app itself.

# Version Change

Minor change

# UI Changes

There should be no UI changes