### PR TITLE
Make horizontal padding configurable on `IconCollectionView`

### DIFF
--- a/FinniversKit/Sources/Components/IconCollection/HorizontalIconCollectionViewCell.swift
+++ b/FinniversKit/Sources/Components/IconCollection/HorizontalIconCollectionViewCell.swift
@@ -6,10 +6,9 @@ import UIKit
 import Warp
 
 public class HorizontalIconCollectionViewCell: UICollectionViewCell {
-    //    private static let titleSideMargin = Warp.Spacing.spacing100
-    private static let leadingInset: CGFloat = 0                              // was spacing100; set to 0 to remove left padding
-    private static let trailingInset: CGFloat = Warp.Spacing.spacing100       // right edge inset
-    private static let iconToTextSpacing: CGFloat = Warp.Spacing.spacing100   // gap between icon and text
+    private static let leadingInset: CGFloat = 0
+    private static let trailingInset: CGFloat = Warp.Spacing.spacing100
+    private static let iconToTextSpacing: CGFloat = Warp.Spacing.spacing100
     private static let verticalPadding: CGFloat = Warp.Spacing.spacing50
     private static let titleStyle = Warp.Typography.body
     private static let bodyStyle = Warp.Typography.bodyStrong
@@ -87,36 +86,23 @@ public class HorizontalIconCollectionViewCell: UICollectionViewCell {
     private func setup() {
         isAccessibilityElement = true
 
-        preservesSuperviewLayoutMargins = false
-        contentView.preservesSuperviewLayoutMargins = false
-        insetsLayoutMarginsFromSafeArea = false
-        contentView.insetsLayoutMarginsFromSafeArea = false
-        contentView.layoutMargins = .zero
-
         contentView.addSubview(iconImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(bodyLabel)
 
         NSLayoutConstraint.activate([
             iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
-                                                   constant: Self.leadingInset),
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.leadingInset),
 
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
-                                            constant: Self.verticalPadding),
-            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor,
-                                                constant: Self.iconToTextSpacing),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
-                                                 constant: -Self.trailingInset),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.verticalPadding),
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: Self.iconToTextSpacing),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.trailingInset),
 
             bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
-            bodyLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor,
-                                               constant: Self.iconToTextSpacing),
-            bodyLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
-                                                constant: -Self.trailingInset),
+            bodyLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: Self.iconToTextSpacing),
+            bodyLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.trailingInset),
 
-            bodyLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor,
-                                              constant: -Self.verticalPadding)
+            bodyLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -Self.verticalPadding)
         ])
     }
 }

--- a/FinniversKit/Sources/Components/IconCollection/HorizontalIconCollectionViewCell.swift
+++ b/FinniversKit/Sources/Components/IconCollection/HorizontalIconCollectionViewCell.swift
@@ -6,13 +6,19 @@ import UIKit
 import Warp
 
 public class HorizontalIconCollectionViewCell: UICollectionViewCell {
-    private static let titleSideMargin = Warp.Spacing.spacing100
+    //    private static let titleSideMargin = Warp.Spacing.spacing100
+    private static let leadingInset: CGFloat = 0                              // was spacing100; set to 0 to remove left padding
+    private static let trailingInset: CGFloat = Warp.Spacing.spacing100       // right edge inset
+    private static let iconToTextSpacing: CGFloat = Warp.Spacing.spacing100   // gap between icon and text
+    private static let verticalPadding: CGFloat = Warp.Spacing.spacing50
     private static let titleStyle = Warp.Typography.body
     private static let bodyStyle = Warp.Typography.bodyStrong
 
     static func height(for viewModel: IconCollectionViewModel, withWidth width: CGFloat) -> CGFloat {
         let imageSize = viewModel.image.size
-        let textWidth = width - imageSize.width - (3 * titleSideMargin)
+        let textWidth = width
+                    - imageSize.width
+                    - (Self.leadingInset + Self.iconToTextSpacing + Self.trailingInset)
 
         let titleHeight = viewModel.title?.height(withConstrainedWidth: textWidth, font: titleStyle.uiFont) ?? 0
         let bodyHeight = viewModel.text.height(withConstrainedWidth: textWidth, font: bodyStyle.uiFont)
@@ -81,21 +87,36 @@ public class HorizontalIconCollectionViewCell: UICollectionViewCell {
     private func setup() {
         isAccessibilityElement = true
 
+        preservesSuperviewLayoutMargins = false
+        contentView.preservesSuperviewLayoutMargins = false
+        insetsLayoutMarginsFromSafeArea = false
+        contentView.insetsLayoutMarginsFromSafeArea = false
+        contentView.layoutMargins = .zero
+
         contentView.addSubview(iconImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(bodyLabel)
 
         NSLayoutConstraint.activate([
             iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: HorizontalIconCollectionViewCell.titleSideMargin),
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
+                                                   constant: Self.leadingInset),
 
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Warp.Spacing.spacing50),
-            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: HorizontalIconCollectionViewCell.titleSideMargin),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -HorizontalIconCollectionViewCell.titleSideMargin),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                            constant: Self.verticalPadding),
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor,
+                                                constant: Self.iconToTextSpacing),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
+                                                 constant: -Self.trailingInset),
 
             bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
-            bodyLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: HorizontalIconCollectionViewCell.titleSideMargin),
-            bodyLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -HorizontalIconCollectionViewCell.titleSideMargin)
+            bodyLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor,
+                                               constant: Self.iconToTextSpacing),
+            bodyLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
+                                                constant: -Self.trailingInset),
+
+            bodyLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor,
+                                              constant: -Self.verticalPadding)
         ])
     }
 }

--- a/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
@@ -55,7 +55,7 @@ public final class IconCollectionView: UIView {
 
     // MARK: - Init
 
-    public init(alignment: Alignment = .vertical, horisontalPadding: CGFloat) {
+    public init(alignment: Alignment = .vertical, horisontalPadding: CGFloat = Warp.Spacing.spacing50) {
         self.alignment = alignment
         self.horisontalPadding = horisontalPadding
         super.init(frame: .zero)

--- a/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
@@ -21,6 +21,7 @@ public final class IconCollectionView: UIView {
     // MARK: - Private properties
 
     private var alignment: Alignment
+    private var horisontalPadding: CGFloat
     private var viewModels = [IconCollectionViewModel]()
 
     private lazy var collectionView: UICollectionView = {
@@ -46,7 +47,7 @@ public final class IconCollectionView: UIView {
     private lazy var margins: UIEdgeInsets = {
         switch alignment {
         case .horizontal:
-            return UIEdgeInsets(vertical: Warp.Spacing.spacing200, horizontal: Warp.Spacing.spacing50)
+            return UIEdgeInsets(vertical: Warp.Spacing.spacing200, horizontal: horisontalPadding)
         case .vertical:
             return .zero
         }
@@ -54,8 +55,9 @@ public final class IconCollectionView: UIView {
 
     // MARK: - Init
 
-    public init(alignment: Alignment = .vertical) {
+    public init(alignment: Alignment = .vertical, horisontalPadding: CGFloat) {
         self.alignment = alignment
+        self.horisontalPadding = horisontalPadding
         super.init(frame: .zero)
         setup()
     }


### PR DESCRIPTION
# Why?

After the landscape-mode changes, we encountered a padding issue in the summary section. This PR makes the padding configurable so it can be set to zero when needed.

# What?

- `IconCollectionView`: make horizontal padding configurable (defaults preserved).
- `HorizontalIconCollectionViewCell`: remove leading inset for the icon; keep explicit icon↔text spacing and trailing inset; update sizing to match.

# Version Change

Minor

# UI Changes

| Before | After |
| --- | --- |
| ![IMG_A5DDED30CA45-1](https://github.com/user-attachments/assets/bb765889-e21b-4d5d-9350-8497af766137) | <img width="331" height="269" alt="Screenshot 2025-08-19 at 10 42 03" src="https://github.com/user-attachments/assets/6985fb8f-964e-4c4c-82c3-8474a6ffe071" /> |
