### PR TITLE
♻️ Add @MainActor to three public Settings protocols

### DIFF
--- a/FinniversKit/Sources/Fullscreen/SettingDetailsView/SettingDetailsView.swift
+++ b/FinniversKit/Sources/Fullscreen/SettingDetailsView/SettingDetailsView.swift
@@ -17,6 +17,7 @@ public protocol SettingDetailsViewModel {
 }
 
 // MARK: - Delegate
+@MainActor
 public protocol SettingDetailsViewDelegate: AnyObject {
     func settingDetailsView(_ detailsView: SettingDetailsView, didTapPrimaryButtonWith model: SettingDetailsViewModel)
 }

--- a/FinniversKit/Sources/Recycling/ListViews/Settings/View/SettingsView.swift
+++ b/FinniversKit/Sources/Recycling/ListViews/Settings/View/SettingsView.swift
@@ -6,12 +6,14 @@ import UIKit
 import SwiftUI
 
 // MARK: - Protocols
+@MainActor
 public protocol SettingsViewDataSource: AnyObject {
     func numberOfSections(in settingsView: SettingsView) -> Int
     func settingsView(_ settingsView: SettingsView, numberOfItemsInSection section: Int) -> Int
     func settingsView(_ settingsView: SettingsView, modelForItemAt indexPath: IndexPath) -> SettingsViewCellModel
 }
 
+@MainActor
 public protocol SettingsViewDelegate: AnyObject {
     func settingsView(_ settingsView: SettingsView, didSelectModelAt indexPath: IndexPath)
     func settingsView(_ settingsView: SettingsView, didToggleSettingAt indexPath: IndexPath, isOn: Bool)


### PR DESCRIPTION
# Why?

Migrating the NMP iOS app's `Settings` module to Swift 6 strict concurrency (finn/ios-app#10447) produced this against three FinniversKit protocols:

```
conformance of 'SettingsViewController' to protocol 'SettingsViewDelegate' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode
```

All three are UI callbacks — they pass `IndexPath`, `SettingsViewCellModel` and view references — so they are inherently main-actor. Isolating the protocol fixes every conformer at once and statically, which is the pattern this repo already adopted in #1463 and #1464. The alternative is `@preconcurrency` sprinkled on each conformance downstream, which only defers the same work.

# What?

`@MainActor` on three public protocols:

- `SettingsViewDataSource` — `Recycling/ListViews/Settings/View/SettingsView.swift:9`
- `SettingsViewDelegate` — `Recycling/ListViews/Settings/View/SettingsView.swift:15`
- `SettingDetailsViewDelegate` — `Fullscreen/SettingDetailsView/SettingDetailsView.swift:20`

Three lines, no other changes.

Both in-repo conformers are Demo types — `SettingsViewDemoView: UIView` and `SettingDetailsDemoViewController: UIViewController` — already implicitly main-actor, so neither needed a change.

**Verified downstream:** with this pulled into the NMP iOS app via a local path dependency, the `Settings` target builds clean under the `StrictConcurrency` flag and a full `FINN NMP` app build succeeds with 0 errors. These three protocols have no conformers anywhere in that app outside the `Settings` module itself.

# Version Change

Minor — same classification as #1463 and #1464. It is source-breaking for any external conformer in a nonisolated context, though in practice conformers are `UIView`/`UIViewController` subclasses that are already main-actor.

# UI Changes

None — isolation annotations only, no behavioural or visual change.
