### PR TITLE
Fix margins for Favorites header

### DIFF
--- a/FinniversKit/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteAdsList/Subviews/FavoriteAdsListTableHeader.swift
@@ -124,8 +124,8 @@ class FavoriteAdsListTableHeader: UIView {
 
         NSLayoutConstraint.activate([
             contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: Warp.Spacing.spacing200),
-            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Warp.Spacing.spacing200),
-            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Warp.Spacing.spacing200),
+            contentStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Warp.Spacing.spacing200),
+            contentStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Warp.Spacing.spacing200),
             contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             sortingView.leadingAnchor.constraint(equalTo: sortingContainerView.leadingAnchor),

--- a/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/Subviews/AddFavoriteFolderViewCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/Subviews/AddFavoriteFolderViewCell.swift
@@ -34,8 +34,8 @@ final class AddFavoriteFolderViewCell: BasicTableViewCell {
         contentView.addSubview(button)
 
         NSLayoutConstraint.activate([
-            button.leadingAnchor.constraint(equalTo: leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor),
+            button.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
             button.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
 


### PR DESCRIPTION
# Why?

Favorites header breaks safe area margins for Landscape

# What?

Fix safe area margins for Favorites Headers

# Version Change

patch

# UI Changes

| Before | After |
| --- | --- |
|<img width="2868" height="1320"alt="Screenshot 2025-07-29 at 15 50 19" src="https://github.com/user-attachments/assets/8eaf79ad-1f87-496c-af96-3f2781ea1938" /> | <img width="2868" height="1320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-29 at 15 45 46" src="https://github.com/user-attachments/assets/947ca98f-ead8-45c9-a9d7-3a437c33e844" /> |
| _Before image/gif_ | <img width="2868" height="1320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-29 at 15 49 31" src="https://github.com/user-attachments/assets/139dee5a-c672-457d-95ab-03457456dc94" /> |





