### PR TITLE
♻️ Add @MainActor to FeedbackViewDelegate, InfoboxViewDelegate and HorizontalSlideTransitionDelegate

### DIFF
--- a/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
+++ b/FinniversKit/Sources/Components/Feedback/FeedbackView.swift
@@ -7,6 +7,7 @@ import Warp
 
 // MARK: - FeedbackViewDelegate
 
+@MainActor
 public protocol FeedbackViewDelegate: AnyObject {
     func feedbackView(
         _ feedbackView: FeedbackView,

--- a/FinniversKit/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
+++ b/FinniversKit/Sources/Components/HorizontalSlide/HorizontalSlideController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 protocol HorizontalSlideControllerDelegate: AnyObject {
     func horizontalSlideControllerDidDismiss(_ horizontalSlideController: HorizontalSlideController)
 }

--- a/FinniversKit/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
+++ b/FinniversKit/Sources/Components/HorizontalSlide/HorizontalSlideTransition.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 @objc public protocol HorizontalSlideTransitionDelegate: AnyObject {
     @objc func horizontalSlideTransitionDidDismiss(_ horizontalSlideTransition: HorizontalSlideTransition)
 }

--- a/FinniversKit/Sources/Components/Infobox/InfoboxView.swift
+++ b/FinniversKit/Sources/Components/Infobox/InfoboxView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol InfoboxViewDelegate: AnyObject {
     func infoboxViewDidSelectPrimaryButton(_ view: InfoboxView)
     func infoboxViewDidSelectSecondaryButton(_ view: InfoboxView)


### PR DESCRIPTION
# Why?

Continues the Swift 6 strict-concurrency work in #1453, #1454, #1455, #1456 and #1457. Consumers migrating a module to `StrictConcurrency` currently have to write `extension SomeCell: @preconcurrency FeedbackViewDelegate` because a `@MainActor` conformer cannot satisfy a nonisolated protocol requirement without tripping "conformance crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode". Annotating the protocols fixes every conformer at once, statically, instead of pushing `@preconcurrency` into each consumer.

# What?

Adds `@MainActor` to three public delegate protocols. All three are main-actor in practice already: `FeedbackView` and `InfoboxView` are `UIView` subclasses and every delegate call site is inside them, and `HorizontalSlideTransition` only invokes its delegate from a `UIPresentationController` callback.

- `FeedbackViewDelegate` (`Components/Feedback/FeedbackView.swift`)
- `InfoboxViewDelegate` (`Components/Infobox/InfoboxView.swift`)
- `HorizontalSlideTransitionDelegate` (`Components/HorizontalSlide/HorizontalSlideTransition.swift`) — `@objc`, which accepts `@MainActor` fine

The fourth line is the one worth a look: the internal `HorizontalSlideControllerDelegate` is annotated too, and it is not optional. `HorizontalSlideTransition` is a plain `NSObject`, and its `HorizontalSlideControllerDelegate` witness is what forwards to the now-main-actor `HorizontalSlideTransitionDelegate`. Isolating only the public protocol would make that forwarding call an error inside FinniversKit itself. Its only caller is `HorizontalSlideController`, a `UIPresentationController` subclass, so it is already on the main actor.

Verified with the `FinniversKit` and `Demo` schemes on iPhone 17 Pro / iOS 26.5: both build with zero errors. Also verified downstream against NMP iOS by pinning `app-modules` at a local checkout of this branch and deleting the three `@preconcurrency` annotations from the SearchQuest module — it builds clean with an unchanged warning list, so no compensating changes are needed on the consumer side.

# Version Change

Minor, same classification as #1454, #1455, #1456 and #1457.

# UI Changes

None. Isolation annotations only, no behaviour or layout change.