### PR TITLE
Reorder elements in EmptyView

### DIFF
--- a/FinniversKit/Sources/Fullscreen/EmptyView/EmptyView.swift
+++ b/FinniversKit/Sources/Fullscreen/EmptyView/EmptyView.swift
@@ -112,13 +112,17 @@ public class EmptyView: UIView {
     private func setup() {
         backgroundColor = .background
 
+        addSubview(imageView)
         addSubview(headerLabel)
         addSubview(messageLabel)
-        addSubview(imageView)
         addSubview(actionButton)
 
         NSLayoutConstraint.activate([
-            headerLabel.topAnchor.constraint(equalTo: topAnchor, constant: Warp.Spacing.spacing800),
+            imageView.topAnchor.constraint(equalTo: topAnchor, constant: Warp.Spacing.spacing800),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing400),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing400),
+
+            headerLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: Warp.Spacing.spacing400),
             headerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing400),
             headerLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing400),
 
@@ -126,11 +130,7 @@ public class EmptyView: UIView {
             messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing400),
             messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing400),
 
-            imageView.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: Warp.Spacing.spacing400),
-            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing400),
-            imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing400),
-
-            actionButton.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: Warp.Spacing.spacing400),
+            actionButton.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: Warp.Spacing.spacing400),
             actionButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing400),
             actionButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing400)
         ])


### PR DESCRIPTION
# Why?

To improve the visual hierarchy and user experience, the image in the EmptyView should be placed above the title and description. This change will also align iOS with Web and Android.

# What?

- Moved the image to the top in the EmptyView component.  
- Title now appears below the image, followed by the description.  

Would this change affect other parts of the app? Please review and let me know if need adjustments.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 - 2025-02-04 at 09 47 56](https://github.com/user-attachments/assets/849d81e4-1ccb-41a5-a781-5f79581911e7) | ![simulator_screenshot_A552BE14-D39A-4DC0-93A1-AE4EE715A8C1](https://github.com/user-attachments/assets/f6f0e5d0-5b30-4c25-a124-5d994ef9871a)|
| ![Simulator Screenshot - iPad (10th generation) - 2025-02-04 at 09 49 19](https://github.com/user-attachments/assets/14f52324-5f44-4d78-ba31-d9bae1a38e6d) |![simulator_screenshot_F113AC70-8CF0-485F-8496-8D9DA9603104](https://github.com/user-attachments/assets/e04f4b61-f386-4eff-8b57-29ec3eb950b9) |
