### PR TITLE
fix voice over for finnish

### DIFF
--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
@@ -40,12 +40,10 @@ public struct PushNotificationNudgingView: View {
                 VStack(alignment: .leading, spacing: Warp.Spacing.spacing50) {
                     Text(viewModel.title)
                         .font(from: .bodyStrong)
-                        .accessibilityLabel(viewModel.title.withoutEmoji())
                     if let description = viewModel.description {
                         Text(description)
                             .font(from: .caption)
                             .foregroundColor(.text)
-                            .accessibilityLabel(description.withoutEmoji())
                     }
                     if let linkDescription = viewModel.linkDescription {
                         Text(linkDescription)

--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
@@ -40,10 +40,12 @@ public struct PushNotificationNudgingView: View {
                 VStack(alignment: .leading, spacing: Warp.Spacing.spacing50) {
                     Text(viewModel.title)
                         .font(from: .bodyStrong)
+                        .accessibilityLabel(viewModel.title.withoutEmoji())
                     if let description = viewModel.description {
                         Text(description)
                             .font(from: .caption)
                             .foregroundColor(.text)
+                            .accessibilityLabel(viewModel.title.withoutEmoji())
                     }
                     if let linkDescription = viewModel.linkDescription {
                         Text(linkDescription)

--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
@@ -45,7 +45,7 @@ public struct PushNotificationNudgingView: View {
                         Text(description)
                             .font(from: .caption)
                             .foregroundColor(.text)
-                            .accessibilityLabel(viewModel.title.withoutEmoji())
+                            .accessibilityLabel(description.withoutEmoji())
                     }
                     if let linkDescription = viewModel.linkDescription {
                         Text(linkDescription)

--- a/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
@@ -32,6 +32,12 @@ public extension String {
     func asAttributedString(attributes: [NSAttributedString.Key: Any]? = nil) -> NSAttributedString {
         NSAttributedString(string: self, attributes: attributes)
     }
+
+    // Extension if we want to ignore emojies for VoiceOver reader
+    func withoutEmoji() -> String {
+        let filteredScalars = unicodeScalars.filter { !$0.properties.isEmojiPresentation }
+        return String(filteredScalars)
+    }
 }
 
 extension Optional where Wrapped == String {

--- a/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
@@ -33,9 +33,9 @@ public extension String {
         NSAttributedString(string: self, attributes: attributes)
     }
 
-    // Extension if we want to ignore emojies for VoiceOver reader
+    // Ignores emojies symbols accrodingly to https://www.ascii-code.com
     func withoutEmoji() -> String {
-        let filteredScalars = unicodeScalars.filter { $0.value <= 255 }
+        let filteredScalars = unicodeScalars.filter { !$0.properties.isEmojiPresentation }
         return String(filteredScalars)
     }
 }

--- a/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
@@ -35,7 +35,7 @@ public extension String {
 
     // Extension if we want to ignore emojies for VoiceOver reader
     func withoutEmoji() -> String {
-        let filteredScalars = unicodeScalars.filter { !$0.properties.isEmojiPresentation }
+        let filteredScalars = unicodeScalars.filter { $0.value <= 255 }
         return String(filteredScalars)
     }
 }

--- a/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/FinniversKit/Sources/Extensions/Foundation/StringExtensions.swift
@@ -32,11 +32,6 @@ public extension String {
     func asAttributedString(attributes: [NSAttributedString.Key: Any]? = nil) -> NSAttributedString {
         NSAttributedString(string: self, attributes: attributes)
     }
-
-    // Extension if we want to ignore emojies for VoiceOver reader
-    func withoutEmoji() -> String {
-        filter { $0.isASCII }
-    }
 }
 
 extension Optional where Wrapped == String {


### PR DESCRIPTION
# Why?

We wanted to remove emojies symbols for norwegian but removed accidentally some finnish symbols (`ä ` particularly) 

# What?

Remove broken method 

# Version Change

Minor
