### PR TITLE
♻️ Add @MainActor to RadioButtonDelegate, AdReporterDelegate and ConfirmationViewDelegate

### DIFF
--- a/FinniversKit/Sources/Components/SelectionBoxes/Selectionbox.swift
+++ b/FinniversKit/Sources/Components/SelectionBoxes/Selectionbox.swift
@@ -7,6 +7,7 @@ import Warp
 
 /* Selection box for selecting a single item */
 
+@MainActor
 public protocol RadioButtonDelegate: AnyObject {
     func radioButton(_ radioButton: RadioButton, didSelectItem item: RadioButtonItem)
     func radioButton(_ radioButton: RadioButton, didUnselectItem item: RadioButtonItem)

--- a/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterView.swift
+++ b/FinniversKit/Sources/Fullscreen/AdReporter/AdReporterView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol AdReporterDelegate: RadioButtonDelegate {
     func adReporterViewHelpButtonPressed(_ adReporterView: AdReporterView)
 }

--- a/FinniversKit/Sources/Fullscreen/AdReporter/ConfirmationView.swift
+++ b/FinniversKit/Sources/Fullscreen/AdReporter/ConfirmationView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol ConfirmationViewDelegate: AnyObject {
     func confirmationViewDidPressDismissButton(_ confirmationView: ConfirmationView)
 }


### PR DESCRIPTION
# Why?

The NMP iOS app is migrating `app-modules` targets to the `StrictConcurrency` upcoming feature flag, one module per PR ([finn-no/ios-app#10447](https://github.schibsted.io/finn/ios-app/issues/10447)). The `AdReporting` module needs three `@preconcurrency` escape hatches to build cleanly, and all three exist only because of FinniversKit declarations.

This continues the work started in #1453, #1454, #1455 and #1456.

# What?

**`@MainActor` on `RadioButtonDelegate`, `AdReporterDelegate` and `ConfirmationViewDelegate`**

All three protocols are already main-actor in practice. `RadioButton` (via `Selectionbox`), `AdReporterView` and `ConfirmationView` are `UIView`/`UIScrollView` subclasses and therefore implicitly `@MainActor`, and every delegate call site is inside them — `RadioButton.handleSelecting(_:)`, `AdReporterView`'s help-button handler, and `ConfirmationView`'s dismiss-button handler. Annotating the protocols makes that explicit so `@MainActor` conformers no longer warn that the conformance "crosses into main actor-isolated code". Same pattern as #1454, #1455 and #1456.

`AdReporterDelegate` refines `RadioButtonDelegate`; it is annotated explicitly rather than relying on inheritance, since a refining protocol's own requirements do not pick up the parent's global actor.

Blast radius is small. The only conformer in this repo is `AdReporterDemoView`, a `UIView` subclass that is already main-actor isolated, so it needed no change. Across the NMP app there is exactly one conformer — `AdReporterViewController` — which is a `UIViewController` and likewise already isolated.

# Version Change

Minor. `@MainActor` on a public protocol is potentially source-breaking for any nonisolated conformer, though there are none in this repo.

# UI Changes

None. Isolation annotations only, no behaviour or layout changes.

# Verification

- `Demo` scheme builds clean against these changes (`Build Succeeded`, zero errors), with all three changed sources plus `AdReporterDemoView` confirmed recompiled rather than served from cache.
- SwiftLint clean on the changed files.
- Verified end-to-end from the consumer side: pointing NMP `app-modules` at this local checkout via `.package(path:)` and enabling `swiftSettings: .strictConcurrency` on the `AdReporting` target builds with **zero errors and zero module-owned warnings and no `@preconcurrency` annotations at all**, confirming this change set is sufficient.
- Full `FINN NMP` app build and simulator launch against this local checkout: `** BUILD SUCCEEDED **`, 0 errors, 0 warnings from `AdReporting`, app launched successfully. This compiles every downstream vertical (Jobs, Mobility, RealEstate, Recommerce), not just the one module.
