### PR TITLE
♻️ Add @MainActor to nine public UI protocols

### DIFF
--- a/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
+++ b/FinniversKit/Sources/Components/Broadcast/Broadcast.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+@MainActor
 public protocol BroadcastDelegate: AnyObject {
     func broadcast(_ broadcast: Broadcast, didDismiss message: BroadcastMessage)
     func broadcast(_ broadcast: Broadcast, didTapURL url: URL, inItemAtIndex index: Int)

--- a/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
+++ b/FinniversKit/Sources/Components/FooterButtonView/FooterButtonView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol FooterButtonViewDelegate: AnyObject {
     func footerButtonView(_ view: FooterButtonView, didSelectButton button: UIButton)
 }

--- a/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
+++ b/FinniversKit/Sources/Components/RemoteImageView/RemoteImageView.swift
@@ -4,10 +4,11 @@
 
 import UIKit
 
+@MainActor
 public protocol RemoteImageViewDataSource: AnyObject {
-    @MainActor func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
-    @MainActor func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
-    @MainActor func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
+    func remoteImageView(_ view: RemoteImageView, cachedImageWithPath imagePath: String, imageWidth: CGFloat) -> UIImage?
+    func remoteImageView(_ view: RemoteImageView, loadImageWithPath imagePath: String, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
+    func remoteImageView(_ view: RemoteImageView, cancelLoadingImageWithPath imagePath: String, imageWidth: CGFloat)
 }
 
 public protocol RemoteImageViewDelegate: AnyObject {

--- a/FinniversKit/Sources/Components/SelectorTitleView/SelectorTitleView.swift
+++ b/FinniversKit/Sources/Components/SelectorTitleView/SelectorTitleView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol SelectorTitleViewDelegate: AnyObject {
     func selectorTitleViewDidSelectButton(_ view: SelectorTitleView)
 }

--- a/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift
@@ -3,6 +3,7 @@
 //
 import Warp
 
+@MainActor
 public protocol MessageUserRequiredSheetDelegate: AnyObject {
     func didTapActionButton(_ sender: Button)
 }

--- a/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
+++ b/FinniversKit/Sources/Fullscreen/Review/BuyerPickerView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+@MainActor
 public protocol BuyerPickerViewDelegate: AnyObject {
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, loadImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat, completion: @escaping @Sendable ((UIImage?) -> Void))
     func buyerPickerView(_ buyerPickerView: BuyerPickerView, cancelLoadingImageForModel model: BuyerPickerProfileModel, imageWidth: CGFloat)

--- a/FinniversKit/Sources/Fullscreen/SoldView/SoldView.swift
+++ b/FinniversKit/Sources/Fullscreen/SoldView/SoldView.swift
@@ -16,6 +16,7 @@ public struct SoldViewModel {
     }
 }
 
+@MainActor
 public protocol SoldViewDelegate: NSObjectProtocol {
     func soldView(_ soldView: SoldView, didSelectCallToAction: Button)
 }

--- a/FinniversKit/Sources/Fullscreen/VerificationActionSheet/VerificationActionSheet.swift
+++ b/FinniversKit/Sources/Fullscreen/VerificationActionSheet/VerificationActionSheet.swift
@@ -3,6 +3,7 @@
 //
 import Warp
 
+@MainActor
 public protocol VerificationActionSheetDelegate: AnyObject {
     func didTapVerificationActionSheetButton(_ sheet: VerificationActionSheet)
 }

--- a/FinniversKit/Sources/Protocols/ImageLoadable.swift
+++ b/FinniversKit/Sources/Protocols/ImageLoadable.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@MainActor
 public protocol ImageLoadable {
     var imageDataSource: RemoteImageViewDataSource? { get set }
 


### PR DESCRIPTION
# Why?

Continues the Swift 6 strict-concurrency work in #1454, #1455, #1456, #1457, #1459, #1460 and #1462. A consumer migrating a module to the `StrictConcurrency` upcoming feature currently has to write `extension SomeType: @preconcurrency SomeDelegate`, because a `@MainActor` conformer cannot satisfy a nonisolated protocol requirement without tripping "conformance crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode". Annotating the protocol fixes every conformer at once, statically, instead of pushing `@preconcurrency` into each consumer.

These nine are exactly the protocols NMP iOS's `AdInsertion` module needs in order to migrate without a single `@preconcurrency` on a FinniversKit type.

# What?

Adds `@MainActor` to nine public protocols. All nine are main-actor in practice already — every declaring type is a `UIView` or `UIViewController` subclass, and every delegate call site lives inside it.

| Protocol | Declaring type | Notes |
| --- | --- | --- |
| `BroadcastDelegate` (`Components/Broadcast/Broadcast.swift`) | `Broadcast: UIStackView` | 2 call sites, both in `Broadcast`. In-repo conformer `BroadcastDemoView` is a `UIView`. |
| `FooterButtonViewDelegate` (`Components/FooterButtonView/FooterButtonView.swift`) | `FooterButtonView: TopShadowView` | 1 call site, a button handler. In-repo conformers `PrimingView`, `FavoriteAdsListView`, `FooterButtonDemoView` are all `UIView`s. |
| `RemoteImageViewDataSource` (`Components/RemoteImageView/RemoteImageView.swift`) | `RemoteImageView: UIImageView` | See note below. |
| `SelectorTitleViewDelegate` (`Components/SelectorTitleView/SelectorTitleView.swift`) | `SelectorTitleView: UIView` | 1 call site. In-repo conformer `SelectorTitleViewDemoView` is a `UIView`. |
| `MessageUserRequiredSheetDelegate` (`Fullscreen/MessageUserRequired/MessageUserRequiredSheet.swift`) | `MessageUserRequiredSheet: BottomSheet` | 1 call site. No in-repo conformers. |
| `BuyerPickerViewDelegate` (`Fullscreen/Review/BuyerPickerView.swift`) | `BuyerPickerView: UIView` | 6 call sites, all on `UITableView` delegate/data-source paths. In-repo conformer `BuyerPickerDemoView` is a `UIView`. |
| `SoldViewDelegate` (`Fullscreen/SoldView/SoldView.swift`) | `SoldView: UIView` | 1 call site, a button handler. No in-repo conformers. |
| `VerificationActionSheetDelegate` (`Fullscreen/VerificationActionSheet/VerificationActionSheet.swift`) | `VerificationActionSheet: BottomSheet` | 1 call site, from `VerificationViewDelegate`. In-repo conformer is the Demo app's `VerificationActionSheetDemoDelegate`. |
| `ImageLoadable` (`Protocols/ImageLoadable.swift`) | — | Its `imageDataSource` is a `RemoteImageViewDataSource`, and its only in-repo refinement is `AdRecommendationCell: UICollectionViewCell, ImageLoadable`, so every conformer is already main-actor. |

**One removal, in `RemoteImageViewDataSource`.** #1462 isolated its three requirements individually. Hoisting `@MainActor` to the protocol is equivalent for the callbacks and additionally isolates the conformance itself, which is the part consumers need — so the three now-redundant per-requirement annotations come out. Happy to keep them if you'd rather the diff be purely additive.

Verified with the `FinniversKit` and `Demo` schemes on iPhone 17 Pro / iOS 26.5: both build with zero errors (`** BUILD SUCCEEDED **` in the raw xcodebuild log, `: error:` count 0).

Verified downstream against NMP iOS by pinning `app-modules` at a local checkout carrying these nine annotations while migrating the `AdInsertion` module to `StrictConcurrency`: the full FINN app builds green with **zero** `@preconcurrency` on any FinniversKit type. The conformers this covers are `BroadcastStateController`, `AdConfirmationView`, `AdConfirmationObjectView`, `PathResolvingRemoteImageViewDataSource`, `UserAdTableViewCell`, `CollapseView`, `PickABuyerViewController`, `SelectMarketSegmentViewController` and `ReviewStateController` in `AdInsertion`, plus `RecommendationController` in `app-modules/Recommendations` — the last of which is why an `AdInsertion`-local `@preconcurrency` fallback would not have been equivalent.

# Version Change

Minor, same classification as #1454, #1455, #1456, #1457, #1459, #1460 and #1462.

# UI Changes

None. Isolation annotations only — no behaviour, layout or animation change.
