### PR TITLE
Internal: add accessible traits to `Broadcast` component

### DIFF
--- a/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
+++ b/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
@@ -31,6 +31,8 @@ public final class Broadcast: UIStackView {
         axis = .vertical
         distribution = .fill
         alignment = .fill
+        isAccessibilityElement = true
+        accessibilityTraits = .summaryElement
     }
 
     public required init(coder: NSCoder) {

--- a/FinniversKit/Sources/Components/Broadcast/BroadcastItem.swift
+++ b/FinniversKit/Sources/Components/Broadcast/BroadcastItem.swift
@@ -77,6 +77,8 @@ class BroadcastItem: UIView {
         clipsToBounds = true
 
         setAttributedText(message)
+        setAccessbilityLabel(message)
+        
         setupSubviews()
     }
 
@@ -129,6 +131,11 @@ extension BroadcastItem {
         let attributedString = NSMutableAttributedString(attributedString: message.attributedString(for: message.text))
         attributedString.addAttributes(BroadcastItem.Style.fontAttributes, range: NSRange(location: 0, length: attributedString.string.utf16.count))
         messageTextView.attributedText = attributedString
+    }
+    
+    private func setAccessbilityLabel(_ message: BroadcastMessage) {
+        messageTextView.accessibilityLabel = message.text
+        accessibilityTraits = .staticText
     }
 
     // MARK: - Actions


### PR DESCRIPTION
# Why?

- Missing accessibility traits

# What?

- Make `BroadcastMessage` accessible and set the `accessibilityTraits` for `BroadcastMessage` to `.summaryElement`
  > This accessibility element provides summary information when the app starts.

- Make `BroadcastItem` accessible and set the `accessibilityTraits` to `staticText`

# Version Change

- Minor
