### PR TITLE
♻️ Add @Sendable to image-loading completion handlers

### DIFF
--- a/Demo/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCellDemoView.swift
+++ b/Demo/Sources/Cells/FavoriteAdTableViewCell/FavoriteAdCellDemoView.swift
@@ -78,7 +78,7 @@ extension FavoriteAdCellDemoView: RemoteImageViewDataSource {
         return nil
     }
 
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Cells/RemoteImageTableViewCell/RemoteImageCellDemoView.swift
+++ b/Demo/Sources/Cells/RemoteImageTableViewCell/RemoteImageCellDemoView.swift
@@ -74,7 +74,7 @@ extension RemoteImageCellDemoView: UITableViewDataSource {
 // MARK: - RemoteImageTableViewCellDataSource
 
 extension RemoteImageCellDemoView: RemoteImageViewDataSource {
-    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Components/FrontPageSavedSearchesDemoView/FrontPageSavedSearchesDemoView.swift
+++ b/Demo/Sources/Components/FrontPageSavedSearchesDemoView/FrontPageSavedSearchesDemoView.swift
@@ -45,7 +45,7 @@ extension FrontPageSavedSearchesDemoView: FrontPageSavedSearchesViewDelegate {
 // MARK: - RemoteImageViewDataSource
 
 extension FrontPageSavedSearchesDemoView: RemoteImageViewDataSource {
-    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Components/LoanCalculator/LoanCalculatorDemoView.swift
+++ b/Demo/Sources/Components/LoanCalculator/LoanCalculatorDemoView.swift
@@ -95,7 +95,7 @@ extension LoanCalculatorDemoView: LoanCalculatorDataSource {
     func loanCalculatorView(
         _ view: LoanCalculatorView,
         loadImageWithUrl url: URL,
-        completion: @escaping ((UIImage?) -> Void)
+        completion: @escaping @Sendable ((UIImage?) -> Void)
     ) {
         // Demo code only.
         let task = URLSession.shared.dataTask(with: url) { data, _, _ in

--- a/Demo/Sources/Components/PromotionDemoView/PromotionDemoView.swift
+++ b/Demo/Sources/Components/PromotionDemoView/PromotionDemoView.swift
@@ -70,14 +70,14 @@ extension PromotionDemoView: RemoteImageViewDataSource {
         nil
     }
 
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         loadImage(imagePath: imagePath, completion: completion)
     }
 
     func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat) {
     }
 
-    private func loadImage(imagePath: String, completion: @escaping ((UIImage?) -> Void)) {
+    private func loadImage(imagePath: String, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Components/RecentlyFavoritedShelfDemoView/RecentlyFavoritedShelfDemoView.swift
+++ b/Demo/Sources/Components/RecentlyFavoritedShelfDemoView/RecentlyFavoritedShelfDemoView.swift
@@ -144,7 +144,7 @@ extension RecentlyFavoritedShelfDemoView: RemoteImageViewDataSource {
         nil
     }
 
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Components/SendInviteView/SendInviteDemoView.swift
+++ b/Demo/Sources/Components/SendInviteView/SendInviteDemoView.swift
@@ -32,7 +32,7 @@ class SendInviteDemoView: UIView, Demoable {
 }
 
 extension SendInviteDemoView: SendInviteViewDelegate {
-    func sendInviteViewLoadImage(_ view: SendInviteView, loadImageWithUrl url: URL, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func sendInviteViewLoadImage(_ view: SendInviteView, loadImageWithUrl url: URL, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         let task = URLSession.shared.dataTask(with: url) { data, _, _ in
             usleep(50_000)
             DispatchQueue.main.async {

--- a/Demo/Sources/Fullscreen/BuyerPicker/BuyerPickerDemoView.swift
+++ b/Demo/Sources/Fullscreen/BuyerPicker/BuyerPickerDemoView.swift
@@ -41,7 +41,7 @@ extension BuyerPickerDemoView: BuyerPickerViewDelegate {
         })
     }
 
-    func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = model.image else {
             let placeholderImage: UIImage = .brandConsentTransparency
             completion(placeholderImage)

--- a/Demo/Sources/Fullscreen/FavoriteAdCommentInput/FavoriteAdCommentInputDemoView.swift
+++ b/Demo/Sources/Fullscreen/FavoriteAdCommentInput/FavoriteAdCommentInputDemoView.swift
@@ -57,7 +57,7 @@ extension FavoriteAdCommentInputDemoView: RemoteImageViewDataSource {
         _ view: RemoteImageView,
         loadImageWithPath imagePath: String,
         imageWidth: CGFloat,
-        completion: @escaping ((UIImage?) -> Void)
+        completion: @escaping @Sendable ((UIImage?) -> Void)
     ) {
         guard let url = URL(string: imagePath) else {
             completion(nil)

--- a/Demo/Sources/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
+++ b/Demo/Sources/Fullscreen/FavoriteAdsListView/FavoriteAdsListDemoViewController.swift
@@ -237,7 +237,7 @@ extension FavoriteAdsListDemoView: FavoriteAdsListViewDataSource {
     func favoriteAdsListView(_ view: FavoriteAdsListView,
                              loadImageWithPath imagePath: String,
                              imageWidth: CGFloat,
-                             completion: @escaping ((UIImage?) -> Void)) {
+                             completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldDemoView.swift
+++ b/Demo/Sources/Fullscreen/FavoriteSoldView/FavoriteSoldDemoView.swift
@@ -49,7 +49,7 @@ class FavoriteSoldDemoView: UIView, Demoable {
         favoriteSoldView.reloadAds()
     }
 
-    private func loadImageWithPath(_ imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    private func loadImageWithPath(_ imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return
@@ -127,7 +127,7 @@ extension FavoriteSoldDemoView: AdRecommendationsGridViewDataSource {
         return cell
     }
 
-    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         return loadImageWithPath(imagePath, imageWidth: imageWidth, completion: completion)
     }
 
@@ -145,7 +145,7 @@ extension FavoriteSoldDemoView: RemoteImageViewDataSource {
         _ view: RemoteImageView,
         loadImageWithPath imagePath: String,
         imageWidth: CGFloat,
-        completion: @escaping ((UIImage?) -> Void)
+        completion: @escaping @Sendable ((UIImage?) -> Void)
     ) {
         return loadImageWithPath(imagePath, imageWidth: imageWidth, completion: completion)
     }

--- a/Demo/Sources/Fullscreen/FrontPage/FrontPageViewDemoView.swift
+++ b/Demo/Sources/Fullscreen/FrontPage/FrontPageViewDemoView.swift
@@ -63,7 +63,7 @@ final class FrontPageViewDemoViewController: UIViewController, Demoable {
         frontPageView.reloadData()
     }
 
-    private func loadImage(imagePath: String, completion: @escaping ((UIImage?) -> Void)) {
+    private func loadImage(imagePath: String, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return
@@ -176,7 +176,7 @@ extension FrontPageViewDemoViewController: AdRecommendationsGridViewDataSource {
         }
     }
 
-    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         loadImage(imagePath: imagePath, completion: completion)
     }
 
@@ -208,7 +208,7 @@ extension FrontPageViewDemoViewController: RemoteImageViewDataSource {
         nil
     }
 
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         loadImage(imagePath: imagePath, completion: completion)
     }
 

--- a/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoView.swift
+++ b/Demo/Sources/Recycling/GridViews/AdRecommendations/AdRecommendationsGridViewDemoView.swift
@@ -164,7 +164,7 @@ extension AdRecommendationsGridViewDemoView: AdRecommendationsGridViewDataSource
         }
     }
 
-    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListDemoView.swift
+++ b/Demo/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListDemoView.swift
@@ -127,7 +127,7 @@ extension FavoriteFoldersListDemoView: FavoriteFoldersListViewDataSource {
     func favoriteFoldersListView(_ view: FavoriteFoldersListView,
                                  loadImageWithPath imagePath: String,
                                  imageWidth: CGFloat,
-                                 completion: @escaping ((UIImage?) -> Void)) {
+                                 completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let url = URL(string: imagePath) else {
             completion(nil)
             return

--- a/Demo/Sources/Recycling/ListViews/Favorites/FavoritesListViewDemoView.swift
+++ b/Demo/Sources/Recycling/ListViews/Favorites/FavoritesListViewDemoView.swift
@@ -46,7 +46,7 @@ extension FavoritesListViewDemoView: FavoritesListViewDataSource {
         return dataSource.favorites[index]
     }
 
-    func favoritesListView(_ favoritesListView: FavoritesListView, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func favoritesListView(_ favoritesListView: FavoritesListView, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let path = model.imagePath, let url = URL(string: path) else {
             completion(nil)
             return

--- a/Demo/Sources/Recycling/ListViews/Notifications/NotificationsListViewDemoView.swift
+++ b/Demo/Sources/Recycling/ListViews/Notifications/NotificationsListViewDemoView.swift
@@ -63,7 +63,7 @@ extension NotificationsListViewDemoView: NotificationsListViewDataSource {
         return notification
     }
 
-    func notificationsListView(_ notificationsListView: NotificationsListView, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func notificationsListView(_ notificationsListView: NotificationsListView, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         guard let path = model.imagePath, let url = URL(string: path) else {
             completion(nil)
             return

--- a/FinniversKit/Sources/Components/LoanCalculator/LoanCalculatorView.swift
+++ b/FinniversKit/Sources/Components/LoanCalculator/LoanCalculatorView.swift
@@ -14,7 +14,7 @@ public extension LoanCalculatorViewModel {
 public protocol LoanCalculatorDataSource: AnyObject {
     func loanCalculatorView(_ view: LoanCalculatorView, formattedCurrencyValue: Float) -> String?
     func loanCalculatorView(_ view: LoanCalculatorView, formattedYearsValue: Int) -> String?
-    func loanCalculatorView(_ view: LoanCalculatorView, loadImageWithUrl: URL, completion: @escaping ((UIImage?) -> Void))
+    func loanCalculatorView(_ view: LoanCalculatorView, loadImageWithUrl: URL, completion: @escaping @Sendable ((UIImage?) -> Void))
     func loanCalculatorView(_ view: LoanCalculatorView, cancelLoadingImageWithUrl: URL)
 }
 
@@ -151,7 +151,7 @@ extension LoanCalculatorView: RemoteImageViewDataSource {
         _ view: RemoteImageView,
         loadImageWithPath imagePath: String,
         imageWidth: CGFloat,
-        completion: @escaping ((UIImage?) -> Void)
+        completion: @escaping @Sendable ((UIImage?) -> Void)
     ) {
         guard let url = URL(string: imagePath) else {
             completion(nil)

--- a/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
+++ b/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 public protocol RemoteImageViewDataSource: AnyObject {
     @MainActor func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
 }
 

--- a/FinniversKit/Sources/Components/SendInviteView/SendInviteView.swift
+++ b/FinniversKit/Sources/Components/SendInviteView/SendInviteView.swift
@@ -4,7 +4,7 @@
 import Warp
 
 public protocol SendInviteViewDelegate: AnyObject {
-    func sendInviteViewLoadImage(_ view: SendInviteView, loadImageWithUrl url: URL, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func sendInviteViewLoadImage(_ view: SendInviteView, loadImageWithUrl url: URL, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func sendInviteViewDidTapSendInviteButton(_ button: Button)
     func sendInviteViewDidTapSendInviteLaterButton(_ button: Button)
 }

--- a/FinniversKit/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
+++ b/FinniversKit/Sources/Fullscreen/FavoriteAdsList/FavoriteAdsListView.swift
@@ -27,7 +27,7 @@ public protocol FavoriteAdsListViewDataSource: AnyObject {
     func favoriteAdsListView(_ view: FavoriteAdsListView,
                              loadImageWithPath imagePath: String,
                              imageWidth: CGFloat,
-                             completion: @escaping ((UIImage?) -> Void)
+                             completion: @escaping @Sendable ((UIImage?) -> Void)
     )
     func favoriteAdsListView(_ view: FavoriteAdsListView,
                              cancelLoadingImageWithPath imagePath: String,
@@ -494,7 +494,7 @@ extension FavoriteAdsListView: RemoteImageViewDataSource {
     public func remoteImageView(_ view: RemoteImageView,
                                 loadImageWithPath imagePath: String,
                                 imageWidth: CGFloat,
-                                completion: @escaping ((UIImage?) -> Void)) {
+                                completion: @escaping @Sendable ((UIImage?) -> Void)) {
         dataSource?.favoriteAdsListView(self, loadImageWithPath: imagePath, imageWidth: imageWidth, completion: { [weak self] image in
             if let image = image {
                 self?.imageCache.add(image, forKey: imagePath)

--- a/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
+++ b/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public protocol BuyerPickerViewDelegate: AnyObject {
-    func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, cancelLoadingImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat)
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, didSelect profile: BuyerPickerProfileModel, forRowAt indexPath: IndexPath)
     func buyerPickerViewDidSelectFallbackCell(_ buyerPickerView: BuyerPickerView)
@@ -132,7 +132,7 @@ extension BuyerPickerView: UITableViewDelegate {
 // MARK: - ReviewProfileCellDelegate
 
 extension BuyerPickerView: BuyerPickerCellDelegate {
-    func buyerPickerCell(_ reviewProfileCell: BuyerPickerProfileCell, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    func buyerPickerCell(_ reviewProfileCell: BuyerPickerProfileCell, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         delegate?.buyerPickerView(self, loadImageForModel: model, imageWidth: imageWidth, completion: completion)
     }
 

--- a/FinniversKit/Sources/Fullscreen/Review/Cell/BuyerPickerProfileCell.swift
+++ b/FinniversKit/Sources/Fullscreen/Review/Cell/BuyerPickerProfileCell.swift
@@ -6,7 +6,7 @@ import UIKit
 import Warp
 
 protocol BuyerPickerCellDelegate: AnyObject {
-    func buyerPickerCell(_ cell: BuyerPickerProfileCell, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func buyerPickerCell(_ cell: BuyerPickerProfileCell, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func buyerPickerCell(_ cell: BuyerPickerProfileCell, cancelLoadingImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat)
 }
 

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -14,7 +14,7 @@ public protocol AdRecommendationsGridViewDataSource: AnyObject {
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, cellClassesIn collectionView: UICollectionView) -> [UICollectionViewCell.Type]
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, heightForItemWithWidth width: CGFloat, at indexPath: IndexPath) -> CGFloat
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
-    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
 }
 
@@ -202,7 +202,7 @@ extension AdRecommendationsGridView: RemoteImageViewDataSource {
         return imageCache.image(forKey: imagePath)
     }
 
-    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         dataSource?.adRecommendationsGridView(self, loadImageWithPath: imagePath, imageWidth: imageWidth, completion: { [weak self] image in
             if let image = image {
                 self?.imageCache.add(image, forKey: imagePath)

--- a/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/FavoriteFolders/FavoriteFoldersListView.swift
@@ -21,7 +21,7 @@ public protocol FavoriteFoldersListViewDataSource: AnyObject {
         _ view: FavoriteFoldersListView,
         loadImageWithPath imagePath: String,
         imageWidth: CGFloat,
-        completion: @escaping ((UIImage?) -> Void)
+        completion: @escaping @Sendable ((UIImage?) -> Void)
     )
     func favoriteFoldersListView(
         _ view: FavoriteFoldersListView,
@@ -417,7 +417,7 @@ extension FavoriteFoldersListView: RemoteImageViewDataSource {
         return imageCache.image(forKey: imagePath)
     }
 
-    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         dataSource?.favoriteFoldersListView(self, loadImageWithPath: imagePath, imageWidth: imageWidth, completion: { [weak self] image in
             if let image = image {
                 self?.imageCache.add(image, forKey: imagePath)

--- a/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Favorites/Cell/FavoritesListViewCell.swift
@@ -6,7 +6,7 @@ import UIKit
 import Warp
 
 public protocol FavoritesListViewCellDataSource: AnyObject {
-    func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, cancelLoadingImageForModel model: FavoritesListViewModel, imageWidth: CGFloat)
 }
 

--- a/FinniversKit/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Favorites/ListView/FavoritesListView.swift
@@ -13,7 +13,7 @@ public protocol FavoritesListViewDelegate: AnyObject {
 public protocol FavoritesListViewDataSource: AnyObject {
     func numberOfItems(inFavoritesListView favoritesListView: FavoritesListView) -> Int
     func favoritesListView(_ favoritesListView: FavoritesListView, modelAtIndex index: Int) -> FavoritesListViewModel
-    func favoritesListView(_ favoritesListView: FavoritesListView, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func favoritesListView(_ favoritesListView: FavoritesListView, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func favoritesListView(_ favoritesListView: FavoritesListView, cancelLoadingImageForModel model: FavoritesListViewModel, imageWidth: CGFloat)
 }
 
@@ -119,7 +119,7 @@ extension FavoritesListView: UITableViewDataSource {
 // MARK: - FavoritesListViewCellDataSource
 
 extension FavoritesListView: FavoritesListViewCellDataSource {
-    public func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func favoritesListViewCell(_ favoritesListViewCell: FavoritesListViewCell, loadImageForModel model: FavoritesListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         dataSource?.favoritesListView(self, loadImageForModel: model, imageWidth: imageWidth, completion: completion)
     }
 

--- a/FinniversKit/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Notifications/Cell/NotificationsListViewCell.swift
@@ -6,7 +6,7 @@ import UIKit
 import Warp
 
 public protocol NotificationsListViewCellDataSource: AnyObject {
-    func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, cancelLoadingImageForModel model: NotificationsListViewModel, imageWidth: CGFloat)
 }
 

--- a/FinniversKit/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Notifications/ListView/NotificationsListView.swift
@@ -17,7 +17,7 @@ public protocol NotificationsListViewDataSource: AnyObject {
     func notificationsListView(_ notificationsListView: NotificationsListView, numberOfItemsInSection section: Int) -> Int
     func notificationsListView(_ notificationsListView: NotificationsListView, groupModelAtSection section: Int) -> NotificationsGroupListViewModel
     func notificationsListView(_ notificationsListView: NotificationsListView, modelAtIndexPath indexPath: IndexPath) -> NotificationsListViewModel
-    func notificationsListView(_ notificationsListView: NotificationsListView, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void))
+    func notificationsListView(_ notificationsListView: NotificationsListView, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func notificationsListView(_ notificationsListView: NotificationsListView, cancelLoadingImageForModel model: NotificationsListViewModel, imageWidth: CGFloat)
 }
 
@@ -165,7 +165,7 @@ extension NotificationsListView: UITableViewDataSource {
 // MARK: - NotificationsListViewCellDataSource
 
 extension NotificationsListView: NotificationsListViewCellDataSource {
-    public func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping ((UIImage?) -> Void)) {
+    public func notificationsListViewCell(_ notificationsListViewCell: NotificationsListViewCell, loadImageForModel model: NotificationsListViewModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void)) {
         dataSource?.notificationsListView(self, loadImageForModel: model, imageWidth: imageWidth, completion: completion)
     }
 


### PR DESCRIPTION
## Why?

The NMP iOS codebase is migrating all `app-modules/` targets to Swift 6 strict concurrency (tracked in finn/ios-app#10447). Several FinniversKit protocols declare image-loading completion handlers without `@Sendable`, which forces consuming modules to use `@preconcurrency` on their conformances and leaves residual warnings that can't be resolved downstream.

## What?

Adds `@Sendable` to every image-loading `completion: @escaping ((UIImage?) -> Void)` parameter across 12 FinniversKit protocols and all their internal + demo conformances (28 files, 40 lines).

**Protocols updated:**
- `RemoteImageViewDataSource`
- `FavoriteAdsListViewDataSource`
- `FavoriteFoldersListViewDataSource`
- `FavoritesListViewDataSource`
- `FavoritesListViewCellDataSource`
- `AdRecommendationsGridViewDataSource`
- `LoanCalculatorDataSource`
- `NotificationsListViewDataSource`
- `NotificationsListViewCellDataSource`
- `SendInviteViewDelegate`
- `BuyerPickerViewDelegate`
- `BuyerPickerCellDelegate`

## Changelog

No user-facing changes — this is a source-compatibility improvement for Swift concurrency.

## Accessibility

N/A

## Reusability

N/A — protocol signature change only.

## Tests

No test changes needed — `@Sendable` is additive and does not affect runtime behavior.

## UI Changes

None.

🤖 Generated with [Claude Code](https://claude.ai/code)