### PR TITLE
♻️ Add @MainActor to StepSliderDelegate

### DIFF
--- a/FinniversKit/Sources/Components/StepSlider/StepSlider.swift
+++ b/FinniversKit/Sources/Components/StepSlider/StepSlider.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol StepSliderDelegate: AnyObject {
     func stepSlider(_ stepSlider: StepSlider, didChangeRawValue value: Float)
     func stepSlider(_ stepSlider: StepSlider, canChangeToStep step: Step) -> Bool


### PR DESCRIPTION
# Why?

Continues the Swift 6 strict-concurrency work in #1453, #1454, #1455, #1456, #1457 and #1459. Consumers migrating a module to `StrictConcurrency` currently have to write `extension SomeView: @preconcurrency StepSliderDelegate` because a `@MainActor` conformer cannot satisfy a nonisolated protocol requirement without tripping "conformance crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode". Annotating the protocol fixes every conformer at once, statically, instead of pushing `@preconcurrency` into each consumer.

# What?

Adds `@MainActor` to one public delegate protocol:

- `StepSliderDelegate` (`Components/StepSlider/StepSlider.swift`)

It is main-actor in practice already. `StepSlider` is a `UISlider` subclass and all five delegate call sites are inside it, reached from `accessibilityValue`, touch handling and value-change tracking. Both in-repo conformers are `UIView` subclasses and need no change: `TitleValueSlider` (`Components/LoanCalculator/TitleValueSliderView.swift`) and `StepSliderDemoView` in the Demo app.

Verified with the `FinniversKit` and `Demo` schemes on iPhone 17 Pro / iOS 26.5: both build with zero errors. Also verified downstream against NMP iOS by pinning `app-modules` at a local checkout of this branch while migrating the Charcoal module to `StrictConcurrency` — the two `StepSliderDelegate` conformance warnings Charcoal was left with are the only ones this removes, and the module then builds with zero concurrency warnings and zero errors, so no compensating changes are needed on the consumer side.

# Version Change

Minor, same classification as #1454, #1455, #1456, #1457 and #1459.

# UI Changes

None. Isolation annotation only, no behaviour or layout change.
