### PR TITLE
♻️ Add @MainActor to AdRecommendationsGridViewDataSource and mark Config statics nonisolated(unsafe)

### DIFF
--- a/FinniversKit/Sources/Config.swift
+++ b/FinniversKit/Sources/Config.swift
@@ -4,8 +4,9 @@ import Warp
 
 public struct Config {
     public static var bundle: Bundle { Bundle.finniversKit }
-    public static var imageProvider: ImageProvider = DefaultImageProvider()
-    public static var isDynamicTypeEnabled: Bool = true
+    // Set once during app startup, read-only afterwards.
+    nonisolated(unsafe) public static var imageProvider: ImageProvider = DefaultImageProvider()
+    nonisolated(unsafe) public static var isDynamicTypeEnabled: Bool = true
 
     public static func accessibilityMultiplier() -> CGFloat {
         if Self.isDynamicTypeEnabled {

--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -8,6 +8,7 @@ public protocol AdRecommendationsGridViewDelegate: AnyObject {
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, didSelectFavoriteButton button: UIButton, on cell: AdRecommendationCell, at indexPath: IndexPath)
 }
 
+@MainActor
 public protocol AdRecommendationsGridViewDataSource: AnyObject {
     func numberOfItems(inAdRecommendationsGridView adRecommendationsGridView: AdRecommendationsGridView) -> Int
     func numberOfColumns(inAdRecommendationsGridView adRecommendationsGridView: AdRecommendationsGridView) -> AdRecommendationsGridView.ColumnConfiguration?


### PR DESCRIPTION
# Why?

The NMP iOS app is migrating `app-modules` targets to the `StrictConcurrency` upcoming feature flag, one module per PR (finn-no/ios-app#10447). The `Recommendations` module currently needs three `@preconcurrency` escape hatches to build cleanly, and two of them exist only because of FinniversKit declarations. Since FinniversKit is a module we own, the policy is to fix the source rather than suppress at the import site.

This continues the work started in #1453 and #1454.

# What?

**`@MainActor` on `AdRecommendationsGridViewDataSource`**

Every method traffics exclusively in `UICollectionView`, `UICollectionViewCell` and `IndexPath`, and every call site is inside `AdRecommendationsGridView`, which is a `UIView`. The protocol is already main-actor in practice; this just makes it explicit so `@MainActor` conformers no longer warn that the conformance "crosses into main actor-isolated code". Same pattern as #1454.

Blast radius is small: the only conformers in this repo are three Demo types (`AdRecommendationsGridViewDemoView`, `FavoriteSoldDemoView`, `FrontPageViewDemoViewController`), all `UIView`/`UIViewController` subclasses and therefore already main-actor. None needed a change.

**`nonisolated(unsafe)` on `Config.imageProvider` and `Config.isDynamicTypeEnabled`**

Both are set once during app startup and read-only afterwards. In NMP the only writes are three brand-selection branches in `Theme.swift` plus one line in `AppDelegate`. `nonisolated(unsafe)` documents that existing contract and silences the "global shared mutable state" warning without changing a single call site.

Note for a possible follow-up, deliberately left out of scope here: `Config.accessibilityMultiplier()` reads `UIScreen.main` and will need `@MainActor` when FinniversKit itself adopts strict concurrency.

**Deliberately not changed:** `RemoteImageViewDataSource`. Its mixed isolation (main-actor `cachedImageWithPath`, nonisolated loading methods) is correct — image loading is genuinely off-main. Isolating it would break `CDNRemoteImageViewDataSource`, which is explicitly `Sendable`, along with several other non-UI conformers in NMP. The consumer-side fix there is to match the protocol method-for-method, which needs nothing from this repo.

# Version Change

Minor. `@MainActor` on a public protocol is potentially source-breaking for any nonisolated conformer, though there are none in this repo.

# UI Changes

None. Isolation annotations only, no behaviour or layout changes.

# Verification

- `Demo` scheme builds clean against these changes (`** BUILD SUCCEEDED **`, zero errors), and the demo app was run in the simulator and works.
- Verified end-to-end from the consumer side: pointing NMP `app-modules` at this local checkout and removing **all three** `@preconcurrency` annotations from `RecommendationController` builds with zero errors and zero warnings, confirming this change set is sufficient.