### PR TITLE
Add optional valueImage property to KeyValuePair

### DIFF
--- a/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
+++ b/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
@@ -133,8 +133,10 @@ public class KeyValueGridView: UIView {
             let imageView = UIImageView(withAutoLayout: true)
             imageView.image = image
             imageView.contentMode = .scaleAspectFit
+            let aspectRatio = image.size.width / image.size.height
             NSLayoutConstraint.activate([
-                imageView.heightAnchor.constraint(equalToConstant: 32)
+                imageView.heightAnchor.constraint(equalToConstant: 32),
+                imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: aspectRatio)
             ])
             valueView = imageView
         } else {

--- a/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
+++ b/FinniversKit/Sources/Components/KeyValueGridView/KeyValueGridView.swift
@@ -128,21 +128,33 @@ public class KeyValueGridView: UIView {
             titleContainer.addArrangedSubview(infoButton)
         }
 
-        let valueLabel = PaddableLabel(style: valueStyle, numberOfLines: 2, withAutoLayout: true)
-        valueLabel.lineBreakMode = .byWordWrapping
-        valueLabel.isAccessibilityElement = true
-        valueLabel.accessibilityTraits = .staticText
-        valueLabel.setTextCopyable(true)
+        let valueView: UIView
+        if let image = pair.valueImage {
+            let imageView = UIImageView(withAutoLayout: true)
+            imageView.image = image
+            imageView.contentMode = .scaleAspectFit
+            NSLayoutConstraint.activate([
+                imageView.heightAnchor.constraint(equalToConstant: 32)
+            ])
+            valueView = imageView
+        } else {
+            let valueLabel = PaddableLabel(style: valueStyle, numberOfLines: 2, withAutoLayout: true)
+            valueLabel.lineBreakMode = .byWordWrapping
+            valueLabel.isAccessibilityElement = true
+            valueLabel.accessibilityTraits = .staticText
+            valueLabel.setTextCopyable(true)
 
-        if let valueStyle = pair.valueStyle {
-            valueLabel.textColor = valueStyle.textColor
-            valueLabel.backgroundColor = valueStyle.backgroundColor
-            valueLabel.textPadding = .init(vertical: 0, horizontal: valueStyle.horizontalPadding)
+            if let valueStyle = pair.valueStyle {
+                valueLabel.textColor = valueStyle.textColor
+                valueLabel.backgroundColor = valueStyle.backgroundColor
+                valueLabel.textPadding = .init(vertical: 0, horizontal: valueStyle.horizontalPadding)
+            }
+
+            valueLabel.text = pair.value
+            valueView = valueLabel
         }
 
-        valueLabel.text = pair.value
-
-        stackView.addArrangedSubviews([titleContainer, valueLabel])
+        stackView.addArrangedSubviews([titleContainer, valueView])
         stackView.arrangedSubviews.forEach {
             $0.setContentCompressionResistancePriority(.required, for: .vertical)
         }

--- a/FinniversKit/Sources/Components/KeyValueGridView/KeyValuePair.swift
+++ b/FinniversKit/Sources/Components/KeyValueGridView/KeyValuePair.swift
@@ -3,6 +3,7 @@ public struct KeyValuePair: Hashable {
     public let value: String
     public let accessibilityLabel: String?
     public let valueStyle: Style?
+    public let valueImage: UIImage?
     public let infoTooltip: String?
     public let infoTooltipAccessibilityLabel: String?
 
@@ -11,6 +12,7 @@ public struct KeyValuePair: Hashable {
         value: String,
         accessibilityLabel: String? = nil,
         valueStyle: Style? = nil,
+        valueImage: UIImage? = nil,
         infoTooltip: String? = nil,
         infoTooltipAccessibilityLabel: String? = nil
     ) {
@@ -18,6 +20,7 @@ public struct KeyValuePair: Hashable {
         self.value = value
         self.accessibilityLabel = accessibilityLabel
         self.valueStyle = valueStyle
+        self.valueImage = valueImage
         self.infoTooltip = infoTooltip
         self.infoTooltipAccessibilityLabel = infoTooltipAccessibilityLabel
     }


### PR DESCRIPTION
# Why?

We need to be able to display assets for energy labels in the item page.

# What?

Add support for an optional image value in the key-value pair used in `KeyValueGridView` which if present causes an image view to be displayed instead of the usual `PaddableLabel`.

# Version Change

Minor

# UI Changes

<img width="301" height="80" alt="Screenshot 2026-04-16 at 11 29 59" src="https://github.com/user-attachments/assets/745e92c8-7d60-4eb0-b84e-57669ad682a8" />
