### PR TITLE
Fix: IconCollectionView

### DIFF
--- a/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
+++ b/FinniversKit/Sources/Components/IconCollection/IconCollectionView.swift
@@ -99,7 +99,10 @@ public final class IconCollectionView: UIView {
         }
 
         guard let firstItem = cellSizes.first else { return targetSize }
-        let numberOfCellsInRow = Int(floor(targetWidth / firstItem.width))
+
+        // Guard against division by zero and ensure we have at least 1 cell per row
+        guard firstItem.width > 0 else { return targetSize }
+        let numberOfCellsInRow = max(1, Int(floor(targetWidth / firstItem.width)))
         let cellRows = cellSizes.chunked(into: numberOfCellsInRow)
         let totalHeight = cellRows.compactMap { $0.max(by: { $0.height < $1.height }) }.reduce(0, { $0 + $1.height })
 


### PR DESCRIPTION
The PR fixes a critical crash in `IconCollectionView.systemLayoutSizeFitting` method that occurred when cells had zero width
  - Added proper guards to prevent division by zero and ensure at least 1 cell per row

# Version Change

Minor