### PR TITLE
♻️ Add @MainActor to HappinessRatingViewDelegate and TextViewDelegate

### DIFF
--- a/FinniversKit/Sources/Components/HappinessRating/HappinessRatingView.swift
+++ b/FinniversKit/Sources/Components/HappinessRating/HappinessRatingView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol HappinessRatingViewDelegate: AnyObject {
     func happinessRatingView(_ happinessRatingView: HappinessRatingView, didSelectRating rating: HappinessRating)
     func happinessRatingView(_ happinessRatingView: HappinessRatingView, textFor rating: HappinessRating) -> String?
@@ -132,6 +133,7 @@ extension HappinessRatingView: RatingViewDelegate {
 
 // MARK: - RatingView
 
+@MainActor
 private protocol RatingViewDelegate: AnyObject {
     func ratingViewText(for rating: HappinessRating) -> String?
 }

--- a/FinniversKit/Sources/Components/TextView/TextView.swift
+++ b/FinniversKit/Sources/Components/TextView/TextView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+@MainActor
 public protocol TextViewDelegate: AnyObject {
     func textViewDidChange(_ textView: TextView)
     func textViewShouldBeginEditing(_ textView: TextView) -> Bool


### PR DESCRIPTION
# Why?

The NMP iOS app is migrating `app-modules` targets to the `StrictConcurrency` upcoming feature flag, one module per PR ([finn-no/ios-app#10447](https://github.schibsted.io/finn/ios-app/issues/10447)). The `Feedback` module currently needs two `@preconcurrency` escape hatches to build cleanly, and both exist only because of FinniversKit declarations.

This continues the work started in #1453, #1454 and #1455.

# What?

**`@MainActor` on `HappinessRatingViewDelegate` and `TextViewDelegate`**

Both protocols are already main-actor in practice. `HappinessRatingView` and `TextView` are `UIView` subclasses and therefore implicitly `@MainActor`, and every delegate call site is inside them. `TextViewDelegate`'s five callbacks are all invoked from `UITextViewDelegate` methods, which the SDK already isolates to the main actor. Annotating the protocols makes that explicit so `@MainActor` conformers no longer warn that the conformance "crosses into main actor-isolated code". Same pattern as #1454 and #1455.

Blast radius is small: every conformer in this repo is a `UIView` subclass and therefore already main-actor isolated, so none needed a change — `HappinessRatingDemoView`, `FavoriteAdCommentInputView`, `AdReporterView` and `TextViewDemoView`. `TextViewDelegate`'s default implementations inherit the protocol's isolation and need no annotation of their own.

**`@MainActor` on the private `RatingViewDelegate`**

`HappinessRatingView` already satisfies it with main-actor-isolated methods, so this is free to fix now. It is private, so there is no external blast radius at all, and it would otherwise warn once FinniversKit itself enables `StrictConcurrency`.

# Version Change

Minor. `@MainActor` on a public protocol is potentially source-breaking for any nonisolated conformer, though there are none in this repo.

# UI Changes

None. Isolation annotations only, no behaviour or layout changes.

# Verification

- `Demo` scheme builds clean against these changes (`** BUILD SUCCEEDED **`, zero errors). It compiles all of `Sources` plus both demo conformers.
- SwiftLint clean.
- Verified end-to-end from the consumer side: pointing NMP `app-modules` at this local checkout and removing **both** `@preconcurrency` annotations from the `Feedback` module (`HappinessRatingViewController`, `TextInputFeedbackViewController`) builds with zero errors and zero warnings, confirming this change set is sufficient.

Note: the `SnapshotTests` scheme could not be run locally — it fails to resolve a simulator destination before compiling anything, which is unrelated to this change.