### PR TITLE
♻️ Isolate RemoteImageViewDataSource callbacks to MainActor

### DIFF
--- a/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
+++ b/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol RemoteImageViewDataSource: AnyObject, Sendable {
+public protocol RemoteImageViewDataSource: AnyObject {
     @MainActor func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
     @MainActor func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     @MainActor func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)

--- a/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
+++ b/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol RemoteImageViewDataSource: AnyObject {
+public protocol RemoteImageViewDataSource: AnyObject, Sendable {
     @MainActor func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
     func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)

--- a/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
+++ b/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
@@ -6,8 +6,8 @@ import UIKit
 
 public protocol RemoteImageViewDataSource: AnyObject, Sendable {
     @MainActor func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
-    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
-    func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
+    @MainActor func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
+    @MainActor func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
 }
 
 public protocol RemoteImageViewDelegate: AnyObject {


### PR DESCRIPTION
# Why?

The NMP iOS app is enabling strict-concurrency checking for FINNNotificationCenter. Its view controllers currently need `@preconcurrency` conformances because two `RemoteImageViewDataSource` requirements are nonisolated even though they are called by the UIKit-backed `RemoteImageView`.

Defining the main-actor contract in FinniversKit removes the consumer-side escape hatch and keeps isolation at the protocol source.

# What?

Marks the load and cancellation requirements on `RemoteImageViewDataSource` as `@MainActor`, matching the cached-image requirement that is already isolated.

All in-repo conformers compile without compensating changes. The FINNNotificationCenter consumer also builds with both `@preconcurrency` annotations removed.

# Version Change

Minor. Adding actor isolation to public protocol requirements can require downstream callers to hop to the main actor.

# UI Changes

None. This is a concurrency contract change with no behavior or layout changes.

# Verification

- FinniversKit Demo build-for-testing on iPhone 17 Pro / iOS 26.5 — passed.
- FINNNotificationCenter build against the final commit with both annotations removed — passed.
- SwiftLint on the changed file — zero violations.
- Full repository lint retains the existing 38 unrelated warnings and zero serious violations.
