### PR TITLE
Rename EmptyView to LegacyEmptyView to avoid SwiftUI.EmptyView ambiguity

### DIFF
--- a/Demo/Sources/Fullscreen/EmptyView/EmptyViewDemoView.swift
+++ b/Demo/Sources/Fullscreen/EmptyView/EmptyViewDemoView.swift
@@ -6,7 +6,7 @@ import FinniversKit
 import DemoKit
 
 class EmptyViewDemoView: UIView {
-    var emptyView: EmptyView?
+    var emptyView: LegacyEmptyView?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -18,7 +18,7 @@ class EmptyViewDemoView: UIView {
     private func setupEmptyView(header: String, message: String, image: UIImage? = nil, actionButtonTitle: String = "") {
         self.emptyView?.removeFromSuperview()
         self.emptyView = nil
-        self.emptyView = EmptyView()
+        self.emptyView = LegacyEmptyView()
         self.addSubview(self.emptyView!) // swiftlint:disable:this force_unwrapping
         self.emptyView?.fillInSuperview()
 

--- a/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
+++ b/FinniversKit/FinniversKit.xcodeproj/project.pbxproj
@@ -132,7 +132,7 @@
 		44AFCE49215839F7005984DB /* LoadingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AFCE47215839F6005984DB /* LoadingIndicatorView.swift */; };
 		44C4E8DE1FFBA714000B014D /* Config.swift in Headers */ = {isa = PBXBuildFile; fileRef = 4447F6C61FDB2B110033DBC1 /* Config.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		44C6CE44209CABFE00929269 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C6CE43209CABFE00929269 /* ImageAsset.swift */; };
-		44D9125F2077AC8A00486848 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D912512077AC8A00486848 /* EmptyView.swift */; };
+		44D9125F2077AC8A00486848 /* LegacyEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D912512077AC8A00486848 /* LegacyEmptyView.swift */; };
 		44F8831220551D59003E3171 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */; };
 		45B2E06A207CF5C100C68B92 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E069207CF5C100C68B92 /* StringExtensions.swift */; };
 		45D7C56B204949E2000E788F /* SwitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C56A204949E2000E788F /* SwitchView.swift */; };
@@ -575,7 +575,7 @@
 		44A557B322E72187001667AE /* CheckboxTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckboxTableViewCell.swift; sourceTree = "<group>"; };
 		44AFCE47215839F6005984DB /* LoadingIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingIndicatorView.swift; sourceTree = "<group>"; };
 		44C6CE43209CABFE00929269 /* ImageAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAsset.swift; sourceTree = "<group>"; };
-		44D912512077AC8A00486848 /* EmptyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
+		44D912512077AC8A00486848 /* LegacyEmptyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyEmptyView.swift; sourceTree = "<group>"; };
 		44F8831120551D59003E3171 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		45B2E069207CF5C100C68B92 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		45D7C56A204949E2000E788F /* SwitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchView.swift; sourceTree = "<group>"; };
@@ -1698,7 +1698,7 @@
 		44D912502077AC8A00486848 /* EmptyView */ = {
 			isa = PBXGroup;
 			children = (
-				44D912512077AC8A00486848 /* EmptyView.swift */,
+				44D912512077AC8A00486848 /* LegacyEmptyView.swift */,
 			);
 			path = EmptyView;
 			sourceTree = "<group>";
@@ -3153,7 +3153,7 @@
 				441FE433209A24E500B04EF1 /* AdRecommendationsGridViewLayout.swift in Sources */,
 				08F0D3F422259AD100968256 /* HappinessRatingView.swift in Sources */,
 				179D06A82906A39D00A65E3A /* HTMLStringParserHTMLTranslator.swift in Sources */,
-				44D9125F2077AC8A00486848 /* EmptyView.swift in Sources */,
+				44D9125F2077AC8A00486848 /* LegacyEmptyView.swift in Sources */,
 				44A557B622E72187001667AE /* CheckboxTableViewCell.swift in Sources */,
 				CF376C18231D452100ED2B24 /* Array+Step.swift in Sources */,
 				B6F5ECB32CB56CCA00E24EC3 /* PushNotificationNudgingView.swift in Sources */,

--- a/FinniversKit/Sources/Fullscreen/EmptyView/GenericErrorSwiftUIView.swift
+++ b/FinniversKit/Sources/Fullscreen/EmptyView/GenericErrorSwiftUIView.swift
@@ -40,8 +40,8 @@ public struct GenericErrorSwiftUIView: UIViewRepresentable {
         self.viewModel = viewModel
     }
 
-    public func makeUIView(context: Context) -> FinniversKit.EmptyView {
-        let genericView = FinniversKit.EmptyView(shapeType: .default)
+    public func makeUIView(context: Context) -> LegacyEmptyView {
+        let genericView = LegacyEmptyView(shapeType: .default)
         genericView.header = viewModel.title
         genericView.message = viewModel.description ?? ""
         genericView.actionButtonTitle = viewModel.buttonTitle ?? ""
@@ -50,25 +50,25 @@ public struct GenericErrorSwiftUIView: UIViewRepresentable {
         return genericView
     }
 
-    public func updateUIView(_ uiView: FinniversKit.EmptyView, context: Context) {
+    public func updateUIView(_ uiView: LegacyEmptyView, context: Context) {
     }
 
     public func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
     }
 
-    public class Coordinator: NSObject, EmptyViewDelegate {
+    public class Coordinator: NSObject, LegacyEmptyViewDelegate {
         let parent: GenericErrorSwiftUIView
 
         init(parent: GenericErrorSwiftUIView) {
             self.parent = parent
         }
 
-        public func emptyView(_ emptyView: FinniversKit.EmptyView, didSelectActionButton button: FinniversKit.Button) {
+        public func emptyView(_ emptyView: LegacyEmptyView, didSelectActionButton button: FinniversKit.Button) {
             parent.viewModel.action?()
         }
 
-        public func emptyView(_ emptyView: FinniversKit.EmptyView, didMoveObjectView view: UIView) {
+        public func emptyView(_ emptyView: LegacyEmptyView, didMoveObjectView view: UIView) {
         }
     }
 }

--- a/FinniversKit/Sources/Fullscreen/EmptyView/LegacyEmptyView.swift
+++ b/FinniversKit/Sources/Fullscreen/EmptyView/LegacyEmptyView.swift
@@ -6,19 +6,19 @@ import CoreMotion
 import UIKit
 import Warp
 
-public protocol EmptyViewDelegate: AnyObject {
-    func emptyView(_ emptyView: EmptyView, didSelectActionButton button: Button)
-    func emptyView(_ emptyView: EmptyView, didMoveObjectView view: UIView)
+public protocol LegacyEmptyViewDelegate: AnyObject {
+    func emptyView(_ emptyView: LegacyEmptyView, didSelectActionButton button: Button)
+    func emptyView(_ emptyView: LegacyEmptyView, didMoveObjectView view: UIView)
 }
 
-public enum EmptyViewShapeType { // Deprecated
+public enum LegacyEmptyViewShapeType { // Deprecated
     case `default`
     case christmas
     case none
 }
 
 @available(*, deprecated, message: "This view is deprecated. Use `StateViews.EmptyStateView` instead")
-public class EmptyView: UIView {
+public class LegacyEmptyView: UIView {
 
     // MARK: - Other private attributes
 
@@ -56,7 +56,7 @@ public class EmptyView: UIView {
 
     // MARK: - External properties / Dependency injection
 
-    public weak var delegate: EmptyViewDelegate?
+    public weak var delegate: LegacyEmptyViewDelegate?
 
     public var header: String = "" {
         didSet {
@@ -102,7 +102,7 @@ public class EmptyView: UIView {
     // MARK: - Deprecated
 
     @available(*, deprecated, message: "shapeType parameter is not supported anymore and should be removed")
-    public init(shapeType: EmptyViewShapeType = .default) {
+    public init(shapeType: LegacyEmptyViewShapeType = .default) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         setup()
@@ -143,3 +143,12 @@ public class EmptyView: UIView {
         delegate?.emptyView(self, didSelectActionButton: actionButton)
     }
 }
+
+@available(*, deprecated, renamed: "LegacyEmptyView")
+public typealias EmptyView = LegacyEmptyView
+
+@available(*, deprecated, renamed: "LegacyEmptyViewDelegate")
+public typealias EmptyViewDelegate = LegacyEmptyViewDelegate
+
+@available(*, deprecated, renamed: "LegacyEmptyViewShapeType")
+public typealias EmptyViewShapeType = LegacyEmptyViewShapeType


### PR DESCRIPTION
  # Why?

  FinniversKit's public (already deprecated) `EmptyView` shadowed `SwiftUI.EmptyView`. Any file importing both modules had to disambiguate with explicit `FinniversKit.EmptyView` /
  `SwiftUI.EmptyView` qualifiers. Renaming removes the name collision.

  # What?

  Renamed the type and its companions:

  - `EmptyView` → `LegacyEmptyView`
  - `EmptyViewDelegate` → `LegacyEmptyViewDelegate`
  - `EmptyViewShapeType` → `LegacyEmptyViewShapeType`

  Deprecated `typealias` declarations for the old names are kept for source compatibility, so downstream consumers won't break. Internal usages (`GenericErrorSwiftUIView`, demo view,
  Xcode project file reference) updated to the new name. The source file was renamed `EmptyView.swift` → `LegacyEmptyView.swift`.

  Note: because the deprecated typealias keeps the old name in the module, the ambiguity with `SwiftUI.EmptyView` is only fully removed once consumers migrate off `EmptyView`. Happy
  to drop the typealias for a hard break if preferred.

  # Version Change

  Minor — non-breaking, additive deprecations only.

  # UI Changes

  None. No visual or behavioral changes.