### PR TITLE
♻️ Add Sendable to AdRecommendationsGridViewDelegate

### DIFF
--- a/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
+++ b/FinniversKit/Sources/Recycling/GridViews/AdRecommendations/GridView/AdRecommendationsGridView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol AdRecommendationsGridViewDelegate: AnyObject {
+public protocol AdRecommendationsGridViewDelegate: AnyObject, Sendable {
     func adRecommendationsGridViewDidStartRefreshing(_ adRecommendationsGridView: AdRecommendationsGridView)
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, didSelectItemAtIndex index: Int)
     func adRecommendationsGridView(_ adRecommendationsGridView: AdRecommendationsGridView, willDisplayItemAtIndex index: Int)


### PR DESCRIPTION
# Why?

The NMP iOS app is enabling strict-concurrency checking for FavoriteSold. Its view controller currently needs an `@preconcurrency` conformance because `AdRecommendationsGridViewDelegate` does not declare that conformers are safe to pass across isolation boundaries.

Defining that contract in FinniversKit removes the consumer-side escape hatch and keeps concurrency checking at the protocol's source.

# What?

Adds `Sendable` conformance to the class-bound `AdRecommendationsGridViewDelegate` protocol.

The three in-repo conformers are UIKit-backed types and already main-actor protected. The Demo test build compiles all of them successfully without compensating changes.

# Version Change

Minor. Adding `Sendable` to a public protocol can require downstream non-Sendable conformers to adopt safe isolation.

# UI Changes

None. This is a concurrency contract change with no behavior or layout changes.

# Verification

- `xcodebuild build-for-testing -scheme Demo -workspace FinniversKit.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' CODE_SIGNING_ALLOWED=NO` — passed.
- `swiftlint lint` — changed file is clean; the repository-wide command reports the existing unrelated baseline of 38 warnings plus one configuration warning.
