### PR TITLE
Fix collapsed native ads 

### DIFF
--- a/FinniversKit/Sources/Components/NativeAdvert/NativeAdvertDetailsContainer.swift
+++ b/FinniversKit/Sources/Components/NativeAdvert/NativeAdvertDetailsContainer.swift
@@ -68,7 +68,7 @@ internal final class NativeAdvertDetailsContainer: UIView {
     ]
 
     private lazy var regularConstraints: [NSLayoutConstraint] = [
-        descriptionLabel.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor),
+        descriptionLabel.bottomAnchor.constraint(equalTo: container.bottomAnchor),
 
         logoView.widthAnchor.constraint(equalToConstant: logoSizeRegular),
         logoView.heightAnchor.constraint(equalToConstant: logoSizeRegular),


### PR DESCRIPTION
# Why?

We were seeing collapsed native ads in certain verticals. This simple code change aims to remedy this ! 

![image](https://github.com/user-attachments/assets/b7d81e16-ba4b-43fe-bddb-856aaaa77b9c)


![image](https://github.com/user-attachments/assets/a20f5863-47f6-48ac-a217-731e3a35c7ae)

