### PR TITLE
♻️ Add @MainActor to AddressMapViewDelegate

### DIFF
--- a/FinniversKit/Sources/Fullscreen/AddressMapView/AddressMapView.swift
+++ b/FinniversKit/Sources/Fullscreen/AddressMapView/AddressMapView.swift
@@ -6,6 +6,7 @@ import UIKit
 import MapKit
 import Warp
 
+@MainActor
 public protocol AddressMapViewDelegate: AnyObject {
     func addressMapViewDidSelectPinButton(_ addressMapView: AddressMapView)
     func addressMapViewDidSelectViewModeButton(_ addressMapView: AddressMapView, sender: UIView)


### PR DESCRIPTION
# Why?

  Part of the Swift 6 strict concurrency migration of the NMP iOS codebase's `app-modules/` targets ([finn/ios-app#10447](https://github.schibsted.io/finn/ios-app/issues/10447)). `AddressMapViewDelegate` carries  no isolation, so a `@MainActor`-isolated consumer in ios-app
  (`AddressViewController` in the Maps module) can only conform to it with `@preconcurrency`, which leaves a residual warning that can't be resolved  downstream.

 Same idea as #1453 (`@Sendable` on image-loading handlers), applied to a delegate protocol, and also in response to [Robin's reply](https://github.schibsted.io/finn/ios-app/pull/10537/files#r1735244) on[ PR #10537](https://github.schibsted.io/finn/ios-app/pull/10537) in the iOS-app repo.

# What?

Annotates `AddressMapViewDelegate` as `@MainActor`.

This is sound because `AddressMapView` is a `UIView` subclass (implicitly  `@MainActor`) and every delegate call site already runs on the main actor. The  annotation just makes the type system reflect where the protocol is actually used.

The only conformer in this repo — `AddressMapDemoView` — is already a `UIView` subclass (implicitly `@MainActor`), so no conformance changes are needed. The `FullscreenViewTests` snapshot test is already `@MainActor` and is unaffected.

Verified downstream by building **FINN NMP** against a local FinniversKit checkout with this change: `AddressViewController` conforms cleanly with its `@preconcurrency` removed, and nothing else in the app regresses.

# Version Change

Patch: additive isolation annotation, no runtime behavior change. `@MainActor` on a delegate protocol is technically source-breaking for any conformer in a nonisolated context, but the only conformer (internal demo) is already main-actor isolated.

  # UI Changes

  None.