### PR TITLE
♻️ Add @MainActor to ResultViewDelegate

### DIFF
--- a/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
+++ b/FinniversKit/Sources/Fullscreen/ResultView/ResultView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Warp
 
+@MainActor
 public protocol ResultViewDelegate: AnyObject {
     func resultViewDidTapActionButton(_ resultView: ResultView)
 }


### PR DESCRIPTION
# Why?

Continues the Swift 6 strict-concurrency work in #1454, #1455, #1456, #1457, #1459, #1460, #1462 and #1463. A consumer migrating a module to the `StrictConcurrency` upcoming feature currently has to write `extension SomeType: @preconcurrency ResultViewDelegate`, because a `@MainActor` conformer cannot satisfy a nonisolated protocol requirement without getting: 
> "conformance crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode". 

Annotating the protocol fixes every conformer at once, statically, instead of pushing `@preconcurrency` into each consumer.

# What?

Adds `@MainActor` to `ResultViewDelegate` (`Fullscreen/ResultView/ResultView.swift`). One line, purely additive.

It is main-actor in practice already. The protocol is declared alongside `ResultView: UIView`, which holds the only `ResultViewDelegate` reference in the repo (`public weak var delegate`) and has a single call site — a button handler inside the view. There are no in-repo conformers, not even a Demo view, so nothing else in FinniversKit is affected.

Verified with the `FinniversKit` and `Demo` schemes on iPhone 17 Pro / iOS 26.5: both build with zero errors.

Verified downstream against NMP iOS by pinning `app-modules` at a local checkout carrying this annotation while migrating the `UserAdManagementEntryPoint` module to `StrictConcurrency`. The full FINN app builds green with zero `@preconcurrency` on any FinniversKit type, and with zero `ResultViewDelegate` diagnostics anywhere. 

# Version Change

Minor, same classification as #1454, #1455, #1456, #1457, #1459, #1460, #1462 and #1463.

# UI Changes

None. Isolation annotation only — no behaviour, layout or animation change.