### PR TITLE
Fix top offset for PushNotificationNudgingBottomSheet

### DIFF
--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingBottomSheet/PushNotificationNudgingBottomSheet.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingBottomSheet/PushNotificationNudgingBottomSheet.swift
@@ -13,7 +13,8 @@ public struct PushNotificationNudgingBottomSheet: View {
             Text(viewModel.title)
                 .font(from: .title3)
                 .multilineTextAlignment(.center)
-                .padding(.top, Warp.Spacing.spacing100)
+                .safeAreaPadding(.top)
+                .padding(.top, Warp.Spacing.spacing200)
 
             VStack(spacing: Warp.Spacing.spacing100) {
                 ForEach(viewModel.sections, id: \.self) {

--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
@@ -40,7 +40,6 @@ public struct PushNotificationNudgingView: View {
                 VStack(alignment: .leading, spacing: Warp.Spacing.spacing50) {
                     Text(viewModel.title)
                         .font(from: .bodyStrong)
-                        .fixedSize(horizontal: false, vertical: true)
                         .accessibilityLabel(viewModel.title.withoutEmoji())
                     if let description = viewModel.description {
                         Text(description)

--- a/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
+++ b/FinniversKit/Sources/Components/PushNotificationNudgingView/PushNotificationNudgingView/PushNotificationNudgingView.swift
@@ -40,6 +40,7 @@ public struct PushNotificationNudgingView: View {
                 VStack(alignment: .leading, spacing: Warp.Spacing.spacing50) {
                     Text(viewModel.title)
                         .font(from: .bodyStrong)
+                        .fixedSize(horizontal: false, vertical: true)
                         .accessibilityLabel(viewModel.title.withoutEmoji())
                     if let description = viewModel.description {
                         Text(description)


### PR DESCRIPTION
# Why?

PushNotificationNudgingBottomSheet is overlapped by navigation bar in Landscape on ios18

# What?

Fix top offset

# Version Change

patch

# UI Changes

| Before | After |
| --- | --- |
| <img width="2532" height="1170" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 16 06 01" src="https://github.com/user-attachments/assets/9e391217-a675-4968-b1f6-ad425ceec995" /> | <img width="2532" height="1170" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 15 57 00" src="https://github.com/user-attachments/assets/0c5aedd5-4d05-4bdb-876e-6b74dc09e426" />|



